### PR TITLE
Use the new cross-memory status service.

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -672,48 +672,24 @@ static void printZISStatus(HttpServer *server) {
   CrossMemoryServerName *zisName =
       getConfiguredProperty(server, HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY);
 
-  /* Use the username/password service because it's the easiest one to use
-   * TODO make a special service for ZIS service info retrieval. */
-  ZISAuthServiceStatus zisStatus = {0};
-  int zisRC = zisCheckUsernameAndPassword(zisName,
-                                          "D U MM Y", "DUMMY",
-                                          &zisStatus);
+  CrossMemoryServerStatus status = cmsGetStatus(zisName);
 
-  const char *statusDescription = "Ok";
+  const char *shortDescription = NULL;
 
-  if (zisRC != RC_ZIS_SRVC_OK) {
-
-    if (zisRC == RC_ZIS_SRVC_CMS_FAILED) {
-
-      int cmsRC = zisStatus.baseStatus.cmsRC;
-      statusDescription = NULL;
-      if (0 <= cmsRC && cmsRC < RC_CMS_MAX_RC) {
-        statusDescription = CMS_RC_DESCRIPTION[cmsRC];
-      }
-
-      if (statusDescription == NULL) {
-        statusDescription = "Failure";
-      }
-
-    } else if (!(zisRC == RC_ZIS_SRVC_SERVICE_FAILED &&
-                zisStatus.baseStatus.serviceRC == RC_ZIS_AUTHSRV_SAF_ERROR)) {
-      /* if this is not the expected failure */
-      statusDescription = "Warning";
-    }
-
+  if (status.cmsRC == RC_CMS_OK) {
+    shortDescription = "Ok";
+  } else {
+    shortDescription = "Failure";
   }
 
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_ALWAYS,
-         "ZIS status - %s (name=\'%.16s\', zisRC=%d, cmsRC=%d, srvcRC=%d, "
-         "clientVersion=%d)\n",
-         statusDescription,
-         zisName ? zisName->nameSpacePadded : "name_not_set",
-         zisRC,
-         zisStatus.baseStatus.cmsRC,
-         zisStatus.baseStatus.serviceRC,
-         CROSS_MEMORY_SERVER_VERSION);
-  zowedump(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_ALWAYS,
-          &zisStatus, sizeof(zisStatus));
+          "ZIS status - %s (name='%.16s', cmsRC=%d, description='%s', "
+          "clientVersion=%d)\n",
+          shortDescription,
+          zisName ? zisName->nameSpacePadded : "name not set",
+          status.cmsRC,
+          status.descriptionNullTerm,
+          CROSS_MEMORY_SERVER_VERSION);
 
 }
 


### PR DESCRIPTION

**Do not merge until https://github.com/zowe/zowe-common-c/pull/14 has been merged**

Remove the dummy call to zisCheckUsernameAndPassword, which produces unnnecessary SAF messages, and use the new status service from the corresponding zowe-common-c [pull-request](https://github.com/zowe/zowe-common-c/pull/14).

Fixes: #8
