### PR TITLE
Add headers for no http caching

### DIFF
--- a/c/authService.c
+++ b/c/authService.c
@@ -114,7 +114,7 @@ static void respond(HttpResponse *res, int rc, const ZISAuthServiceStatus
   jsonPrinter* p = respondWithJsonPrinter(res);
 
   setResponseStatus(res, HTTP_STATUS_OK, "OK");
-  setDefaultJSONRESTHeaders(response);
+  setDefaultJSONRESTHeaders(res);
   writeHeader(res);
   if (rc == RC_ZIS_SRVC_OK) {
     jsonStart(p); {

--- a/c/authService.c
+++ b/c/authService.c
@@ -31,6 +31,7 @@
 #include "bpxnet.h"
 #include "socketmgmt.h"
 #include "zis/client.h"
+#include "httpserver.h"
 
 /*
  * A handler performing the SAF_AUTH check: checks if the user has the

--- a/c/authService.c
+++ b/c/authService.c
@@ -114,8 +114,7 @@ static void respond(HttpResponse *res, int rc, const ZISAuthServiceStatus
   jsonPrinter* p = respondWithJsonPrinter(res);
 
   setResponseStatus(res, HTTP_STATUS_OK, "OK");
-  setContentType(res, "application/json");
-  addStringHeader(res, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(res);
   if (rc == RC_ZIS_SRVC_OK) {
     jsonStart(p); {

--- a/c/omvsService.c
+++ b/c/omvsService.c
@@ -73,9 +73,7 @@ static int serveOMVSSegment(HttpService *service, HttpResponse *response)
   if (strlen(request->username) > 8)
   {
     setResponseStatus(response, 500, "Internal Server Error");
-    setContentType(response,"text/json");
-    addStringHeader(response,"Server","jdmfws");
-    addStringHeader(response,"Transfer-Encoding","chunked");
+    setDefaultJSONRESTHeaders(response);
     writeHeader(response);
 
     jsonStart(p);
@@ -102,9 +100,7 @@ static int serveOMVSSegment(HttpService *service, HttpResponse *response)
     if (status != 0)
     {
       setResponseStatus(response, 500, "Internal Server Error");
-      setContentType(response,"text/json");
-      addStringHeader(response,"Server","jdmfws");
-      addStringHeader(response,"Transfer-Encoding","chunked");
+      setDefaultJSONRESTHeaders(response);
       writeHeader(response);
 
       jsonStart(p);
@@ -115,9 +111,7 @@ static int serveOMVSSegment(HttpService *service, HttpResponse *response)
     else
     {
       setResponseStatus(response, 200, "OK");
-      setContentType(response,"text/json");
-      addStringHeader(response,"Server","jdmfws");
-      addStringHeader(response,"Transfer-Encoding","chunked");
+      setDefaultJSONRESTHeaders(response);
       writeHeader(response);
 
       jsonStart(p);
@@ -136,9 +130,7 @@ static int serveOMVSSegment(HttpService *service, HttpResponse *response)
   else
   {
     setResponseStatus(response, 405, "Method Not Allowed");
-    setContentType(response, "text/json");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "GET");
     writeHeader(response);
 

--- a/c/rasService.c
+++ b/c/rasService.c
@@ -202,9 +202,7 @@ static int serveRASData(HttpService *service, HttpResponse *response) {
 
     jsonPrinter *p = respondWithJsonPrinter(response);
     setResponseStatus(response, HTTP_STATUS_OK, "OK");
-    setContentType(response, "text/json");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     writeHeader(response);
 
     jsonStart(p);

--- a/c/rasService.c
+++ b/c/rasService.c
@@ -26,6 +26,7 @@
 
 #include "zowetypes.h"
 #include "utils.h"
+#include "httpserver.h"
 #include "zssLogging.h"
 #include "logging.h"
 #include "rasService.h"

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -176,10 +176,8 @@ static void timeOutDestroyer(void *userData, void *value) {
 static void respondWithSessionID(HttpResponse *response, int sessionID) {
   jsonPrinter *out = respondWithJsonPrinter(response);
 
-  setContentType(response, "text/json");
   setResponseStatus(response, 200, "OK");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(response);
 
   jsonStart(out);
@@ -707,10 +705,8 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "GET, PUT, DELETE");
     writeHeader(response);
 
@@ -757,10 +753,8 @@ static int serveUnixFileCopy(HttpService *service, HttpResponse *response) {
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "POST");
     writeHeader(response);
 
@@ -805,10 +799,8 @@ static int serveUnixFileRename(HttpService *service, HttpResponse *response) {
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "POST");
     writeHeader(response);
 
@@ -839,10 +831,8 @@ static int serveUnixFileMakeDirectory(HttpService *service, HttpResponse *respon
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "POST");
     writeHeader(response);
 
@@ -873,10 +863,8 @@ static int serveUnixFileTouch(HttpService *service, HttpResponse *response) {
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "POST");
     writeHeader(response);
 
@@ -900,10 +888,8 @@ static int serveUnixFileMetadata(HttpService *service, HttpResponse *response) {
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "GET");
     writeHeader(response);
 
@@ -922,10 +908,8 @@ static int serveTableOfContents(HttpService *service, HttpResponse *response) {
   if (!strcmp(request->method, methodGET)) {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 404, "Not Found");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     writeHeader(response);
 
     jsonStart(out);
@@ -963,10 +947,8 @@ static int serveTableOfContents(HttpService *service, HttpResponse *response) {
   else {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
-    setContentType(response, "text/json");
     setResponseStatus(response, 405, "Method Not Allowed");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     addStringHeader(response, "Allow", "GET");
     writeHeader(response);
 

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -26,6 +26,7 @@
 #include "collections.h"
 #include "unixFileService.h"
 #include "zssLogging.h"
+#include "httpserver.h"
 
 /* Time it takes in seconds for a session to be
  * removed from the hashtable due to

--- a/c/zosDiscovery.c
+++ b/c/zosDiscovery.c
@@ -71,9 +71,7 @@ static jsonPrinter *startResponse(HttpResponse *response){
   } else{
     jsonPrinter *p = respondWithJsonPrinter(response);
     setResponseStatus(response,200,"OK");
-    setContentType(response,"text/json");
-    addStringHeader(response,"Server","jdmfws");
-    addStringHeader(response,"Transfer-Encoding","chunked");
+    setDefaultJSONRESTHeaders(response);
     writeHeader(response);
     return p;
   }

--- a/c/zss.c
+++ b/c/zss.c
@@ -114,9 +114,7 @@ static int servePluginDefinitions(HttpService *service, HttpResponse *response){
     }
   }
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(response);
   jsonStart(printer);
   {
@@ -215,6 +213,8 @@ int serveLoginWithSessionToken(HttpService *service, HttpResponse *response) {
   setContentType(response,"text/html");
   addStringHeader(response,"Server","jdmfws");
   addStringHeader(response,"Transfer-Encoding","chunked");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");
   /* HACK: the cookie header should be set inside serviceAuthNativeWithSessionToken, */
   /* but that is currently broken: the header doesn't get sent if it is set there */
   if (response->sessionCookie){
@@ -241,6 +241,8 @@ int serveLogoutByRemovingSessionToken(HttpService *service, HttpResponse *respon
   setContentType(response,"text/html");
   addStringHeader(response,"Server","jdmfws");
   addStringHeader(response,"Transfer-Encoding","chunked");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");
   
   /* Remove the session token when the user wants to log out */
   addStringHeader(response,"Set-Cookie","jedHTTPSession=non-token");


### PR DESCRIPTION
Implements https://github.com/zowe/zss/issues/11
Aside from adding headers instructing receivers not to cache the results, this change also unifies the content type of json. The majority of our code used MIME "text/json", but the official MIME type is "application/json", so hopefully this improves compatibility in edge cases.