### PR TITLE
RBAC: Remove the username and class from the url  

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -795,6 +795,17 @@ static int validateConfigPermissionsInner(const char *path) {
   return 0;
 }
 
+#ifdef ZSS_IGNORE_PERMISSION_PROBLEMS
+
+static int validateFilePermissions(const char *filePath) {
+  zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_SEVERE,
+    "Skipping validation of file permissions: disabled during compilation, "
+    "file %s.\n", filePath);
+  return 0;
+}
+
+#else /* ZSS_IGNORE_PERMISSION_PROBLEMS */
+
 /* Validates that both file AND parent folder meet requirements */
 static int validateFilePermissions(const char *filePath) {
   if (!filePath) {
@@ -827,6 +838,8 @@ static int validateFilePermissions(const char *filePath) {
     return validateConfigPermissionsInner(filePath);
   }
 }
+
+#endif /* ZSS_IGNORE_PERMISSION_PROBLEMS */
 
 int main(int argc, char **argv){
   if (argc == 1) { 


### PR DESCRIPTION
- /user/class/profile/level -> /profile/level
- use the authenticated user name from the request
- use the hardcoded class ZOWE

I've not yet replaced the call to ZIS with a direct RACROUTE call as this is a lower priority. 

Also, this PR contains an unrelated change that fixes the nasty problem with config file permissions in a dev sandbox.