### PR TITLE
Security management services

### DIFF
--- a/build/zis.xml
+++ b/build/zis.xml
@@ -23,6 +23,7 @@
     <exec executable="xlc" dir="${TMPDIR}" failonerror="true">
       <arg line="-S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1"/>
       <arg value="-DMSGPREFIX=&quot;ZWE&quot;"/>
+      <arg value="-DRADMIN_XMEM_MODE"/>
       <arg value="-qreserved_reg=r12"/>
       <arg value="-Wc,arch(8),agg,exp,list(),so(),off,xref,roconst,longname,lp64"/>
       <arg line="-I ${COMMON}/h"/>
@@ -39,6 +40,7 @@
       <arg value="${COMMON}/c/mtlskt.c"/>
       <arg value="${COMMON}/c/nametoken.c"/>
       <arg value="${COMMON}/c/qsam.c"/>
+      <arg value="${COMMON}/c/radmin.c"/>
       <arg value="${COMMON}/c/recovery.c"/>
       <arg value="${COMMON}/c/resmgr.c"/>
       <arg value="${COMMON}/c/scheduling.c"/>
@@ -54,6 +56,7 @@
       <arg value="${ZSS}/c/zis/service.c"/>
       <arg value="${ZSS}/c/zis/services/auth.c"/>
       <arg value="${ZSS}/c/zis/services/nwm.c"/>
+      <arg value="${ZSS}/c/zis/services/secmgmt.c"/>
       <arg value="${ZSS}/c/zis/services/snarfer.c"/>
     </exec> 
 
@@ -69,6 +72,7 @@
     <antcall target="assemble"><param name="file" value="mtlskt"/></antcall>
     <antcall target="assemble"><param name="file" value="nametoken"/></antcall>
     <antcall target="assemble"><param name="file" value="qsam"/></antcall>
+    <antcall target="assemble"><param name="file" value="radmin"/></antcall>
     <antcall target="assemble"><param name="file" value="recovery"/></antcall>
     <antcall target="assemble"><param name="file" value="resmgr"/></antcall>
     <antcall target="assemble"><param name="file" value="scheduling"/></antcall>
@@ -88,6 +92,11 @@
     <antcall target="assemble"><param name="file" value="nwm"/></antcall>
     <antcall target="assemble"><param name="file" value="snarfer"/></antcall>
 
+    <antcall target="assemble"><param name="file" value="auth"/></antcall>
+    <antcall target="assemble"><param name="file" value="nwm"/></antcall>
+    <antcall target="assemble"><param name="file" value="secmgmt"/></antcall>
+    <antcall target="assemble"><param name="file" value="snarfer"/></antcall>
+
 
     <exec executable="ld" dir="${TMPDIR}" failonerror="true" output="${TMPDIR}/ZWESIS01.link">
       <env key="_LD_SYSLIB" value="//&apos;SYS1.CSSLIB&apos;://&apos;CEE.SCEELKEX&apos;://&apos;CEE.SCEELKED&apos;://&apos;CEE.SCEERUN&apos;://&apos;CEE.SCEERUN2&apos;://&apos;CSF.SCSFMOD0&apos;"/>
@@ -105,6 +114,7 @@
       <arg value="mtlskt.o"/>
       <arg value="nametoken.o"/>
       <arg value="qsam.o"/>
+      <arg value="radmin.o"/>
       <arg value="recovery.o"/>
       <arg value="resmgr.o"/>
       <arg value="scheduling.o"/>
@@ -120,6 +130,7 @@
       <arg value="service.o"/>
       <arg value="auth.o"/>
       <arg value="nwm.o"/>
+      <arg value="secmgmt.o"/>
       <arg value="snarfer.o"/>
     </exec>
 

--- a/build/zss.xml
+++ b/build/zss.xml
@@ -104,6 +104,7 @@
       <arg value="${ZSS}/c/unixFileService.c"/>
       <arg value="${ZSS}/c/datasetService.c"/>
       <arg value="${ZSS}/c/zosDiscovery.c"/>
+      <arg value="${ZSS}/c/securityService.c"/>
       <arg value="${ZSS}/c/zis/client.c"/>
     </exec> 
 

--- a/c/securityService.c
+++ b/c/securityService.c
@@ -1,0 +1,3408 @@
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "utils.h"
+#include "charsets.h"
+#include "bpxnet.h"
+#include "socketmgmt.h"
+#include "httpserver.h"
+#include "logging.h"
+#include "json.h"
+
+#include "securityService.h"
+#include "zssLogging.h"
+#include "serviceUtils.h"
+
+#include "zis/client.h"
+#include "zis/services/secmgmt.h"
+
+
+/* TODO there is a huge amount of boiler plate and copy-paste code in
+ * the format and respond functions, consider extracting abstraction
+ * once these services have stabilized. */
+
+/************ Common helper functions ************/
+
+#define ERROR_MSG_MAX_SIZE 4096
+
+typedef void (ZISSvcErrorMessageFormatter)(int zisCallRC,
+                                           const void *serviceStatus,
+                                           char *messageBuffer,
+                                           size_t messageBufferSize);
+
+static void formatZISErrorMessage(int zisCallRC,
+                                  const void *serviceStatus,
+                                  ZISSvcErrorMessageFormatter *formatter,
+                                  char *messageBuffer,
+                                  size_t messageBufferSize) {
+
+  const ZISServiceStatus *baseStatus = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_OK) {
+    return;
+  }
+
+  if (zisCallRC == RC_ZIS_SRVC_STATUS_NULL) {
+    snprintf(messageBuffer, messageBufferSize,
+             "ZIS status block not provided");
+    return;
+  }
+
+  if (zisCallRC == RC_ZIS_SRVC_CMS_FAILED) {
+    int cmsRC = baseStatus->cmsRC;
+    int cmsRSN = baseStatus->cmsRSN;
+    if (0 <= cmsRC && cmsRC <= RC_CMS_MAX_RC && CMS_RC_DESCRIPTION[cmsRC]) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Cross-Memory server failure (RC = %d, RSN = %d) - %s",
+               baseStatus->cmsRC, baseStatus->cmsRSN,
+               CMS_RC_DESCRIPTION[cmsRC]);
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "Cross-Memory server failure (RC = %d, RSN = %d)",
+               baseStatus->cmsRC, baseStatus->cmsRSN);
+    }
+    return;
+  }
+
+  if (zisCallRC < 0) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED && baseStatus->serviceRC < 0) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS service error (RC = %d, RSN = %d)",
+             baseStatus->serviceRC, baseStatus->serviceRSN);
+    return;
+  }
+
+  if (formatter == NULL) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Cross-Memory service failure (RC = %d, RSN = %d)",
+             baseStatus->serviceRC, baseStatus->serviceRSN);
+  } else {
+    formatter(zisCallRC, baseStatus, messageBuffer, messageBufferSize);
+  }
+
+}
+
+static bool getDryRunValue(HttpRequest *request) {
+
+  HttpRequestParam *realEntityParam = getCheckedParam(request, "dryRun");
+  char *realEntityParmString =
+      (realEntityParam ? realEntityParam->stringValue : "");
+  if (!strcmp(realEntityParmString, "false")) {
+    return false;
+  }
+
+  return true;
+}
+
+static int getTraceLevel(HttpRequest *request) {
+  HttpRequestParam *traceParam = getCheckedParam(request, "traceLevel");
+  return (traceParam ? traceParam->intValue : 0);
+}
+
+static void respondWithZISError(HttpResponse *response,
+                                int zisRC,
+                                const void *status,
+                                ZISSvcErrorMessageFormatter *formatter) {
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Error");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+  {
+    printErrorResponseMetadata(printer);
+    char errorMessage[ERROR_MSG_MAX_SIZE] = {0};
+    formatZISErrorMessage(zisRC, status, formatter,
+                          errorMessage, sizeof(errorMessage));
+    jsonAddString(printer, "message", errorMessage);
+  }
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+/************ User-profile functions ************/
+
+#define USER_PROFILE_MAX_COUNT  1000
+
+static int getUserProfileCount(HttpRequest *request) {
+  HttpRequestParam *countParam = getCheckedParam(request, "count");
+  return (countParam ? countParam->intValue : USER_PROFILE_MAX_COUNT);
+}
+
+static void printUserProfileToJSON(jsonPrinter *printer,
+                                   const ZISUserProfileEntry *entry) {
+
+  char userIDNullTerm[sizeof(entry->userID) + 1] = {0};
+  char defaultGroupNullTerm[sizeof(entry->defaultGroup) + 1] = {0};
+  char nameNullTerm[sizeof(entry->name) + 1] = {0};
+  memcpy(userIDNullTerm, entry->userID, sizeof(entry->userID));
+  memcpy(defaultGroupNullTerm, entry->defaultGroup,
+         sizeof(entry->defaultGroup));
+  memcpy(nameNullTerm, entry->name, sizeof(entry->name));
+
+  nullTerminate(userIDNullTerm, sizeof(userIDNullTerm) - 1);
+  nullTerminate(defaultGroupNullTerm, sizeof(defaultGroupNullTerm) - 1);
+  nullTerminate(nameNullTerm, sizeof(nameNullTerm) - 1);
+
+  jsonStartObject(printer, NULL);
+  {
+    jsonAddString(printer, "userID", userIDNullTerm);
+    jsonAddString(printer, "defaultGroup", defaultGroupNullTerm);
+    jsonAddString(printer, "name", nameNullTerm);
+  }
+  jsonEndObject(printer);
+
+}
+
+static void formatZISUserProfileServiceError(int zisCallRC,
+                                             const void *serviceStatus,
+                                             char *messageBuffer,
+                                             size_t messageBufferSize) {
+
+  const ZISUserProfileServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_UPRFSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_UPRFSRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_UPRFSRV_INTERNAL_SERVICE_FAILED) {
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN);
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_UPRFSRV_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_UPRFSRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+static void respondWithUserProfiles(HttpResponse *response,
+                                    const char *startProfile,
+                                    unsigned int profilesRequested,
+                                    const ZISUserProfileEntry *profiles,
+                                    unsigned int profileCount) {
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_OK, "OK");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+
+  printTableResultResponseMetadata(printer);
+  jsonAddString(printer, "resultType", "table");
+  jsonStartObject(printer, "metaData");
+  {
+
+    jsonStartObject(printer, "tableMetaData");
+    {
+      jsonAddString(printer, "tableIdentifier", "user-profiles");
+      jsonAddString(printer, "shortTableLabel", "user-profiles");
+      jsonAddString(printer, "longTableLabel", "User Profiles");
+      jsonAddString(printer, "globalIdentifier",
+                    "org.zowe.zss.security-mgmt.user-profiles");
+      jsonAddInt(printer, "minRows", 0);
+      jsonAddInt(printer, "maxRows", USER_PROFILE_MAX_COUNT);
+    }
+    jsonEndObject(printer);
+
+    jsonStartArray(printer, "columnMetaData");
+    {
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "userID");
+        jsonAddString(printer, "shortColumnLabel", "userID");
+        jsonAddString(printer, "longColumnLabel", "User ID");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(profiles[0].userID));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "defaultGroup");
+        jsonAddString(printer, "shortColumnLabel", "defaultGroup");
+        jsonAddString(printer, "longColumnLabel", "Default Group");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength",
+                   sizeof(profiles[0].defaultGroup));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "name");
+        jsonAddString(printer, "shortColumnLabel", "name");
+        jsonAddString(printer, "longColumnLabel", "User Name");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(profiles[0].name));
+      }
+      jsonEndObject(printer);
+
+    }
+    jsonEndArray(printer);
+
+  }
+  jsonEndObject(printer);
+
+  int profilesToReturn = (profileCount > profilesRequested) ?
+                          profileCount - 1 : profileCount;
+
+  jsonAddString(printer, "start", startProfile ? (char *)startProfile : "");
+  jsonAddInt(printer, "count", profilesToReturn);
+  jsonAddInt(printer, "countRequested", profilesRequested);
+  if (profilesRequested < profileCount) {
+    jsonAddBoolean(printer, "hasMore", TRUE);
+  } else {
+    jsonAddBoolean(printer, "hasMore", FALSE);
+  }
+
+  jsonStartArray(printer, "rows");
+  {
+    for (int i = 0; i < profilesToReturn; i++) {
+      const ZISUserProfileEntry *entry = &profiles[i];
+      printUserProfileToJSON(printer, entry);
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+              "user profile entry #%d: \'%.*s\', \'%.*s\', \'%.*s\'\n", i,
+              sizeof(profiles->userID), profiles->userID,
+              sizeof(profiles->defaultGroup), profiles->defaultGroup,
+              sizeof(profiles->name), profiles->name);
+    }
+  }
+  jsonEndArray(printer);
+
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+/* The endpoint for serving RACF user profiles. Currently, we do not
+ * parse the data. This is left to the caller to do once receiving
+ * the entirety of the data.
+ */
+static int serveUserProfile(HttpService *service, HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  HttpRequest *request = response->request;
+
+  /* A GET request is the only supported method for this
+   * route.
+   */
+  if (strcmp(request->method, methodGET) != 0) {
+    respondWithError(response, HTTP_STATUS_NOT_IMPLEMENTED,
+                     "Unsupported request");
+    return 0;
+  }
+
+  /* Gets the CrossMemoryServerName, which is needed
+   * to use ZIS functions.
+   */
+  CrossMemoryServerName *privilegedServerName =
+      getConfiguredProperty(service->server,
+                            HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY);
+
+  int zisRC = RC_ZIS_SRVC_OK;
+  char *startUserID = getQueryParam(response->request, "start");
+  int profilesToExtract = getUserProfileCount(request);
+  if (profilesToExtract < 0 || USER_PROFILE_MAX_COUNT < profilesToExtract) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Count out of range");
+    return 0;
+  }
+
+  ZISUserProfileEntry resultBuffer[USER_PROFILE_MAX_COUNT + 1];
+  unsigned int profilesExtracted = 0;
+  ZISUserProfileServiceStatus status = {0};
+  int traceLevel = getTraceLevel(request);
+
+  zisRC = zisExtractUserProfiles(
+      privilegedServerName,
+      startUserID,
+      profilesToExtract + 1,
+      resultBuffer,
+      &profilesExtracted,
+      &status,
+      traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisExtractUserProfiles: RC=%d, base=(%d,%d,%d,%d), "
+         "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisExtractUserProfiles: start=%s, profiles to extract = %u, "
+         "extracted = %u\n", startUserID ? startUserID : "n/a",
+         profilesToExtract, profilesExtracted);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithUserProfiles(response, startUserID, profilesToExtract,
+                            resultBuffer, profilesExtracted);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISUserProfileServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+  return 0;
+}
+
+/************ Class management functions ************/
+
+/* TODO this is copy-pasted from zss.c, move somewhere before the PR */
+#define JSON_ERROR_BUFFER_SIZE 1024
+static JsonObject * getJsonBody(char *content, int contentLength,
+                                ShortLivedHeap *slh) {
+
+  char errorBuffer[JSON_ERROR_BUFFER_SIZE];
+  char *ebcdicBuffer = safeMalloc(contentLength * 2,
+                                  "Test Echo Ebcdic Buffer");
+  int conversionLength = 0;
+  int reasonCode = 0;
+  int status = convertCharset(content,
+                              contentLength,
+                              CCSID_UTF_8,
+                              CHARSET_OUTPUT_USE_BUFFER,
+                              &ebcdicBuffer,
+                              contentLength * 2,
+                              CCSID_EBCDIC_1047,
+                              NULL,
+                              &conversionLength,
+                              &reasonCode);
+  Json * body = jsonParseUnterminatedString(
+      slh,
+      ebcdicBuffer,
+      conversionLength,
+      errorBuffer,
+      JSON_ERROR_BUFFER_SIZE
+  );
+
+  return  jsonAsObject(body);
+}
+
+#define CLASS_MGMT_ALLOWED_CLASS              "default-class"
+#define CLASS_MGMT_QUERY_MIN_SEGMENT_COUNT    1
+#define CLASS_MGMT_QUERY_MAX_SEGMENT_COUNT    7
+#define CLASS_MGMT_CLASS_SEGMENT_ID           1
+#define CLASS_MGMT_PROFILE_SEGMENT_ID         3
+#define CLASS_MGMT_ACCESS_LIST_SEGMENT_ID     5
+
+static bool isClassMgmtQueryStringValid(StringList *path) {
+
+  char *pathSegments[CLASS_MGMT_QUERY_MAX_SEGMENT_COUNT] = {0};
+  int minSegmentCount = CLASS_MGMT_QUERY_MIN_SEGMENT_COUNT;
+  int maxSegmentCount = sizeof(pathSegments) / sizeof(pathSegments[0]);
+
+  int segmentCount = path->count;
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "class-mgmt query segment count = %d [%d, %d]\n",
+         segmentCount, minSegmentCount, maxSegmentCount);
+
+  if (segmentCount < minSegmentCount || maxSegmentCount < segmentCount) {
+    return false;
+  }
+
+  StringListElt *pathSegment = firstStringListElt(path);
+
+  for (int i = 0; i < maxSegmentCount; i++) {
+    if (pathSegment == NULL) {
+      break;
+    }
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "class-mgmt path segment #%d =\'%s\'\n", i, pathSegment->string);
+
+    pathSegments[i] = pathSegment->string;
+    pathSegment = pathSegment->next;
+  }
+
+  char *serviceSegment = pathSegments[0];
+  if (serviceSegment == NULL) {
+    return false;
+  }
+  if (strcmp(serviceSegment, "security-mgmt") != 0) {
+    return false;
+  }
+
+  /* security-mgmt/classes ? No, leave. The URL is incorrect */
+  char *classSegment = pathSegments[CLASS_MGMT_CLASS_SEGMENT_ID];
+  if (classSegment != NULL && strcmp(classSegment, "classes") != 0) {
+    return false;
+  }
+
+  /* security-mgmt/classes/class_value/profiles ? No, leave.
+   * The URL is incorrect */
+  char *profileSegment = pathSegments[CLASS_MGMT_PROFILE_SEGMENT_ID];
+  if (profileSegment != NULL && strcmp(profileSegment, "profiles") != 0) {
+    return false;
+  }
+
+  /* security-mgmt/classes/class_value/profiles/profile_value/access-list ?
+   * No, leave. The URL is incorrect */
+  char *accessListSegment = pathSegments[CLASS_MGMT_ACCESS_LIST_SEGMENT_ID];
+  if (accessListSegment != NULL &&
+      strcmp(accessListSegment, "access-list") != 0) {
+    return false;
+  }
+
+  return true;
+}
+
+static void extractClassMgmtQueryParms(StringList *path,
+                                       const char **className,
+                                       const char **profileName,
+                                       const char **accessListEntryID) {
+
+  char *pathSegments[CLASS_MGMT_QUERY_MAX_SEGMENT_COUNT] = {0};
+  int maxSegmentCount = sizeof(pathSegments) / sizeof(pathSegments[0]);
+
+  StringListElt *pathSegment = firstStringListElt(path);
+  for (int i = 0; i < maxSegmentCount; i++) {
+    if (pathSegment == NULL) {
+      break;
+    }
+    pathSegments[i] = pathSegment->string;
+    pathSegment = pathSegment->next;
+  }
+
+  char *classSegment = pathSegments[CLASS_MGMT_CLASS_SEGMENT_ID];
+  char *classSegmentValue =
+      pathSegments[CLASS_MGMT_CLASS_SEGMENT_ID + 1];
+  if (classSegment != NULL && classSegmentValue == NULL) {
+    *className = "";
+  } else {
+    *className = classSegmentValue;
+  }
+
+  if (*className != NULL && !strcmp(*className, CLASS_MGMT_ALLOWED_CLASS)) {
+    *className = "";
+  }
+
+  char *profileSegment = pathSegments[CLASS_MGMT_PROFILE_SEGMENT_ID];
+  char *profileSegmentValue =
+      pathSegments[CLASS_MGMT_PROFILE_SEGMENT_ID + 1];
+  if (profileSegment != NULL && profileSegmentValue == NULL) {
+    *profileName = "";
+  } else {
+    *profileName = profileSegmentValue;
+  }
+
+  char *accessListSegment = pathSegments[CLASS_MGMT_ACCESS_LIST_SEGMENT_ID];
+  char *accessListSegmentValue =
+      pathSegments[CLASS_MGMT_ACCESS_LIST_SEGMENT_ID + 1];
+  if (accessListSegment != NULL && accessListSegmentValue == NULL) {
+    *accessListEntryID = "";
+  } else {
+    *accessListEntryID = accessListSegmentValue;
+  }
+
+}
+
+typedef enum ClassMgmtRequestType_tag {
+  CLASS_MGMT_UNKNOWN_REQUEST,
+  CLASS_MGMT_PROFILE_GET,
+  CLASS_MGMT_PROFILE_POST,
+  CLASS_MGMT_PROFILE_PUT,
+  CLASS_MGMT_PROFILE_DELETE,
+  CLASS_MGMT_ACCESS_LIST_GET,
+  CLASS_MGMT_ACCESS_LIST_POST,
+  CLASS_MGMT_ACCESS_LIST_PUT,
+  CLASS_MGMT_ACCESS_LIST_DELETE
+} ClassMgmtRequestType;
+
+static ClassMgmtRequestType getClassMgmtRequstType(HttpRequest *request) {
+
+  const char *className = NULL;
+  const char *profileName = NULL;
+  const char *accessListEntryID = NULL;
+  extractClassMgmtQueryParms(request->parsedFile,
+                    &className,
+                    &profileName,
+                    &accessListEntryID);
+
+  bool profileQuery = false;
+  bool accessListQuery = false;
+
+  if (className != NULL && profileName != NULL && accessListEntryID != NULL) {
+    accessListQuery = true;
+  } else if (className != NULL && profileName != NULL) {
+    profileQuery = true;
+  } else {
+    return CLASS_MGMT_UNKNOWN_REQUEST;
+  }
+
+  if (!strcmp(request->method, methodGET)) {
+    if (profileQuery) {
+      return CLASS_MGMT_PROFILE_GET;
+    } else if (accessListQuery) {
+      return CLASS_MGMT_ACCESS_LIST_GET;
+    }
+  } else if (!strcmp(request->method, methodPOST)) {
+    if (profileQuery) {
+      return CLASS_MGMT_PROFILE_POST;
+    } else if (accessListQuery) {
+      return CLASS_MGMT_ACCESS_LIST_POST;
+    }
+  } else if (!strcmp(request->method, methodPUT)) {
+    if (profileQuery) {
+      return CLASS_MGMT_PROFILE_PUT;
+    } else if (accessListQuery) {
+      return CLASS_MGMT_ACCESS_LIST_PUT;
+    }
+  } else if (!strcmp(request->method, methodDELETE)) {
+    if (profileQuery) {
+      return CLASS_MGMT_PROFILE_DELETE;
+    } else if (accessListQuery) {
+      return CLASS_MGMT_ACCESS_LIST_DELETE;
+    }
+  } else {
+    return CLASS_MGMT_UNKNOWN_REQUEST;
+  }
+
+
+  return CLASS_MGMT_UNKNOWN_REQUEST;
+}
+
+typedef struct ClassMgmtCommonParms_tag {
+  JsonObject *requestBody;
+  CrossMemoryServerName *zisServerName;
+  const char *className;
+  const char *profileName;
+  const char *accessListEntryID;
+  bool isDryRun;
+  int traceLevel;
+} ClassMgmtCommonParms;
+
+static void printGenresProfileToJSON(jsonPrinter *printer,
+                                     const ZISGenresProfileEntry *entry) {
+
+  char profileNullTerm[sizeof(entry->profile) + 1] = {0};
+  char ownerNullTerm[sizeof(entry->owner) + 1] = {0};
+  memcpy(profileNullTerm, entry->profile, sizeof(entry->profile));
+  memcpy(ownerNullTerm, entry->owner, sizeof(entry->owner));
+
+  nullTerminate(profileNullTerm, sizeof(profileNullTerm) - 1);
+  nullTerminate(ownerNullTerm, sizeof(ownerNullTerm) - 1);
+
+  jsonStartObject(printer, NULL);
+  {
+    jsonAddString(printer, "profile", profileNullTerm);
+    jsonAddString(printer, "owner", ownerNullTerm);
+  }
+  jsonEndObject(printer);
+
+}
+
+static void formatZISGenresAdminServiceError(int zisCallRC,
+                                             const void *serviceStatus,
+                                             char *messageBuffer,
+                                             size_t messageBufferSize) {
+
+  const ZISGenresAdminServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_GSADMNSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_GSADMNSRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_GSADMNSRV_INTERNAL_SERVICE_FAILED) {
+
+      const char *radminMessage = NULL;
+      size_t radminMessageLength = 0;
+      if (status->message.length > 0) {
+        radminMessage = status->message.text;
+        radminMessageLength = status->message.length;
+      } else {
+        radminMessage = "no additional info";
+        radminMessageLength = strlen(radminMessage);
+      }
+
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)"
+               " - \'%.*s\'",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN,
+               radminMessageLength, radminMessage);
+
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_PADMIN_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_GSADMNSRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+static void formatZISGenresProfileServiceError(int zisCallRC,
+                                               const void *serviceStatus,
+                                               char *messageBuffer,
+                                               size_t messageBufferSize) {
+
+  const ZISGenresProfileServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_GRPRFSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_GRPRFSRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_GRPRFSRV_INTERNAL_SERVICE_FAILED) {
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN);
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_GRPRFSRV_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_GRPRFSRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+static void printGenresAccessListEntryToJSON(jsonPrinter *printer,
+                                       const ZISGenresAccessEntry *entry) {
+
+  char idNullTerm[sizeof(entry->id) + 1] = {0};
+  char accessTypeNullTerm[sizeof(entry->accessType) + 1] = {0};
+  memcpy(idNullTerm, entry->id, sizeof(entry->id));
+  memcpy(accessTypeNullTerm, entry->accessType, sizeof(entry->accessType));
+
+  nullTerminate(idNullTerm, sizeof(idNullTerm) - 1);
+  nullTerminate(accessTypeNullTerm, sizeof(accessTypeNullTerm) - 1);
+
+  jsonStartObject(printer, NULL);
+  {
+    jsonAddString(printer, "id", idNullTerm);
+    jsonAddString(printer, "accessType", accessTypeNullTerm);
+  }
+  jsonEndObject(printer);
+
+}
+
+static void formatZISGenresAccessListServiceError(int zisCallRC,
+                                                  const void *serviceStatus,
+                                                  char *messageBuffer,
+                                                  size_t messageBufferSize) {
+
+  const ZISGenresAccessListServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_ACSLSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_ACSLSRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_ACSLSRV_INTERNAL_SERVICE_FAILED) {
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN);
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_ACSLSRV_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_ACSLSRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+#define GENRES_PROFILE_MAX_COUNT  1000
+
+static void respondWithGenresProfiles(HttpResponse *response,
+                                      const char *startProfile,
+                                      unsigned int profilesRequested,
+                                      const ZISGenresProfileEntry *profiles,
+                                      unsigned int profileCount) {
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_OK, "OK");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+
+  printTableResultResponseMetadata(printer);
+  jsonAddString(printer, "resultType", "table");
+  jsonStartObject(printer, "metaData");
+  {
+
+    jsonStartObject(printer, "tableMetaData");
+    {
+      jsonAddString(printer, "tableIdentifier", "profiles");
+      jsonAddString(printer, "shortTableLabel", "profiles");
+      jsonAddString(printer, "longTableLabel", "Profiles");
+      jsonAddString(printer, "globalIdentifier",
+                    "org.zowe.zss.security-mgmt.profiles");
+      jsonAddInt(printer, "minRows", 0);
+      jsonAddInt(printer, "maxRows", GENRES_PROFILE_MAX_COUNT);
+    }
+    jsonEndObject(printer);
+
+    jsonStartArray(printer, "columnMetaData");
+    {
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "profile");
+        jsonAddString(printer, "shortColumnLabel", "profile");
+        jsonAddString(printer, "longColumnLabel", "Profile Name");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(profiles[0].profile));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "owner");
+        jsonAddString(printer, "shortColumnLabel", "owner");
+        jsonAddString(printer, "longColumnLabel", "Owner");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(profiles[0].owner));
+      }
+      jsonEndObject(printer);
+
+    }
+    jsonEndArray(printer);
+
+  }
+  jsonEndObject(printer);
+
+  int profilesToReturn = (profileCount > profilesRequested) ?
+                          profileCount - 1 : profileCount;
+
+  jsonAddString(printer, "start", startProfile ? (char *)startProfile : "");
+  jsonAddInt(printer, "count", profilesToReturn);
+  jsonAddInt(printer, "countRequested", profilesRequested);
+  if (profilesRequested < profileCount) {
+    jsonAddBoolean(printer, "hasMore", TRUE);
+  } else {
+    jsonAddBoolean(printer, "hasMore", FALSE);
+  }
+
+  jsonStartArray(printer, "rows");
+  {
+    for (int i = 0; i < profilesToReturn; i++) {
+      const ZISGenresProfileEntry *entry = &profiles[i];
+      printGenresProfileToJSON(printer, entry);
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "genres entry #%d: %.*s, %.*s\n", i,
+             sizeof(entry->profile), entry->profile,
+             sizeof(entry->owner), entry->owner);
+    }
+  }
+  jsonEndArray(printer);
+
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+typedef enum GenresAction_tag {
+  GENRES_ACTION_ADD_PROFILE,
+  GENRES_ACTION_REMOVE_PROFILE,
+  GENRES_ACTION_UPDATE_PROFILE
+} GenresAction;
+
+static void respondWithGenresAdminInfo(
+    HttpResponse *response,
+    GenresAction action,
+    bool isDryRun,
+    const ZISGenresAdminServiceMessage *operatorCommand)
+{
+
+  if (isDryRun) {
+
+    jsonPrinter *printer = respondWithJsonPrinter(response);
+    setResponseStatus(response, HTTP_STATUS_OK, "OK");
+    setContentType(response, "text/json");
+    addStringHeader(response, "Server", "jdmfws");
+    addStringHeader(response, "Transfer-Encoding", "chunked");
+    writeHeader(response);
+
+    jsonStart(printer);
+
+    jsonAddString(printer, "_objectType",
+                  "org.zowe.zss.security-mgmt.operator-command");
+    jsonAddString(printer, "resultMetaDataSchemaVersion", "1.0");
+    jsonAddString(printer, "serviceVersion", "1.0");
+
+
+    jsonAddLimitedString(printer, "operatorCommand",
+                         (char *)operatorCommand->text,
+                         operatorCommand->length);
+
+    jsonEnd(printer);
+
+  } else {
+
+    if (action == GENRES_ACTION_ADD_PROFILE) {
+      setResponseStatus(response, HTTP_STATUS_CREATED, "OK");
+    } else {
+      setResponseStatus(response, HTTP_STATUS_NO_CONTENT, "OK");
+    }
+    setContentType(response, "text/plain");
+    addIntHeader(response, "Content-Length", 0);
+    addStringHeader(response,"Server","jdmfws");
+    writeHeader(response);
+
+  }
+
+  finishResponse(response);
+
+}
+
+static void respondWithProfileAccessList(HttpResponse *response,
+                                         const ZISGenresAccessEntry *accessList,
+                                         unsigned int accessListEntryCount) {
+
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_OK, "OK");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+
+  printTableResultResponseMetadata(printer);
+  jsonAddString(printer, "resultType", "table");
+  jsonStartObject(printer, "metaData");
+  {
+
+    jsonStartObject(printer, "tableMetaData");
+    {
+      jsonAddString(printer, "tableIdentifier", "access-list");
+      jsonAddString(printer, "shortTableLabel", "access-list");
+      jsonAddString(printer, "longTableLabel", "Access List");
+      jsonAddString(printer, "globalIdentifier",
+                    "org.zowe.zss.security-mgmt.profile-access-list");
+    }
+    jsonEndObject(printer);
+
+    jsonStartArray(printer, "columnMetaData");
+    {
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "id");
+        jsonAddString(printer, "shortColumnLabel", "id");
+        jsonAddString(printer, "longColumnLabel", "ID");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(accessList[0].id));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "accessType");
+        jsonAddString(printer, "shortColumnLabel", "accessType");
+        jsonAddString(printer, "longColumnLabel", "Access Type");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength",
+                   sizeof(accessList[0].accessType));
+      }
+      jsonEndObject(printer);
+
+    }
+    jsonEndArray(printer);
+
+  }
+  jsonEndObject(printer);
+
+  jsonAddInt(printer, "count", accessListEntryCount);
+
+  jsonStartArray(printer, "rows");
+  {
+    for (int i = 0; i < accessListEntryCount; i++) {
+      const ZISGenresAccessEntry *entry = &accessList[i];
+      printGenresAccessListEntryToJSON(printer, entry);
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "access list entry #%d: %.*s, %.*s\n", i,
+             sizeof(entry->id), entry->id,
+             sizeof(entry->accessType), entry->accessType);
+    }
+  }
+  jsonEndArray(printer);
+
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+static void respondToProfileGET(ClassMgmtCommonParms *commonParms,
+                                HttpService *service,
+                                HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->profileName) > 0) {
+    respondWithError(response, HTTP_STATUS_NOT_IMPLEMENTED,
+                     "specific profile info retrieval not implemented");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "profile not provided for profiles GET, leaving...\n");
+    return;
+  }
+
+  HttpRequest *request = response->request;
+
+  int zisRC = RC_ZIS_SRVC_OK;
+  char *startProfile = getQueryParam(response->request, "start");
+  int profilesToExtract = getUserProfileCount(request);
+  if (profilesToExtract < 0 || GENRES_PROFILE_MAX_COUNT < profilesToExtract) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Count out of range");
+    return;
+  }
+
+  ZISGenresProfileEntry resultBuffer[GENRES_PROFILE_MAX_COUNT + 1];
+  unsigned int profilesExtracted = 0;
+  ZISGenresProfileServiceStatus status = {0};
+
+  zisRC = zisExtractGenresProfiles(
+      commonParms->zisServerName,
+      commonParms->className,
+      startProfile,
+      profilesToExtract + 1,
+      resultBuffer,
+      &profilesExtracted,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisExtractGenresProfiles: RC=%d, base=(%d,%d,%d,%d), "
+         "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisExtractGenresProfiles: profiles to extract = %u, "
+         "extracted = %u\n",
+         profilesToExtract, profilesExtracted);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGenresProfiles(response, startProfile, profilesToExtract,
+                              resultBuffer, profilesExtracted);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGenresProfileServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void respondToProfilePOST(ClassMgmtCommonParms *commonParms,
+                                 HttpService *service,
+                                 HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->className) > 0) {
+    respondWithError(response, HTTP_STATUS_FORBIDDEN,
+                     "non standard class not allowed for mutation requests");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "non standard class provided for profiles POST, leaving...\n");
+    return;
+  }
+
+  if (strlen(commonParms->profileName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "profile name required for profile POST\n");
+    return;
+  }
+
+  char *owner = NULL;
+  if (commonParms->requestBody != NULL) {
+    Json *ownerParm = jsonObjectGetPropertyValue(commonParms->requestBody,
+                                                 "owner");
+    if (ownerParm != NULL) {
+      owner = jsonAsString(ownerParm);
+    }
+  }
+
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGenresAdminServiceMessage operatorCommand = {0};
+  ZISGenresAdminServiceStatus status = {0};
+  int zisRC = zisDefineProfile(
+      commonParms->zisServerName,
+      commonParms->profileName,
+      owner,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDefineProfile: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+         "SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDefineProfile: serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDefineProfile: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGenresAdminInfo(response, GENRES_ACTION_ADD_PROFILE, isDryRun,
+                               &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGenresAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void respondToProfileDELETE(ClassMgmtCommonParms *commonParms,
+                                   HttpService *service,
+                                   HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->className) > 0) {
+    respondWithError(response, HTTP_STATUS_FORBIDDEN,
+                     "non standard class not allowed for mutation requests");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "non standard class provided for profiles DELETE, leaving...\n");
+    return;
+  }
+
+  if (strlen(commonParms->profileName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "profile name required for profile DELETE\n");
+    return;
+  }
+
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGenresAdminServiceMessage operatorCommand = {0};
+  ZISGenresAdminServiceStatus status = {0};
+  int zisRC = zisDeleteProfile(
+      commonParms->zisServerName,
+      commonParms->profileName,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDeleteProfile: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+         "SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDeleteProfile:  serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDeleteProfile: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGenresAdminInfo(response, GENRES_ACTION_REMOVE_PROFILE, isDryRun,
+                               &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGenresAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static ZISGenresAdminServiceAccessType
+translateGenresAccessType(const char *typeString) {
+
+  if (!strcmp(typeString, "READ")) {
+    return ZIS_GENRES_ADMIN_ACESS_TYPE_READ;
+  }
+
+  if (!strcmp(typeString, "UPDATE")) {
+    return ZIS_GENRES_ADMIN_ACESS_TYPE_UPDATE;
+  }
+
+  if (!strcmp(typeString, "ALTER")) {
+    return ZIS_GENRES_ADMIN_ACESS_TYPE_ALTER;
+  }
+
+  return ZIS_GENRES_ADMIN_ACESS_TYPE_UNKNOWN;
+}
+
+static void respondToProfileAccessListPUT(ClassMgmtCommonParms *commonParms,
+                                          HttpService *service,
+                                          HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->className) > 0) {
+    respondWithError(response, HTTP_STATUS_FORBIDDEN,
+                     "non standard class not allowed for mutation requests");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "non standard class provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  if (strlen(commonParms->profileName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "profile name required for user POST/PUT\n");
+    return;
+  }
+
+  if (strlen(commonParms->accessListEntryID) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "user ID required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "user ID required for user POST/PUT\n");
+    return;
+  }
+
+  if (commonParms->requestBody == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Body missing");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "body not provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  Json *accessTypeParm = jsonObjectGetPropertyValue(commonParms->requestBody,
+                                                    "accessType");
+  if (accessTypeParm == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "accessType missing");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "access type not provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  char *accessTypeString = jsonAsString(accessTypeParm);
+  if (accessTypeString == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "accessType has bad type");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "bad access type provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  ZISGenresAdminServiceAccessType accessType =
+      translateGenresAccessType(accessTypeString);
+  if (accessType == ZIS_GENRES_ADMIN_ACESS_TYPE_UNKNOWN) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "unknown access type, use [READ, UPDATE, ALTER]");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "unknown access type (%d( provided for user POST/PUT, leaving...\n",
+           accessType);
+    return;
+  }
+
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGenresAdminServiceMessage operatorCommand = {0};
+  ZISGenresAdminServiceStatus status = {0};
+  int zisRC = zisGiveAccessToProfile(
+      commonParms->zisServerName,
+      commonParms->accessListEntryID,
+      commonParms->profileName,
+      accessType,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisGiveAccessToProfile: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+         "SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisGiveAccessToProfile:  serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisGiveAccessToProfile: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGenresAdminInfo(response, GENRES_ACTION_UPDATE_PROFILE, isDryRun,
+                               &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGenresAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+#define CLASS_MGMT_ACCESS_LIST_DEFAULT_SIZE     128
+#define CLASS_MGMT_ACCESS_LIST_MAX_SIZE         8192
+
+static void respondToProfileAccessListGET(ClassMgmtCommonParms *commonParms,
+                                          HttpService *service,
+                                          HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->accessListEntryID) > 0) {
+    respondWithError(response, HTTP_STATUS_NOT_IMPLEMENTED,
+                     "specific user access status retrieval not implemented");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "access list can only be retrieved in bulk, leaving...\n");
+    return;
+  }
+
+  unsigned int resultBufferCapacity = CLASS_MGMT_ACCESS_LIST_DEFAULT_SIZE;
+  unsigned int resultBufferSize = 0;
+  ZISGenresAccessEntry *resultBuffer = NULL;
+  int zisRC = RC_ZIS_SRVC_OK;
+  unsigned int entriesExtracted = 0;
+  ZISGenresAccessListServiceStatus status = {0};
+
+  for (int i = 0; i < 2; i++) {
+
+    resultBufferSize = sizeof(ZISGenresAccessEntry) * resultBufferCapacity;
+    resultBuffer =
+        (ZISGenresAccessEntry *)safeMalloc(resultBufferSize, "access list");
+    if (resultBuffer == NULL) {
+      respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                       "out of memory");
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+             "access list buffer with size %u not allocated, leaving...\n",
+             resultBufferSize);
+      return;
+    }
+
+    zisRC = zisExtractGenresAccessList(
+        commonParms->zisServerName,
+        commonParms->className,
+        commonParms->profileName,
+        resultBuffer,
+        resultBufferCapacity,
+        &entriesExtracted,
+        &status,
+        commonParms->traceLevel
+    );
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "zisExtractAccessList: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+           "SAF=(%d,%d,%d)\n", zisRC,
+           status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+           status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+           status.internalServiceRC, status.internalServiceRSN,
+           status.safStatus.safRC, status.safStatus.racfRC,
+           status.safStatus.racfRSN);
+
+    if (zisRC == RC_ZIS_SRVC_ACSLSRV_INSUFFICIENT_BUFFER) {
+
+      safeFree((char *)resultBuffer, resultBufferSize);
+      resultBuffer = NULL;
+
+      if (entriesExtracted <= 0 ||
+          CLASS_MGMT_ACCESS_LIST_MAX_SIZE < entriesExtracted) {
+        respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                         "access list size our of range");
+        zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+               "access list size our of range (%u), leaving...\n",
+               entriesExtracted);
+        return;
+      }
+
+      resultBufferCapacity = entriesExtracted;
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "access list will be re-allocated with capacity %u\n",
+             resultBufferCapacity);
+
+    } else {
+      break;
+    }
+
+  }
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithProfileAccessList(response, resultBuffer, entriesExtracted);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGenresAccessListServiceError);
+  }
+
+  safeFree((char *)resultBuffer, resultBufferSize);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "access list buffer with size %u freed @ 0x%p\n",
+         resultBufferSize, resultBuffer);
+
+  resultBuffer = NULL;
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void respondToProfileAccessListDELETE(ClassMgmtCommonParms *commonParms,
+                                             HttpService *service,
+                                             HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->className) > 0) {
+    respondWithError(response, HTTP_STATUS_FORBIDDEN,
+                     "non standard class not allowed for mutation requests");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "non standard class provided for access list DELETE, leaving...\n");
+    return;
+  }
+
+  if (strlen(commonParms->profileName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "profile name required for access list  DELETE\n");
+    return;
+  }
+
+  if (strlen(commonParms->accessListEntryID) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "access list entry name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "access list entry name required for access list DELETE\n");
+    return;
+  }
+
+  HttpRequest *request = response->request;
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGenresAdminServiceMessage operatorCommand;
+  ZISGenresAdminServiceStatus status = {0};
+  int zisRC = zisRevokeAccessToProfile(
+      commonParms->zisServerName,
+      commonParms->accessListEntryID,
+      commonParms->profileName,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisRevokeAccessToProfile: RC=%d, base=(%d,%d,%d,%d), "
+         "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisRevokeAccessToProfile:  serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisRevokeAccessToProfile: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGenresAdminInfo(response, GENRES_ACTION_UPDATE_PROFILE, isDryRun,
+                               &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGenresAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void extractClassMgmtCommonParms(HttpService *service,
+                                        HttpRequest *request,
+                                        ClassMgmtCommonParms *parms) {
+
+  parms->zisServerName =
+      getConfiguredProperty(service->server,
+                            HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY);
+  extractClassMgmtQueryParms(request->parsedFile,
+                    &parms->className,
+                    &parms->profileName,
+                    &parms->accessListEntryID);
+  parms->requestBody = getJsonBody(request->contentBody,
+                                   request->contentLength,
+                                   request->slh);
+
+  parms->isDryRun = getDryRunValue(request);
+  parms->traceLevel = getTraceLevel(request);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "class-mgmt parms: zisServerName=\'%.16s\', "
+         "class=\'%s\', profile=\'%s\', accessListEntryID=\'%s\', "
+         "traceLevel=%d\n",
+         parms->zisServerName->nameSpacePadded,
+         parms->className ? parms->className : "null",
+         parms->profileName ? parms->profileName : "null",
+         parms->accessListEntryID ? parms->accessListEntryID : "null",
+         parms->traceLevel);
+
+}
+
+static int serveClassManagement(HttpService *service,
+                                HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  HttpRequest *request = response->request;
+
+  if (isClassMgmtQueryStringValid(request->parsedFile) == false) {
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "class-mgmt query string is invalid, leaving...\n");
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Incorrect query");
+    return 0;
+  }
+
+  ClassMgmtCommonParms commonParms;
+  extractClassMgmtCommonParms(service, response->request, &commonParms);
+
+  ClassMgmtRequestType requestType = getClassMgmtRequstType(request);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "class-mgmt requestType = %d\n", requestType);
+
+  switch (requestType) {
+  case CLASS_MGMT_PROFILE_GET:
+    respondToProfileGET(&commonParms, service, response);
+    break;
+  case CLASS_MGMT_PROFILE_POST:
+    respondToProfilePOST(&commonParms, service, response);
+    break;
+  case CLASS_MGMT_PROFILE_DELETE:
+    respondToProfileDELETE(&commonParms, service, response);
+    break;
+  case CLASS_MGMT_ACCESS_LIST_GET:
+    respondToProfileAccessListGET(&commonParms, service, response);
+    break;
+  case CLASS_MGMT_ACCESS_LIST_PUT:
+    respondToProfileAccessListPUT(&commonParms, service, response);
+    break;
+  case CLASS_MGMT_ACCESS_LIST_DELETE:
+    respondToProfileAccessListDELETE(&commonParms, service, response);
+    break;
+  default:
+  {
+    respondWithError(response, HTTP_STATUS_NOT_IMPLEMENTED,
+                     "Unsupported request");
+  }
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+  return 0;
+}
+
+/************ Group management functions ************/
+
+#define GROUP_MGMT_QUERY_MIN_SEGMENT_COUNT    1
+#define GROUP_MGMT_QUERY_MAX_SEGMENT_COUNT    5
+#define GROUP_MGMT_GROUP_SEGMENT_ID           1
+#define GROUP_MGMT_ACCESS_LIST_SEGMENT_ID     3
+
+static bool isGroupMgmtQueryStringValid(StringList *path) {
+
+  char *pathSegments[GROUP_MGMT_QUERY_MAX_SEGMENT_COUNT] = {0};
+  int minSegmentCount = GROUP_MGMT_QUERY_MIN_SEGMENT_COUNT;
+  int maxSegmentCount = sizeof(pathSegments) / sizeof(pathSegments[0]);
+
+  int segmentCount = path->count;
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "group-mgmt query segment count = %d [%d, %d]\n",
+         segmentCount, minSegmentCount, maxSegmentCount);
+
+  if (segmentCount < minSegmentCount || maxSegmentCount < segmentCount) {
+    return false;
+  }
+
+  StringListElt *pathSegment = firstStringListElt(path);
+
+  for (int i = 0; i < maxSegmentCount; i++) {
+    if (pathSegment == NULL) {
+      break;
+    }
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "group-mgmt path segment #%d =\'%s\'\n", i, pathSegment->string);
+
+    pathSegments[i] = pathSegment->string;
+    pathSegment = pathSegment->next;
+  }
+
+  char *serviceSegment = pathSegments[0];
+  if (serviceSegment == NULL) {
+    return false;
+  }
+  if (strcmp(serviceSegment, "security-mgmt") != 0) {
+    return false;
+  }
+
+  /* security-mgmt/groups ? No, leave. The URL is incorrect */
+  char *groupSegment = pathSegments[GROUP_MGMT_GROUP_SEGMENT_ID];
+  if (groupSegment != NULL && strcmp(groupSegment, "groups") != 0) {
+    return false;
+  }
+
+  /* security-mgmt/groups/group_value/access-list ?
+   * No, leave. The URL is incorrect */
+  char *accessListSegment = pathSegments[GROUP_MGMT_ACCESS_LIST_SEGMENT_ID];
+  if (accessListSegment != NULL &&
+      strcmp(accessListSegment, "access-list") != 0) {
+    return false;
+  }
+
+  return true;
+}
+
+static void extractGroupMgmtQueryParms(StringList *path,
+                                       const char **groupName,
+                                       const char **accessListEntryID) {
+
+  char *pathSegments[GROUP_MGMT_QUERY_MAX_SEGMENT_COUNT] = {0};
+  int maxSegmentCount = sizeof(pathSegments) / sizeof(pathSegments[0]);
+
+  StringListElt *pathSegment = firstStringListElt(path);
+  for (int i = 0; i < maxSegmentCount; i++) {
+    if (pathSegment == NULL) {
+      break;
+    }
+    pathSegments[i] = pathSegment->string;
+    pathSegment = pathSegment->next;
+  }
+
+  char *groupSegment = pathSegments[GROUP_MGMT_GROUP_SEGMENT_ID];
+  char *groupSegmentValue =
+      pathSegments[GROUP_MGMT_GROUP_SEGMENT_ID + 1];
+  if (groupSegment != NULL && groupSegmentValue == NULL) {
+    *groupName = "";
+  } else {
+    *groupName = groupSegmentValue;
+  }
+
+  char *accessListSegment = pathSegments[GROUP_MGMT_ACCESS_LIST_SEGMENT_ID];
+  char *accessListSegmentValue =
+      pathSegments[GROUP_MGMT_ACCESS_LIST_SEGMENT_ID + 1];
+  if (accessListSegment != NULL && accessListSegmentValue == NULL) {
+    *accessListEntryID = "";
+  } else {
+    *accessListEntryID = accessListSegmentValue;
+  }
+
+}
+
+typedef enum GroupMgmtRequestType_tag {
+  GROUP_MGMT_UNKNOWN_REQUEST,
+  GROUP_MGMT_GROUP_GET,
+  GROUP_MGMT_GROUP_POST,
+  GROUP_MGMT_GROUP_PUT,
+  GROUP_MGMT_GROUP_DELETE,
+  GROUP_MGMT_ACCESS_LIST_GET,
+  GROUP_MGMT_ACCESS_LIST_POST,
+  GROUP_MGMT_ACCESS_LIST_PUT,
+  GROUP_MGMT_ACCESS_LIST_DELETE
+} GroupMgmtRequestType;
+
+static GroupMgmtRequestType getGroupMgmtRequstType(HttpRequest *request) {
+
+  const char *groupName = NULL;
+  const char *accessListEntryID = NULL;
+  extractGroupMgmtQueryParms(request->parsedFile,
+                             &groupName,
+                             &accessListEntryID);
+
+  bool groupQuery = false;
+  bool accessListQuery = false;
+
+  if (groupName != NULL && accessListEntryID != NULL) {
+    accessListQuery = true;
+  } else if (groupName != NULL) {
+    groupQuery = true;
+  } else {
+    return GROUP_MGMT_UNKNOWN_REQUEST;
+  }
+
+  if (!strcmp(request->method, methodGET)) {
+    if (groupQuery) {
+      return GROUP_MGMT_GROUP_GET;
+    } else if (accessListQuery) {
+      return GROUP_MGMT_ACCESS_LIST_GET;
+    }
+  } else if (!strcmp(request->method, methodPOST)) {
+    if (groupQuery) {
+      return GROUP_MGMT_GROUP_POST;
+    } else if (accessListQuery) {
+      return GROUP_MGMT_ACCESS_LIST_POST;
+    }
+  } else if (!strcmp(request->method, methodPUT)) {
+    if (groupQuery) {
+      return GROUP_MGMT_GROUP_PUT;
+    } else if (accessListQuery) {
+      return GROUP_MGMT_ACCESS_LIST_PUT;
+    }
+  } else if (!strcmp(request->method, methodDELETE)) {
+    if (groupQuery) {
+      return GROUP_MGMT_GROUP_DELETE;
+    } else if (accessListQuery) {
+      return GROUP_MGMT_ACCESS_LIST_DELETE;
+    }
+  } else {
+    return GROUP_MGMT_UNKNOWN_REQUEST;
+  }
+
+
+  return GROUP_MGMT_UNKNOWN_REQUEST;
+}
+
+typedef struct GroupMgmtCommonParms_tag {
+  JsonObject *requestBody;
+  CrossMemoryServerName *zisServerName;
+  const char *groupName;
+  const char *accessListEntryID;
+  bool isDryRun;
+  int traceLevel;
+} GroupMgmtCommonParms;
+
+#define GROUP_PROFILE_MAX_COUNT  1000
+
+static int getGroupCount(HttpRequest *request) {
+  HttpRequestParam *countParam = getCheckedParam(request, "count");
+  return (countParam ? countParam->intValue : GROUP_PROFILE_MAX_COUNT);
+}
+
+static void printGroupProfileToJSON(jsonPrinter *printer,
+                                    const ZISGroupProfileEntry *entry) {
+
+  char profileNullTerm[sizeof(entry->group) + 1] = {0};
+  char ownerNullTerm[sizeof(entry->owner) + 1] = {0};
+  char superiorGroupNullTerm[sizeof(entry->superiorGroup) + 1] = {0};
+  memcpy(profileNullTerm, entry->group, sizeof(entry->group));
+  memcpy(ownerNullTerm, entry->owner, sizeof(entry->owner));
+  memcpy(superiorGroupNullTerm, entry->superiorGroup,
+         sizeof(entry->superiorGroup));
+
+  nullTerminate(profileNullTerm, sizeof(profileNullTerm) - 1);
+  nullTerminate(ownerNullTerm, sizeof(ownerNullTerm) - 1);
+  nullTerminate(superiorGroupNullTerm, sizeof(ownerNullTerm) - 1);
+
+  jsonStartObject(printer, NULL);
+  {
+    jsonAddString(printer, "profile", profileNullTerm);
+    jsonAddString(printer, "owner", ownerNullTerm);
+    jsonAddString(printer, "superiorGroup", superiorGroupNullTerm);
+  }
+  jsonEndObject(printer);
+
+}
+
+static void respondWithGroupProfiles(HttpResponse *response,
+                                     const char *startGroup,
+                                     unsigned int groupsRequested,
+                                     const ZISGroupProfileEntry *groups,
+                                     unsigned int groupCount) {
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_OK, "OK");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+
+  printTableResultResponseMetadata(printer);
+  jsonAddString(printer, "resultType", "table");
+  jsonStartObject(printer, "metaData");
+  {
+
+    jsonStartObject(printer, "tableMetaData");
+    {
+      jsonAddString(printer, "tableIdentifier", "profiles");
+      jsonAddString(printer, "shortTableLabel", "profiles");
+      jsonAddString(printer, "longTableLabel", "Profiles");
+      jsonAddString(printer, "globalIdentifier",
+                    "org.zowe.zss.security-mgmt.groups");
+      jsonAddInt(printer, "minRows", 0);
+      jsonAddInt(printer, "maxRows", GROUP_PROFILE_MAX_COUNT);
+    }
+    jsonEndObject(printer);
+
+    jsonStartArray(printer, "columnMetaData");
+    {
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "group");
+        jsonAddString(printer, "shortColumnLabel", "group");
+        jsonAddString(printer, "longColumnLabel", "Group Name");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(groups[0].group));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "owner");
+        jsonAddString(printer, "shortColumnLabel", "owner");
+        jsonAddString(printer, "longColumnLabel", "Owner");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(groups[0].owner));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "superiorGroup");
+        jsonAddString(printer, "shortColumnLabel", "superiorGroup");
+        jsonAddString(printer, "longColumnLabel", "Superior Group");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength",
+                   sizeof(groups[0].superiorGroup));
+      }
+      jsonEndObject(printer);
+
+    }
+    jsonEndArray(printer);
+
+  }
+  jsonEndObject(printer);
+
+  int groupsToReturn = (groupCount > groupsRequested) ?
+                        groupCount - 1 : groupCount;
+
+  jsonAddString(printer, "start", startGroup ? (char *)startGroup : "");
+  jsonAddInt(printer, "count", groupsToReturn);
+  jsonAddInt(printer, "countRequested", groupsRequested);
+  if (groupsRequested < groupCount) {
+    jsonAddBoolean(printer, "hasMore", TRUE);
+  } else {
+    jsonAddBoolean(printer, "hasMore", FALSE);
+  }
+
+  jsonStartArray(printer, "rows");
+  {
+    for (int i = 0; i < groupsToReturn; i++) {
+      const ZISGroupProfileEntry *entry = &groups[i];
+      printGroupProfileToJSON(printer, entry);
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "group entry #%d: %.*s, %.*s\n", i,
+             sizeof(entry->group), entry->group,
+             sizeof(entry->owner), entry->owner);
+    }
+  }
+  jsonEndArray(printer);
+
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+static void formatZISGroupProfileServiceError(int zisCallRC,
+                                              const void *serviceStatus,
+                                              char *messageBuffer,
+                                              size_t messageBufferSize) {
+
+  const ZISGroupProfileServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_GRPRFSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_GPPRFSRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_GPPRFSRV_INTERNAL_SERVICE_FAILED) {
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN);
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_GRPRFSRV_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_GPPRFSRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+static void respondToGroupGET(GroupMgmtCommonParms *commonParms,
+                              HttpService *service,
+                              HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  HttpRequest *request = response->request;
+
+  int zisRC = RC_ZIS_SRVC_OK;
+  char *startGroup = getQueryParam(response->request, "start");
+  int groupsToExtract = getGroupCount(request);
+  if (groupsToExtract < 0 || GROUP_PROFILE_MAX_COUNT < groupsToExtract) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Count out of range");
+    return;
+  }
+
+  ZISGroupProfileEntry resultBuffer[GROUP_PROFILE_MAX_COUNT + 1];
+  unsigned int groupsExtracted = 0;
+  ZISGroupProfileServiceStatus status = {0};
+
+  zisRC = zisExtractGroupProfiles(
+      commonParms->zisServerName,
+      startGroup,
+      groupsToExtract + 1,
+      resultBuffer,
+      &groupsExtracted,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisExtractGroupProfiles: RC=%d, base=(%d,%d,%d,%d), "
+         "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisExtractGroupProfiles: profiles to extract = %u, "
+         "extracted = %u\n",
+         groupsToExtract, groupsExtracted);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGroupProfiles(response, startGroup, groupsToExtract,
+                             resultBuffer, groupsExtracted);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGroupProfileServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+typedef enum GroupAction_tag {
+  GROUP_ACTION_ADD_GROUP,
+  GROUP_ACTION_REMOVE_GROUP,
+  GROUP_ACTION_UPDATE_GROUP
+} GroupAction;
+
+static void respondWithGroupAdminInfo(
+    HttpResponse *response,
+    GroupAction action,
+    bool isDryRun,
+    const ZISGroupAdminServiceMessage *operatorCommand)
+{
+
+  if (isDryRun) {
+
+    jsonPrinter *printer = respondWithJsonPrinter(response);
+    setResponseStatus(response, HTTP_STATUS_OK, "OK");
+    setContentType(response, "text/json");
+    addStringHeader(response, "Server", "jdmfws");
+    addStringHeader(response, "Transfer-Encoding", "chunked");
+    writeHeader(response);
+
+    jsonStart(printer);
+
+    jsonAddString(printer, "_objectType",
+                  "org.zowe.zss.security-mgmt.operator-command");
+    jsonAddString(printer, "resultMetaDataSchemaVersion", "1.0");
+    jsonAddString(printer, "serviceVersion", "1.0");
+
+
+    jsonAddLimitedString(printer, "operatorCommand",
+                         (char *)operatorCommand->text,
+                         operatorCommand->length);
+
+    jsonEnd(printer);
+
+  } else {
+
+    if (action == GROUP_ACTION_ADD_GROUP) {
+      setResponseStatus(response, HTTP_STATUS_CREATED, "OK");
+    } else {
+      setResponseStatus(response, HTTP_STATUS_NO_CONTENT, "OK");
+    }
+    setContentType(response, "text/plain");
+    addIntHeader(response, "Content-Length", 0);
+    addStringHeader(response,"Server","jdmfws");
+    writeHeader(response);
+
+  }
+
+  finishResponse(response);
+
+}
+
+static void formatZISGroupAdminServiceError(int zisCallRC,
+                                             const void *serviceStatus,
+                                             char *messageBuffer,
+                                             size_t messageBufferSize) {
+
+  const ZISGroupAdminServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_GSADMNSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_GRPASRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_GRPASRV_INTERNAL_SERVICE_FAILED) {
+
+      const char *radminMessage = NULL;
+      size_t radminMessageLength = 0;
+      if (status->message.length > 0) {
+        radminMessage = status->message.text;
+        radminMessageLength = status->message.length;
+      } else {
+        radminMessage = "no additional info";
+        radminMessageLength = strlen(radminMessage);
+      }
+
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)"
+               " - \'%.*s\'",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN,
+               radminMessageLength, radminMessage);
+
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_PADMIN_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_GRPASRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+static void respondToGroupPOST(GroupMgmtCommonParms *commonParms,
+                               HttpService *service,
+                               HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->groupName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "group name required for profile POST\n");
+    return;
+  }
+
+  if (commonParms->requestBody == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Body missing");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "body not provided for group POST, leaving...\n");
+    return;
+  }
+
+  Json *superiorGroupParm =
+      jsonObjectGetPropertyValue(commonParms->requestBody, "superiorGroup");
+  if (superiorGroupParm == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "superiorGroup missing");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "superior not provided for group POST, leaving...\n");
+    return;
+  }
+
+  char *superiorGroupString = jsonAsString(superiorGroupParm);
+  if (superiorGroupString == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "superior group has bad type");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "bad superior group provided for group POST, leaving...\n");
+    return;
+  }
+
+
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGroupAdminServiceMessage operatorCommand = {0};
+  ZISGroupAdminServiceStatus status = {0};
+  int zisRC = zisAddGroup(
+      commonParms->zisServerName,
+      commonParms->groupName,
+      superiorGroupString,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisAddGroup: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+         "SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisAddGroup: serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisAddGroup: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGroupAdminInfo(response, GROUP_ACTION_ADD_GROUP, isDryRun,
+                              &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGroupAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void respondToGroupDELETE(GroupMgmtCommonParms *commonParms,
+                                 HttpService *service,
+                                 HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->groupName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "profile name required for profile DELETE\n");
+    return;
+  }
+
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGroupAdminServiceMessage operatorCommand = {0};
+  ZISGroupAdminServiceStatus status = {0};
+  int zisRC = zisDeleteGroup(
+      commonParms->zisServerName,
+      commonParms->groupName,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDeleteGroup: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+         "SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDeleteGroup:  serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisDeleteGroup: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGroupAdminInfo(response, GROUP_ACTION_REMOVE_GROUP, isDryRun,
+                               &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGroupAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static ZISGroupAdminServiceAccessType
+translateGroupAccessType(const char *typeString) {
+
+  if (!strcmp(typeString, "USE")) {
+    return ZIS_GROUP_ADMIN_ACESS_TYPE_USE;
+  }
+
+  if (!strcmp(typeString, "CREATE")) {
+    return ZIS_GROUP_ADMIN_ACESS_TYPE_CREATE;
+  }
+
+  if (!strcmp(typeString, "CONNECT")) {
+    return ZIS_GROUP_ADMIN_ACESS_TYPE_CONNECT;
+  }
+
+  if (!strcmp(typeString, "JOIN")) {
+    return ZIS_GROUP_ADMIN_ACESS_TYPE_JOIN;
+  }
+
+  return ZIS_GROUP_ADMIN_ACESS_TYPE_UNKNOWN;
+}
+
+static void respondToGroupAccessListPUT(GroupMgmtCommonParms *commonParms,
+                                        HttpService *service,
+                                        HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->groupName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "group name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "group name required for user POST/PUT\n");
+    return;
+  }
+
+  if (strlen(commonParms->accessListEntryID) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "user ID required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "user ID required for user POST/PUT\n");
+    return;
+  }
+
+  if (commonParms->requestBody == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Body missing");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "body not provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  Json *accessTypeParm = jsonObjectGetPropertyValue(commonParms->requestBody,
+                                                    "accessType");
+  if (accessTypeParm == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "accessType missing");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "access type not provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  char *accessTypeString = jsonAsString(accessTypeParm);
+  if (accessTypeString == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "accessType has bad type");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "bad access type provided for user POST/PUT, leaving...\n");
+    return;
+  }
+
+  ZISGroupAdminServiceAccessType accessType =
+      translateGroupAccessType(accessTypeString);
+  if (accessType == ZIS_GROUP_ADMIN_ACESS_TYPE_UNKNOWN) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "unknown access type, use [USE, CREATE, CONNECT, JOIN]");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "unknown access type (%d( provided for user POST/PUT, leaving...\n",
+           accessType);
+    return;
+  }
+
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGroupAdminServiceMessage operatorCommand = {0};
+  ZISGroupAdminServiceStatus status = {0};
+  int zisRC = zisConnectToGroup(
+      commonParms->zisServerName,
+      commonParms->accessListEntryID,
+      commonParms->groupName,
+      accessType,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisConnectToGroup: RC=%d, base=(%d,%d,%d,%d), internal=(%d,%d), "
+         "SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisConnectToGroup:  serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisConnectToGroup: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGroupAdminInfo(response, GROUP_ACTION_UPDATE_GROUP, isDryRun,
+                              &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGroupAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void printGroupAccessListEntryToJSON(jsonPrinter *printer,
+                                           const ZISGroupAccessEntry *entry) {
+
+  char idNullTerm[sizeof(entry->id) + 1] = {0};
+  char accessTypeNullTerm[sizeof(entry->accessType) + 1] = {0};
+  memcpy(idNullTerm, entry->id, sizeof(entry->id));
+  memcpy(accessTypeNullTerm, entry->accessType, sizeof(entry->accessType));
+
+  nullTerminate(idNullTerm, sizeof(idNullTerm) - 1);
+  nullTerminate(accessTypeNullTerm, sizeof(accessTypeNullTerm) - 1);
+
+  jsonStartObject(printer, NULL);
+  {
+    jsonAddString(printer, "id", idNullTerm);
+    jsonAddString(printer, "accessType", accessTypeNullTerm);
+  }
+  jsonEndObject(printer);
+
+}
+
+static void respondWithGroupAccessList(HttpResponse *response,
+                                       const ZISGroupAccessEntry *accessList,
+                                       unsigned int accessListEntryCount) {
+
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_OK, "OK");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+
+  printTableResultResponseMetadata(printer);
+  jsonAddString(printer, "resultType", "table");
+  jsonStartObject(printer, "metaData");
+  {
+
+    jsonStartObject(printer, "tableMetaData");
+    {
+      jsonAddString(printer, "tableIdentifier", "access-list");
+      jsonAddString(printer, "shortTableLabel", "access-list");
+      jsonAddString(printer, "longTableLabel", "Access List");
+      jsonAddString(printer, "globalIdentifier",
+                    "org.zowe.zss.security-mgmt.group-access-list");
+    }
+    jsonEndObject(printer);
+
+    jsonStartArray(printer, "columnMetaData");
+    {
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "id");
+        jsonAddString(printer, "shortColumnLabel", "id");
+        jsonAddString(printer, "longColumnLabel", "ID");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength", sizeof(accessList[0].id));
+      }
+      jsonEndObject(printer);
+
+      jsonStartObject(printer, NULL);
+      {
+        jsonAddString(printer, "columnIdentifier", "accessType");
+        jsonAddString(printer, "shortColumnLabel", "accessType");
+        jsonAddString(printer, "longColumnLabel", "Access Type");
+        jsonAddString(printer, "rawDataType", "string");
+        jsonAddInt(printer, "rawDataTypeLength",
+                   sizeof(accessList[0].accessType));
+      }
+      jsonEndObject(printer);
+
+    }
+    jsonEndArray(printer);
+
+  }
+  jsonEndObject(printer);
+
+  jsonAddInt(printer, "count", accessListEntryCount);
+
+  jsonStartArray(printer, "rows");
+  {
+    for (int i = 0; i < accessListEntryCount; i++) {
+      const ZISGroupAccessEntry *entry = &accessList[i];
+      printGroupAccessListEntryToJSON(printer, entry);
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "access list entry #%d: %.*s, %.*s\n", i,
+             sizeof(entry->id), entry->id,
+             sizeof(entry->accessType), entry->accessType);
+    }
+  }
+  jsonEndArray(printer);
+
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+static void formatZISGroupAccessListServiceError(int zisCallRC,
+                                                 const void *serviceStatus,
+                                                 char *messageBuffer,
+                                                 size_t messageBufferSize) {
+
+  const ZISGroupAccessListServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_ACSLSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    const char *description = ZIS_GRPALSRV_SERVICE_RC_DESCRIPTION[serviceRC];
+    if (serviceRC == RC_ZIS_GRPALSRV_INTERNAL_SERVICE_FAILED) {
+      snprintf(messageBuffer, messageBufferSize,
+               "R_admin failed (RC = %d, SAF RC = %d, RACF RC = %d, RSN = %d)",
+               status->internalServiceRC,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN);
+    } else {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+    return;
+
+  }
+
+  if (zisCallRC > RC_ZIS_SRVC_ACSLSRV_MAX_RC) {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+    return;
+  }
+
+  const char *description = ZIS_GRPALSRV_WRAPPER_RC_DESCRIPTION[zisCallRC];
+  snprintf(messageBuffer, messageBufferSize, "ZIS failed (RC = %d) - %s",
+           zisCallRC, description);
+
+}
+
+#define GROUP_MGMT_ACCESS_LIST_DEFAULT_SIZE     128
+#define GROUP_MGMT_ACCESS_LIST_MAX_SIZE         8192
+
+static void respondToGroupAccessListGET(GroupMgmtCommonParms *commonParms,
+                                        HttpService *service,
+                                        HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->accessListEntryID) > 0) {
+    respondWithError(response, HTTP_STATUS_NOT_IMPLEMENTED,
+                     "specific user access status retrieval not implemented");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "access list can only be retrieved in bulk, leaving...\n");
+    return;
+  }
+
+  unsigned int resultBufferCapacity = GROUP_MGMT_ACCESS_LIST_DEFAULT_SIZE;
+  unsigned int resultBufferSize = 0;
+  ZISGroupAccessEntry *resultBuffer = NULL;
+  int zisRC = RC_ZIS_SRVC_OK;
+  unsigned int entriesExtracted = 0;
+  ZISGroupAccessListServiceStatus status = {0};
+
+  for (int i = 0; i < 2; i++) {
+
+    resultBufferSize = sizeof(ZISGroupAccessEntry) * resultBufferCapacity;
+    resultBuffer =
+        (ZISGroupAccessEntry *)safeMalloc(resultBufferSize, "access list");
+    if (resultBuffer == NULL) {
+      respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                       "out of memory");
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+             "access list buffer with size %u not allocated, leaving...\n",
+             resultBufferSize);
+      return;
+    }
+
+    zisRC = zisExtractGroupAccessList(
+        commonParms->zisServerName,
+        commonParms->groupName,
+        resultBuffer,
+        resultBufferCapacity,
+        &entriesExtracted,
+        &status,
+        commonParms->traceLevel
+    );
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "zisExtractGroupAccessList: RC=%d, base=(%d,%d,%d,%d), "
+           "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+           status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+           status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+           status.internalServiceRC, status.internalServiceRSN,
+           status.safStatus.safRC, status.safStatus.racfRC,
+           status.safStatus.racfRSN);
+
+    if (zisRC == RC_ZIS_SRVC_GRPALSRV_INSUFFICIENT_BUFFER) {
+
+      safeFree((char *)resultBuffer, resultBufferSize);
+      resultBuffer = NULL;
+
+      if (entriesExtracted <= 0 ||
+          GROUP_MGMT_ACCESS_LIST_MAX_SIZE < entriesExtracted) {
+        respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                         "access list size our of range");
+        zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+               "access list size our of range (%u), leaving...\n",
+               entriesExtracted);
+        return;
+      }
+
+      resultBufferCapacity = entriesExtracted;
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "access list will be re-allocated with capacity %u\n",
+             resultBufferCapacity);
+
+    } else {
+      break;
+    }
+
+  }
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGroupAccessList(response, resultBuffer, entriesExtracted);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGroupAccessListServiceError);
+  }
+
+  safeFree((char *)resultBuffer, resultBufferSize);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "access list buffer with size %u freed @ 0x%p\n",
+         resultBufferSize, resultBuffer);
+
+  resultBuffer = NULL;
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void respondToGroupAccessListDELETE(GroupMgmtCommonParms *commonParms,
+                                           HttpService *service,
+                                           HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  if (strlen(commonParms->groupName) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "group name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "group name required for access list  DELETE\n");
+    return;
+  }
+
+  if (strlen(commonParms->accessListEntryID) == 0) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "access list entry name required");
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "access list entry name required for access list DELETE\n");
+    return;
+  }
+
+  HttpRequest *request = response->request;
+  bool isDryRun = commonParms->isDryRun;
+
+  ZISGroupAdminServiceMessage operatorCommand;
+  ZISGroupAdminServiceStatus status = {0};
+  int zisRC = zisRemoveFromGroup(
+      commonParms->zisServerName,
+      commonParms->accessListEntryID,
+      commonParms->groupName,
+      isDryRun,
+      &operatorCommand,
+      &status,
+      commonParms->traceLevel
+  );
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisRemoveFromGroup: RC=%d, base=(%d,%d,%d,%d), "
+         "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+         status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+         status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+         status.internalServiceRC, status.internalServiceRSN,
+         status.safStatus.safRC, status.safStatus.racfRC,
+         status.safStatus.racfRSN);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisRemoveFromGroup:  serviceMsg=\'%.*s\'\n",
+         status.message.length, status.message.text);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "zisRemoveFromGroup: isDryRun=%d, operCmd=\'%.*s\'\n",
+         isDryRun, operatorCommand.length, operatorCommand.text);
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    respondWithGroupAdminInfo(response, GROUP_ACTION_UPDATE_GROUP, isDryRun,
+                              &operatorCommand);
+  } else {
+    respondWithZISError(response, zisRC, &status,
+                        formatZISGroupAdminServiceError);
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+
+}
+
+static void extractGroupMgmtCommonParms(HttpService *service,
+                                        HttpRequest *request,
+                                        GroupMgmtCommonParms *parms) {
+
+  parms->zisServerName =
+      getConfiguredProperty(service->server,
+                            HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY);
+  extractGroupMgmtQueryParms(request->parsedFile,
+                             &parms->groupName,
+                             &parms->accessListEntryID);
+  parms->requestBody = getJsonBody(request->contentBody,
+                                   request->contentLength,
+                                   request->slh);
+
+  parms->isDryRun = getDryRunValue(request);
+  parms->traceLevel = getTraceLevel(request);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "group-mgmt parms: zisServerName=\'%.16s\', "
+         "gorup=\'%s\', accessListEntryID=\'%s\', "
+         "traceLevel=%d\n",
+         parms->zisServerName->nameSpacePadded,
+         parms->groupName ? parms->groupName : "null",
+         parms->accessListEntryID ? parms->accessListEntryID : "null",
+         parms->traceLevel);
+
+}
+
+static int serveGroupManagement(HttpService *service,
+                                HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  HttpRequest *request = response->request;
+
+  if (isGroupMgmtQueryStringValid(request->parsedFile) == false) {
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+           "group-mgmt query string is invalid, leaving...\n");
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Incorrect query");
+    return 0;
+  }
+
+  GroupMgmtCommonParms commonParms;
+  extractGroupMgmtCommonParms(service, response->request, &commonParms);
+
+  GroupMgmtRequestType requestType = getGroupMgmtRequstType(request);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+         "group-mgmt requestType = %d\n", requestType);
+
+  switch (requestType) {
+  case GROUP_MGMT_GROUP_GET:
+    respondToGroupGET(&commonParms, service, response);
+    break;
+  case GROUP_MGMT_GROUP_POST:
+    respondToGroupPOST(&commonParms, service, response);
+    break;
+  case GROUP_MGMT_GROUP_DELETE:
+    respondToGroupDELETE(&commonParms, service, response);
+    break;
+  case GROUP_MGMT_ACCESS_LIST_GET:
+    respondToGroupAccessListGET(&commonParms, service, response);
+    break;
+  case GROUP_MGMT_ACCESS_LIST_PUT:
+    respondToGroupAccessListPUT(&commonParms, service, response);
+    break;
+  case GROUP_MGMT_ACCESS_LIST_DELETE:
+    respondToGroupAccessListDELETE(&commonParms, service, response);
+    break;
+  default:
+  {
+    respondWithError(response, HTTP_STATUS_NOT_IMPLEMENTED,
+                     "Unsupported request");
+  }
+  }
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+  return 0;
+}
+
+#define DEFAULT_TEAM_PROFILE_COUNT  128
+
+static ZISGenresProfileEntry *getProfilesByPrefixOrFail(
+    HttpResponse *response,
+    CrossMemoryServerName *zisServerName,
+    const char *profilePrefix,
+    int *profileCount,
+    int traceLevel
+ ) {
+
+  ShortLivedHeap *slh = response->slh;
+
+  unsigned int prefixSize = strlen(profilePrefix);
+  if (prefixSize > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+    /* TODO handle */
+    return NULL;
+  }
+
+  char startProfile[ZIS_SECURITY_PROFILE_MAX_LENGTH + 1] = {0};
+  strcpy(startProfile, profilePrefix);
+
+  unsigned int resultBufferCapacity = DEFAULT_TEAM_PROFILE_COUNT;
+  unsigned int resultBufferSize =
+      resultBufferCapacity * sizeof(ZISGenresProfileEntry);
+  ZISGenresProfileEntry *resultBuffer =
+      (ZISGenresProfileEntry *)SLHAlloc(slh, resultBufferSize);
+  unsigned int profilesFound = 0;
+
+  ZISGenresProfileEntry workBuffer[GENRES_PROFILE_MAX_COUNT];
+
+  while (TRUE) {
+
+    unsigned int profilesToExtract = sizeof(workBuffer) / sizeof(workBuffer[0]);
+    unsigned int profilesExtracted = 0;
+    ZISGenresProfileServiceStatus status = {0};
+
+    int zisRC = zisExtractGenresProfiles(
+        zisServerName,
+        NULL,
+        startProfile,
+        profilesToExtract,
+        workBuffer,
+        &profilesExtracted,
+        &status,
+        traceLevel
+    );
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "getProfilesByClassAndPrefix: RC=%d, base=(%d,%d,%d,%d), "
+           "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+           status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+           status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+           status.internalServiceRC, status.internalServiceRSN,
+           status.safStatus.safRC, status.safStatus.racfRC,
+           status.safStatus.racfRSN);
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "getProfilesByClassAndPrefix: profiles to extract = %u, "
+           "extracted = %u\n",
+           profilesToExtract, profilesExtracted);
+
+    if (zisRC != RC_ZIS_SRVC_OK) {
+      respondWithZISError(response, zisRC, &status,
+                          formatZISGenresProfileServiceError);
+      *profileCount = 0;
+      return NULL;
+    }
+
+    int profilesToProcess = profilesExtracted < profilesToExtract ?
+                            profilesExtracted : profilesToExtract - 1;
+    for (int i = 0; i < profilesToProcess; i++) {
+
+      if (memcmp(&workBuffer[i].profile, profilePrefix, prefixSize) != 0) {
+        continue;
+      }
+
+      if (resultBufferCapacity < profilesFound + 1) {
+        resultBufferCapacity *= 2;
+        unsigned int newBufferSize =
+            resultBufferCapacity * sizeof(ZISGenresProfileEntry);
+        ZISGenresProfileEntry *newBuffer =
+            (ZISGenresProfileEntry *)SLHAlloc(slh, newBufferSize);
+        memcpy(newBuffer, resultBuffer,
+               sizeof(resultBuffer[0]) * profilesFound);
+        resultBuffer = newBuffer;
+      }
+
+      resultBuffer[profilesFound++] = workBuffer[i];
+
+    }
+
+    if (profilesExtracted < profilesToExtract) {
+      break;
+    }
+
+    memcpy(startProfile, workBuffer[profilesToExtract - 1].profile,
+           sizeof(startProfile) - 1);
+    nullTerminate(startProfile, sizeof(startProfile) - 1);
+
+  }
+
+  *profileCount = profilesFound;
+  return resultBuffer;
+}
+
+static ZISGroupAccessEntry *getAccessListByGroupOrFail(
+    HttpResponse *response,
+    CrossMemoryServerName *zisServerName,
+    const char *group,
+    int *entryCount,
+    int traceLevel
+) {
+
+  ShortLivedHeap *slh = response->slh;
+  unsigned int resultBufferCapacity = GROUP_MGMT_ACCESS_LIST_DEFAULT_SIZE;
+  unsigned int resultBufferSize = 0;
+  ZISGroupAccessEntry *resultBuffer = NULL;
+  int zisRC = RC_ZIS_SRVC_OK;
+  unsigned int entriesExtracted = 0;
+  ZISGroupAccessListServiceStatus status = {0};
+
+  for (int i = 0; i < 2; i++) {
+
+    resultBufferSize = sizeof(ZISGroupAccessEntry) * resultBufferCapacity;
+    resultBuffer =
+        (ZISGroupAccessEntry *)SLHAlloc(slh, resultBufferSize);
+
+    zisRC = zisExtractGroupAccessList(
+        zisServerName,
+        group,
+        resultBuffer,
+        resultBufferCapacity,
+        &entriesExtracted,
+        &status,
+        traceLevel
+    );
+
+    zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+           "getAccessListByGroup: RC=%d, base=(%d,%d,%d,%d), "
+           "internal=(%d,%d), SAF=(%d,%d,%d)\n", zisRC,
+           status.baseStatus.cmsRC, status.baseStatus.cmsRSN,
+           status.baseStatus.serviceRC, status.baseStatus.serviceRSN,
+           status.internalServiceRC, status.internalServiceRSN,
+           status.safStatus.safRC, status.safStatus.racfRC,
+           status.safStatus.racfRSN);
+
+    if (zisRC == RC_ZIS_SRVC_GRPALSRV_INSUFFICIENT_BUFFER) {
+
+      if (entriesExtracted <= 0 ||
+          GROUP_MGMT_ACCESS_LIST_MAX_SIZE < entriesExtracted) {
+        respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                         "access list size our of range");
+        zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_WARNING,
+               "access list size our of range (%u), leaving...\n",
+               entriesExtracted);
+        *entryCount = 0;
+        return NULL;
+      }
+
+      resultBufferCapacity = entriesExtracted;
+      zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG,
+             "access list will be re-allocated with capacity %u\n",
+             resultBufferCapacity);
+
+    } else if (zisRC != RC_ZIS_SRVC_OK) {
+      respondWithZISError(response, zisRC, &status,
+                          formatZISGroupAccessListServiceError);
+      *entryCount = 0;
+      return NULL;
+    }
+  }
+
+  *entryCount = entriesExtracted;
+  return resultBuffer;
+}
+
+static const char *translateSAFAccessLevelToString(int accessLevel,
+                                                   bool isTeamFormat) {
+
+  if (isTeamFormat) {
+    switch (accessLevel) {
+    case ZIS_SAF_ACCESS_NONE:
+      return "n/a";
+    case ZIS_SAF_ACCESS_READ:
+      return "user";
+    case ZIS_SAF_ACCESS_UPDATE:
+      return "admin";
+    case ZIS_SAF_ACCESS_CONTROL:
+    case ZIS_SAF_ACCESS_ALETER:
+      return "superadmin";
+    default:
+      return "n/a";
+    }
+  } else {
+    switch (accessLevel) {
+    case ZIS_SAF_ACCESS_NONE:
+      return "NONE";
+    case ZIS_SAF_ACCESS_READ:
+      return "READ";
+    case ZIS_SAF_ACCESS_UPDATE:
+      return "UPDATE";
+    case ZIS_SAF_ACCESS_CONTROL:
+      return "CONTROL";
+    case ZIS_SAF_ACCESS_ALETER:
+      return "ALTER";
+    default:
+      return "UNKNOWN";
+    }
+  }
+
+}
+
+static void formatZISProfileAccessError(int zisCallRC,
+                                        const void *serviceStatus,
+                                        char *messageBuffer,
+                                        size_t messageBufferSize) {
+
+  const ZISAuthServiceStatus *status = serviceStatus;
+
+  if (zisCallRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+    int serviceRSN = status->baseStatus.serviceRSN;
+    if (serviceRC > RC_ZIS_AUTHSRV_MAX_RC) {
+      snprintf(messageBuffer, messageBufferSize,
+               "Unknown ZIS service error (RC = %d, RSN = %d)",
+               serviceRC, serviceRSN);
+      return;
+    }
+
+    if (serviceRC == RC_ZIS_AUTHSRV_SAF_ABENDED) {
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - "
+               "SAF ABENDed with S%03X-%02X",
+               serviceRC, serviceRSN,
+               status->abendInfo.completionCode,
+               status->abendInfo.reasonCode);
+    } else if (serviceRC == RC_ZIS_AUTHSRV_SAF_ERROR ||
+               serviceRC == RC_ZIS_AUTHSRV_CREATE_FAILED ||
+               serviceRC == RC_ZIS_AUTHSRV_DELETE_FAILED) {
+      const char *description = ZIS_AUTH_RC_DESCRIPTION[serviceRC];
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s "
+               "(SAF RC = %d, RACF RC = %d, RSN = %d)",
+               serviceRC, serviceRSN, description,
+               status->safStatus.safRC,
+               status->safStatus.racfRC,
+               status->safStatus.racfRSN);
+    } else {
+      const char *description = ZIS_AUTH_RC_DESCRIPTION[serviceRC];
+      snprintf(messageBuffer, messageBufferSize,
+               "ZIS service failed (RC = %d, RSN = %d) - %s",
+               serviceRC, serviceRSN, description);
+    }
+
+  } else {
+    snprintf(messageBuffer, messageBufferSize,
+             "Unknown ZIS error (RC = %d)", zisCallRC);
+  }
+
+}
+
+static bool isFatalAccessInfoError(int zisRC,
+                                   const ZISAuthServiceStatus *status) {
+
+  if (zisRC == RC_ZIS_SRVC_OK) {
+    return false;
+  }
+
+  if (zisRC == RC_ZIS_SRVC_SERVICE_FAILED) {
+
+    int serviceRC = status->baseStatus.serviceRC;
+
+    if (serviceRC == RC_ZIS_AUTHSRV_SAF_ERROR ||
+        serviceRC == RC_ZIS_AUTHSRV_SAF_ABENDED ||
+        serviceRC == RC_ZIS_AUTHSRV_SAF_NO_DECISION) {
+      return false;
+    }
+
+  }
+
+  /* Anything other than those ZIS and service RCs is considered bad. */
+
+  return true;
+}
+
+static void printAccessInfoError(jsonPrinter *printer, int zisRC,
+                                 const ZISAuthServiceStatus *serviceStatus) {
+
+  char errorMessage[ERROR_MSG_MAX_SIZE] = {0};
+  jsonStartObject(printer, "error");
+  {
+    printErrorResponseMetadata(printer);
+    formatZISErrorMessage(zisRC, serviceStatus,
+                          formatZISProfileAccessError,
+                          errorMessage, sizeof(errorMessage));
+    jsonAddString(printer, "message", errorMessage);
+  }
+  jsonEndObject(printer);
+
+}
+
+static void respondWithAccessInfo(HttpResponse *response,
+                                  const CrossMemoryServerName *zisServerName,
+                                  const ZISGroupAccessEntry *groupAccessList,
+                                  unsigned int groupAccessEntryCount,
+                                  const ZISGenresProfileEntry *profiles,
+                                  unsigned int profileCount,
+                                  bool isTeamFormat,
+                                  int traceLevel) {
+
+  const char *userKey = isTeamFormat ? "member" : "userID";
+  const char *profilesKey = isTeamFormat ? "teams" : "profiles";
+  const char *accessTypeKey = isTeamFormat ? "role" : "accessType";
+
+  jsonPrinter *printer = respondWithJsonPrinter(response);
+  setResponseStatus(response, HTTP_STATUS_OK, "OK");
+  setContentType(response, "text/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  writeHeader(response);
+
+  jsonStart(printer);
+
+  jsonAddString(printer, "_objectType",
+                "org.zowe.zss.security-mgmt.access-info");
+  jsonAddString(printer, "resultMetaDataSchemaVersion", "1.0");
+  jsonAddString(printer, "serviceVersion", "1.0");
+
+  jsonStartArray(printer, "users");
+  {
+    for (unsigned int accessEntryID = 0; accessEntryID < groupAccessEntryCount;
+         accessEntryID++) {
+
+      char id[sizeof(groupAccessList[accessEntryID].id) + 1];
+      memset(id, 0, sizeof(id));
+      memcpy(id, groupAccessList[accessEntryID].id,
+             sizeof(groupAccessList[accessEntryID].id));
+      nullTerminate(id, sizeof(id) - 1);
+
+      jsonStartObject(printer, NULL);
+      {
+
+        bool accessInfoSvcErrorDetected = false;
+        int accessInfoSvcErrorRC = RC_ZIS_SRVC_OK;
+        ZISAuthServiceStatus accessInfoSvcErrorStatus = {0};
+
+        jsonAddString(printer, (char *)userKey, id);
+        jsonStartArray(printer, (char *)profilesKey);
+        {
+          for (unsigned int profileID = 0; profileID < profileCount;
+               profileID++) {
+
+            char profile[sizeof(profiles[0].profile) + 1];
+            memset(profile, 0, sizeof(profile));
+            memcpy(profile, profiles[profileID].profile,
+                   sizeof(profiles[0].profile));
+            nullTerminate(profile, sizeof(profile) - 1);
+
+            ZISSAFAccessLevel accessLevel = ZIS_SAF_ACCESS_NONE;
+
+            ZISAuthServiceStatus status = {0};
+            int zisRC = zisGetSAFAccessLevel(zisServerName, id, NULL, profile,
+                                             &accessLevel, &status, traceLevel);
+
+            if (zisRC == RC_ZIS_SRVC_OK) {
+              if (accessLevel != ZIS_SAF_ACCESS_NONE) {
+                jsonStartObject(printer, NULL);
+                {
+                  const char *accessTypeString =
+                      translateSAFAccessLevelToString(accessLevel, isTeamFormat);
+                  jsonAddString(printer, "name", profile);
+                  jsonAddString(printer, (char *)accessTypeKey,
+                                (char *)accessTypeString);
+                }
+                jsonEndObject(printer);
+              }
+            } else {
+
+              if (isFatalAccessInfoError(zisRC, &status)) {
+                accessInfoSvcErrorDetected = true;
+                accessInfoSvcErrorRC = zisRC;
+                accessInfoSvcErrorStatus = status;
+                break;
+              }
+
+              jsonStartObject(printer, NULL);
+              {
+                jsonAddString(printer, "name", profile);
+                printAccessInfoError(printer, zisRC, &status);
+              }
+              jsonEndObject(printer);
+            }
+
+          }
+        }
+        jsonEndArray(printer);
+
+        if (accessInfoSvcErrorDetected) {
+          printAccessInfoError(printer, accessInfoSvcErrorRC,
+                               &accessInfoSvcErrorStatus);
+        }
+
+      }
+      jsonEndObject(printer);
+
+    }
+  }
+  jsonEndArray(printer);
+
+  jsonEnd(printer);
+
+  finishResponse(response);
+
+}
+
+static const ZISGroupAccessEntry *findAccessListEntryByUserID(
+    const ZISGroupAccessEntry *entries,
+    int count,
+    const char *userID
+) {
+
+  char userIDSpacePadded[sizeof(entries->id)];
+
+  size_t userIDLength = strlen(userID);
+  if (userIDLength > sizeof(userIDSpacePadded)) {
+    return NULL;
+  }
+
+  memset(userIDSpacePadded, ' ', sizeof(userIDSpacePadded));
+  memcpy(userIDSpacePadded, userID, userIDLength);
+
+  /* TODO consider binary search if the entries are sorted */
+  for (int i = 0; i < count; i++) {
+    if (!memcmp(entries[i].id, userIDSpacePadded, sizeof(userIDSpacePadded))) {
+      return &entries[i];
+    }
+  }
+
+  return NULL;
+}
+
+static int serveAccessInfo(HttpService *service,
+                           HttpResponse *response) {
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  HttpRequest *request = response->request;
+
+  CrossMemoryServerName *zisServerName =
+      getConfiguredProperty(service->server,
+                            HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY);
+
+  char *group = getQueryParam(request, "group");
+  if (group == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "group must be provided");
+    return 0;
+  }
+
+  char *profile = getQueryParam(request, "profile");
+  if (profile == NULL) {
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,
+                     "profile must be provided");
+    return 0;
+  }
+
+  bool isTeamFormat = false;
+  {
+    char *format = getQueryParam(request, "format");
+    if (format && !strcmp(format, "team")) {
+      isTeamFormat = TRUE;
+    }
+  }
+
+  int traceLevel = getTraceLevel(request);
+
+  int accessEntryCount = 0;
+  const ZISGroupAccessEntry *accessEntries =
+          getAccessListByGroupOrFail(response,
+                                     zisServerName,
+                                     group,
+                                     &accessEntryCount,
+                                     traceLevel);
+  if (accessEntries == NULL) {
+    return 0;
+  }
+
+  char *userID = getQueryParam(request, "userID");
+  if (userID != NULL) {
+    accessEntries = findAccessListEntryByUserID(accessEntries,
+                                                accessEntryCount,
+                                                userID);
+    accessEntryCount = accessEntries ? 1 : 0;
+  }
+
+  int profileCount = 0;
+  const ZISGenresProfileEntry *profiles = NULL;
+  if (accessEntryCount > 0) {
+    profiles = getProfilesByPrefixOrFail(response,
+                                         zisServerName,
+                                         profile,
+                                         &profileCount,
+                                         traceLevel);
+    if (profiles == NULL) {
+      return 0;
+    }
+  }
+
+  respondWithAccessInfo(response, zisServerName,
+                        accessEntries, accessEntryCount,
+                        profiles, profileCount,
+                        isTeamFormat,
+                        traceLevel);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+  return 0;
+}
+
+void installSecurityManagementServices(HttpServer *server) {
+
+  logConfigureComponent(NULL, LOG_COMP_ID_SECURITY, "security-mgmt",
+                        LOG_DEST_PRINTF_STDOUT, ZOWE_LOG_INFO);
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
+
+  HttpService *classMgmtService =
+      makeGeneratedService("class management service",
+                           "/security-mgmt/classes/**");
+  classMgmtService->paramSpecList =
+      makeIntParamSpec("count", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeIntParamSpec("traceLevel", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeStringParamSpec("dryRun", SERVICE_ARG_OPTIONAL, NULL
+      )));
+  classMgmtService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  classMgmtService->serviceFunction = &serveClassManagement;
+  classMgmtService->runInSubtask = TRUE;
+  classMgmtService->doImpersonation = TRUE;
+  registerHttpService(server, classMgmtService);
+
+  HttpService *userProfileService =
+      makeGeneratedService("user profile service",
+                           "/security-mgmt/user-profiles/**");
+  userProfileService->paramSpecList =
+      makeIntParamSpec("count", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeIntParamSpec("traceLevel", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeStringParamSpec("dryRun", SERVICE_ARG_OPTIONAL, NULL
+      )));
+  userProfileService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  userProfileService->serviceFunction = &serveUserProfile;
+  userProfileService->runInSubtask = TRUE;
+  userProfileService->doImpersonation = TRUE;
+  registerHttpService(server, userProfileService);
+
+  HttpService *groupMgmtService =
+      makeGeneratedService("group management service",
+                           "/security-mgmt/groups/**");
+  groupMgmtService->paramSpecList =
+      makeIntParamSpec("count", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeIntParamSpec("traceLevel", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeStringParamSpec("dryRun", SERVICE_ARG_OPTIONAL, NULL
+      )));
+  groupMgmtService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  groupMgmtService->serviceFunction = &serveGroupManagement;
+  groupMgmtService->runInSubtask = TRUE;
+  groupMgmtService->doImpersonation = TRUE;
+  registerHttpService(server, groupMgmtService);
+
+  HttpService *accessService =
+      makeGeneratedService("access info service",
+                           "/security-mgmt/access/**");
+  accessService->paramSpecList =
+      makeIntParamSpec("count", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0,
+      makeIntParamSpec("traceLevel", SERVICE_ARG_OPTIONAL, 0, 0, 0, 0, NULL
+      ));
+  accessService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  accessService->serviceFunction = &serveAccessInfo;
+  accessService->runInSubtask = TRUE;
+  accessService->doImpersonation = TRUE;
+  registerHttpService(server, accessService);
+
+  zowelog(NULL, LOG_COMP_ID_SECURITY, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
+}
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+

--- a/c/zis/build.sh
+++ b/c/zis/build.sh
@@ -9,6 +9,7 @@
 COMMON=../../../zowe-common-c
 
 CFLAGS=(-S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX='"IDX"'
+-DRADMIN_XMEM_MODE
 -DCMS_LPA_DEV_MODE
 -qreserved_reg=r12
 -Wc,"arch(8),agg,exp,list(),so(),off,xref,roconst,longname,lp64" -I ../../h
@@ -32,6 +33,7 @@ $COMMON/c/mtlskt.c \
 $COMMON/c/nametoken.c \
 $COMMON/c/zos.c \
 $COMMON/c/qsam.c \
+$COMMON/c/radmin.c \
 $COMMON/c/recovery.c \
 $COMMON/c/resmgr.c \
 $COMMON/c/scheduling.c \
@@ -46,6 +48,7 @@ server.c \
 service.c \
 services/auth.c \
 services/nwm.c \
+services/secmgmt.c \
 services/snarfer.c
 
 as "${ASFLAGS[@]}" -aegimrsx=alloc.asm alloc.s
@@ -61,6 +64,7 @@ as "${ASFLAGS[@]}" -aegimrsx=mtlskt.asm mtlskt.s
 as "${ASFLAGS[@]}" -aegimrsx=nametoken.asm nametoken.s
 as "${ASFLAGS[@]}" -aegimrsx=zos.asm zos.s
 as "${ASFLAGS[@]}" -aegimrsx=qsam.asm qsam.s
+as "${ASFLAGS[@]}" -aegimrsx=radmin.asm radmin.s
 as "${ASFLAGS[@]}" -aegimrsx=recovery.asm recovery.s
 as "${ASFLAGS[@]}" -aegimrsx=resmgr.asm resmgr.s
 as "${ASFLAGS[@]}" -aegimrsx=scheduling.asm scheduling.s
@@ -77,6 +81,11 @@ as "${ASFLAGS[@]}" -aegimrsx=service.asm service.s
 
 as "${ASFLAGS[@]}" -aegimrsx=auth.asm auth.s
 as "${ASFLAGS[@]}" -aegimrsx=nwm.asm nwm.s
+as "${ASFLAGS[@]}" -aegimrsx=snarfer.asm snarfer.s
+
+as "${ASFLAGS[@]}" -aegimrsx=auth.asm auth.s
+as "${ASFLAGS[@]}" -aegimrsx=nwm.asm nwm.s
+as "${ASFLAGS[@]}" -aegimrsx=secmgmt.asm secmgmt.s
 as "${ASFLAGS[@]}" -aegimrsx=snarfer.asm snarfer.s
 
 export _LD_SYSLIB="//'SYS1.CSSLIB'://'CEE.SCEELKEX'://'CEE.SCEELKED'://'CEE.SCEERUN'://'CEE.SCEERUN2'://'CSF.SCSFMOD0'"
@@ -96,6 +105,7 @@ mtlskt.o \
 nametoken.o \
 zos.o \
 qsam.o \
+radmin.o \
 recovery.o \
 resmgr.o \
 scheduling.o \
@@ -110,6 +120,7 @@ server.o \
 service.o \
 auth.o \
 nwm.o \
+secmgmt.o \
 snarfer.o \
 > ZISSRV01.link
 

--- a/c/zis/client.c
+++ b/c/zis/client.c
@@ -226,6 +226,894 @@ int zisGetSAFAccessLevel(const CrossMemoryServerName *serverName,
   return authRC;
 }
 
+
+const char *ZIS_UPRFSRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_UPRFSRV_OK] = "Ok",
+  [RC_ZIS_UPRFSRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_UPRFSRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_UPRFSRV_USER_ID_TOO_LONG] = "User ID is too long",
+  [RC_ZIS_UPRFSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+  [RC_ZIS_UPRFSRV_PROFILE_COUNT_NULL] = "Profile count is null",
+  [RC_ZIS_UPRFSRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_UPRFSRV_INTERNAL_SERVICE_FAILED] = "R_admin service failed",
+  [RC_ZIS_UPRFSRV_ALLOC_FAILED] = "Alloc function failed",
+};
+
+const char *ZIS_UPRFSRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_UPRFSRV_USER_ID_TOO_LONG] = "User ID is too long",
+    [RC_ZIS_SRVC_UPRFSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+    [RC_ZIS_SRVC_UPRFSRV_PROFILE_COUNT_NULL] = "Profile count is null"
+};
+
+int zisExtractUserProfiles(const CrossMemoryServerName *serverName,
+                           const char *startProfile,
+                           unsigned int profilesToExtract,
+                           ZISUserProfileEntry *resultBuffer,
+                           unsigned int *profilesExtracted,
+                           ZISUserProfileServiceStatus *status,
+                           int traceLevel) {
+
+  ZISUserProfileServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_USERPROF_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+
+  if (startProfile != NULL) {
+    size_t profileLength = strlen(startProfile);
+    if (profileLength > ZIS_USER_ID_MAX_LENGTH) {
+      return RC_ZIS_SRVC_UPRFSRV_USER_ID_TOO_LONG;
+    }
+    parmList.startUserID.length = profileLength;
+    memcpy(parmList.startUserID.value, startProfile, profileLength);
+  }
+
+  parmList.profilesToExtract = profilesToExtract;
+
+  if (resultBuffer == NULL) {
+    return RC_ZIS_SRVC_UPRFSRV_RESULT_BUFF_NULL;
+  }
+  parmList.resultBuffer = resultBuffer;
+
+  parmList.traceLevel = traceLevel;
+
+  if (profilesExtracted == NULL) {
+    return RC_ZIS_SRVC_UPRFSRV_PROFILE_COUNT_NULL;
+  }
+
+  int serviceRC = RC_ZIS_UPRFSRV_OK;
+  int cmsCallRC = cmsCallService(
+      serverName,
+      ZIS_SERVICE_ID_USERPROF_SRV,
+      &parmList,
+      &serviceRC
+  );
+
+
+  if (cmsCallRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsCallRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  } else if (serviceRC != RC_ZIS_SNRFSRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  } else {
+    *profilesExtracted = parmList.profilesExtracted;
+  }
+
+  return RC_ZIS_SRVC_OK;
+}
+
+const char *ZIS_GRPRFSRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_GRPRFSRV_OK] = "Ok",
+  [RC_ZIS_GRPRFSRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_GRPRFSRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_GRPRFSRV_CLASS_TOO_LONG] = "Class is too long",
+  [RC_ZIS_GRPRFSRV_PROFILE_TOO_LONG] = "Profile is too long",
+  [RC_ZIS_GRPRFSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+  [RC_ZIS_GRPRFSRV_PROFILE_COUNT_NULL] = "Profile count is null",
+  [RC_ZIS_GRPRFSRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_GRPRFSRV_INTERNAL_SERVICE_FAILED] = "R_admin failed",
+  [RC_ZIS_GRPRFSRV_ALLOC_FAILED] = "Alloc function failed",
+  [RC_ZIS_GRPRFSRV_USER_CLASS_NOT_READ] = CMS_PROD_ID" class is not read"
+};
+
+const char *ZIS_GRPRFSRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_GRPRFSRV_CLASS_TOO_LONG] = "Class is too long",
+    [RC_ZIS_SRVC_GRPRFSRV_PROFILE_TOO_LONG] = "Profile is too long",
+    [RC_ZIS_SRVC_GRPRFSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+    [RC_ZIS_SRVC_GRPRFSRV_PROFILE_COUNT_NULL] = "Profile count is null"
+};
+
+int zisExtractGenresProfiles(const CrossMemoryServerName *serverName,
+                             const char *class,
+                             const char *startProfile,
+                             unsigned int profilesToExtract,
+                             ZISGenresProfileEntry *resultBuffer,
+                             unsigned int *profilesExtracted,
+                             ZISGenresProfileServiceStatus *status,
+                             int traceLevel) {
+
+  ZISGenresProfileServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_GRESPROF_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+
+  if (class != NULL) {
+    size_t classLength = strlen(class);
+    if (classLength > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+      return RC_ZIS_SRVC_GRPRFSRV_CLASS_TOO_LONG;
+    }
+    parmList.class.length = classLength;
+    memcpy(parmList.class.value, class, classLength);
+  }
+
+  if (startProfile != NULL) {
+    size_t profileLength = strlen(startProfile);
+    if (profileLength > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+      return RC_ZIS_SRVC_GRPRFSRV_PROFILE_TOO_LONG;
+    }
+    parmList.startProfile.length = profileLength;
+    memcpy(parmList.startProfile.value, startProfile, profileLength);
+  }
+
+  parmList.profilesToExtract = profilesToExtract;
+
+  if (resultBuffer == NULL) {
+    return RC_ZIS_SRVC_GRPRFSRV_RESULT_BUFF_NULL;
+  }
+  parmList.resultBuffer = resultBuffer;
+
+  parmList.traceLevel = traceLevel;
+
+  if (profilesExtracted == NULL) {
+    return RC_ZIS_SRVC_GRPRFSRV_PROFILE_COUNT_NULL;
+  }
+
+  int serviceRC = RC_ZIS_UPRFSRV_OK;
+  int cmsCallRC = cmsCallService(
+      serverName,
+      ZIS_SERVICE_ID_GRESPROF_SRV,
+      &parmList,
+      &serviceRC
+  );
+
+  if (cmsCallRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsCallRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  } else if (serviceRC != RC_ZIS_SNRFSRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  } else {
+    *profilesExtracted = parmList.profilesExtracted;
+  }
+
+  return RC_ZIS_SRVC_OK;
+
+}
+
+const char *ZIS_ACSLSRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_ACSLSRV_OK] = "Ok",
+  [RC_ZIS_ACSLSRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_ACSLSRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_ACSLSRV_CLASS_TOO_LONG] = "Class is too long",
+  [RC_ZIS_ACSLSRV_PROFILE_TOO_LONG] = "Profile is too long",
+  [RC_ZIS_ACSLSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+  [RC_ZIS_ACSLSRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_ACSLSRV_ALLOC_FAILED] = "Alloc function failed",
+  [RC_ZIS_ACSLSRV_INTERNAL_SERVICE_FAILED] = "R_admin failed",
+  [RC_ZIS_ACSLSRV_INSUFFICIENT_SPACE] = "Provided buffer is too small",
+  [RC_ZIS_ACSLSRV_USER_CLASS_NOT_READ] = CMS_PROD_ID" class is not read"
+};
+
+const char *ZIS_ACSLSRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_ACSLSRV_CLASS_TOO_LONG] = "Class is too long",
+    [RC_ZIS_SRVC_ACSLSRV_PROFILE_NULL] = "Profile is null",
+    [RC_ZIS_SRVC_ACSLSRV_PROFILE_TOO_LONG] = "Profile is too long",
+    [RC_ZIS_SRVC_ACSLSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+    [RC_ZIS_SRVC_ACSLSRV_ENTRY_COUNT_NULL] = "Entry count is null",
+    [RC_ZIS_SRVC_ACSLSRV_INSUFFICIENT_BUFFER] = "Provided buffer is too small"
+};
+
+int zisExtractGenresAccessList(const CrossMemoryServerName *serverName,
+                               const char *class,
+                               const char *profile,
+                               ZISGenresAccessEntry *resultBuffer,
+                               unsigned int resultBufferCapacity,
+                               unsigned int *entriesExtracted,
+                               ZISGenresAccessListServiceStatus *status,
+                               int traceLevel) {
+
+  ZISGenresAccessListServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_ACSLIST_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+
+  if (class != NULL) {
+    size_t classLength = strlen(class);
+    if (classLength > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+      return RC_ZIS_SRVC_ACSLSRV_CLASS_TOO_LONG;
+    }
+    parmList.class.length = classLength;
+    memcpy(parmList.class.value, class, classLength);
+  }
+
+  if (profile == NULL) {
+    return RC_ZIS_SRVC_ACSLSRV_PROFILE_NULL;
+  }
+
+  size_t profileLength = strlen(profile);
+  if (profileLength > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+    return RC_ZIS_SRVC_ACSLSRV_PROFILE_TOO_LONG;
+  }
+  parmList.profile.length = profileLength;
+  memcpy(parmList.profile.value, profile, profileLength);
+
+  if (resultBuffer == NULL) {
+    return RC_ZIS_SRVC_ACSLSRV_RESULT_BUFF_NULL;
+  }
+  parmList.resultBuffer = resultBuffer;
+  parmList.resultBufferCapacity = resultBufferCapacity;
+
+  parmList.traceLevel = traceLevel;
+
+  if (entriesExtracted == NULL) {
+    return RC_ZIS_SRVC_ACSLSRV_ENTRY_COUNT_NULL;
+  }
+
+  int serviceRC = RC_ZIS_ACSLSRV_OK;
+  int cmsCallRC = cmsCallService(
+      serverName,
+      ZIS_SERVICE_ID_ACSLIST_SRV,
+      &parmList,
+      &serviceRC
+  );
+
+  if (cmsCallRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsCallRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  } else if (serviceRC == RC_ZIS_ACSLSRV_INSUFFICIENT_SPACE) {
+    *entriesExtracted = parmList.entriesFound;
+    return RC_ZIS_SRVC_ACSLSRV_INSUFFICIENT_BUFFER;
+  } else if (serviceRC != RC_ZIS_ACSLSRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  } else {
+    *entriesExtracted = parmList.entriesExtracted;
+  }
+
+  return RC_ZIS_SRVC_OK;
+}
+
+const char *ZIS_GSADMNSRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_GSADMNSRV_OK] = "Ok",
+  [RC_ZIS_GSADMNSRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_GSADMNSRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_GSADMNSRV_PROF_TOO_LONG] = "Profile is too long",
+  [RC_ZIS_GSADMNSRV_UNSUPPORTED_PRODUCT] = "Unsupported product",
+  [RC_ZIS_GSADMNSRV_USER_ID_NULL] = "User ID is null",
+  [RC_ZIS_GSADMNSRV_USER_ID_TOO_LONG] = "User ID is too long",
+  [RC_ZIS_GSADMNSRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_GSADMNSRV_BAD_FUNCTION] = "Bad function",
+  [RC_ZIS_GSADMNSRV_BAD_ACCESS_TYPE] = "Bad access type",
+  [RC_ZIS_GSADMNSRV_INTERNAL_SERVICE_FAILED] = "R_admin failed",
+  [RC_ZIS_GSADMNSRV_PARM_INTERNAL_ERROR] = "Parm list creation failed",
+  [RC_ZIS_GSADMNSRV_USER_CLASS_TOO_LONG] = CMS_PROD_ID" class is too long",
+  [RC_ZIS_GSADMNSRV_USER_CLASS_NOT_READ] = CMS_PROD_ID" class read failed",
+  [RC_ZIS_GSADMNSRV_AUTOREFRESH_NOT_READ] = "Auto refresh option read failed",
+  [RC_ZIS_GSADMNSRV_OWNER_TOO_LONG] = "Owner name is too long"
+};
+
+const char *ZIS_GSADMNSRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_PADMIN_USERID_NULL] = "User ID is null",
+    [RC_ZIS_SRVC_PADMIN_USERID_TOO_LONG] = "User ID is too long",
+    [RC_ZIS_SRVC_PADMIN_PROFILE_NULL] = "Profile is null",
+    [RC_ZIS_SRVC_PADMIN_PROFILE_TOO_LONG] = "Profile is too long",
+    [RC_ZIS_SRVC_PADMIN_OPER_CMD_NULL] = "Operator command is null"
+};
+
+
+static int handleProfileFunction(
+    ZISGenresAdminFunction function,
+    const CrossMemoryServerName *serverName,
+    const char *userID,
+    const char *profileName,
+    const char *owner,
+    ZISGenresAdminServiceAccessType accessType,
+    bool isDryRun,
+    ZISGenresAdminServiceMessage *operatorCommand,
+    ZISGenresAdminServiceStatus *status,
+    int traceLevel
+) {
+
+  if (status == NULL) {
+    return RC_ZIS_SRVC_STATUS_NULL;
+  }
+
+  size_t userIDLength = 0;
+  size_t profileLength = 0;
+  size_t ownerLength = 0;
+
+  if (userID == NULL) {
+    return RC_ZIS_SRVC_PADMIN_USERID_NULL;
+  }
+  userIDLength = strlen(userID);
+  if (userIDLength > ZIS_USER_ID_MAX_LENGTH) {
+    return RC_ZIS_SRVC_PADMIN_USERID_TOO_LONG;
+  }
+
+  if (profileName == NULL) {
+    return RC_ZIS_SRVC_PADMIN_PROFILE_NULL;
+  }
+  profileLength = strlen(profileName);
+  if (profileLength > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+    return RC_ZIS_SRVC_PADMIN_PROFILE_TOO_LONG;
+  }
+
+  if (owner != NULL) {
+    ownerLength = strlen(owner);
+    if (ownerLength > ZIS_USER_ID_MAX_LENGTH) {
+      return RC_ZIS_SRVC_PADMIN_OWNER_TOO_LONG;
+    }
+  }
+
+  if (isDryRun) {
+    if (operatorCommand == NULL) {
+      return RC_ZIS_SRVC_PADMIN_OPER_CMD_NULL;
+    }
+  }
+
+  ZISGenresAdminServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_GENRES_ADMIN_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+  parmList.flags = isDryRun ? ZIS_GENRES_ADMIN_FLAG_DRYRUN : 0x00;
+  parmList.function = function;
+  parmList.profile.length = profileLength;
+  memcpy(parmList.profile.value, profileName, profileLength);
+  parmList.owner.length = ownerLength;
+  memcpy(parmList.owner.value, owner, ownerLength);
+  parmList.user.length = userIDLength;
+  memcpy(parmList.user.value, userID, userIDLength);
+  parmList.accessType = accessType;
+  parmList.traceLevel = traceLevel;
+
+  int serviceRC = RC_ZIS_GSADMNSRV_OK;
+  int cmsRC = cmsCallService(serverName, ZIS_SERVICE_ID_GENRES_ADMIN_SRV,
+                             &parmList, &serviceRC);
+
+  if (cmsRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  }
+
+  if (serviceRC != RC_ZIS_GSADMNSRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    status->message = parmList.serviceMessage;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  }
+
+  if (isDryRun) {
+    *operatorCommand = parmList.operatorCommand;
+  }
+
+  return RC_ZIS_SRVC_OK;
+}
+
+int zisDefineProfile(const CrossMemoryServerName *serverName,
+                     const char *profileName,
+                     const char *owner,
+                     bool isDryRun,
+                     ZISGenresAdminServiceMessage *operatorCommand,
+                     ZISGenresAdminServiceStatus *status,
+                     int traceLevel) {
+
+  const char *dummyUserID = "";
+  ZISGenresAdminServiceAccessType dummyAccessType =
+      ZIS_GENRES_ADMIN_ACESS_TYPE_READ;
+
+  int handleRC = handleProfileFunction(
+      ZIS_GENRES_ADMIN_SRV_FC_DEFINE,
+      serverName,
+      dummyUserID,
+      profileName,
+      owner,
+      dummyAccessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+int zisDeleteProfile(const CrossMemoryServerName *serverName,
+                     const char *profileName,
+                     bool isDryRun,
+                     ZISGenresAdminServiceMessage *operatorCommand,
+                     ZISGenresAdminServiceStatus *status,
+                     int traceLevel) {
+
+  const char *dummyUserID = "";
+  const char *dummyOwner = "";
+  ZISGenresAdminServiceAccessType dummyAccessType =
+      ZIS_GENRES_ADMIN_ACESS_TYPE_READ;
+
+  int handleRC = handleProfileFunction(
+      ZIS_GENRES_ADMIN_SRV_FC_DELETE,
+      serverName,
+      dummyUserID,
+      profileName,
+      dummyOwner,
+      dummyAccessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+int zisGiveAccessToProfile(const CrossMemoryServerName *serverName,
+                           const char *userID,
+                           const char *profileName,
+                           ZISGenresAdminServiceAccessType accessType,
+                           bool isDryRun,
+                           ZISGenresAdminServiceMessage *operatorCommand,
+                           ZISGenresAdminServiceStatus *status,
+                           int traceLevel) {
+
+  const char *dummyOwner = "";
+
+  int handleRC = handleProfileFunction(
+      ZIS_GENRES_ADMIN_SRV_FC_GIVE_ACCESS,
+      serverName,
+      userID,
+      profileName,
+      dummyOwner,
+      accessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+int zisRevokeAccessToProfile(const CrossMemoryServerName *serverName,
+                            const char *userID,
+                            const char *profileName,
+                            bool isDryRun,
+                            ZISGenresAdminServiceMessage *operatorCommand,
+                            ZISGenresAdminServiceStatus *status,
+                            int traceLevel) {
+
+  const char *dummyOwner = "";
+  ZISGenresAdminServiceAccessType dummyAccessType =
+      ZIS_GENRES_ADMIN_ACESS_TYPE_READ;
+
+  int handleRC = handleProfileFunction(
+      ZIS_GENRES_ADMIN_SRV_FC_REVOKE_ACCESS,
+      serverName,
+      userID,
+      profileName,
+      dummyOwner,
+      dummyAccessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+const char *ZIS_GPPRFSRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_GPPRFSRV_OK] = "Ok",
+  [RC_ZIS_GPPRFSRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_GPPRFSRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_GPPRFSRV_GROUP_TOO_LONG] = "Group is too long",
+  [RC_ZIS_GPPRFSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+  [RC_ZIS_GPPRFSRV_PROFILE_COUNT_NULL] = "Profile count is null",
+  [RC_ZIS_GPPRFSRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_GPPRFSRV_INTERNAL_SERVICE_FAILED] = "R_admin failed",
+  [RC_ZIS_GPPRFSRV_ALLOC_FAILED] = "Alloc function failed"
+};
+
+const char *ZIS_GPPRFSRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_GPPRFSRV_CLASS_TOO_LONG] = "Class is too long",
+    [RC_ZIS_SRVC_GPPRFSRV_GROUP_TOO_LONG] = "Group is too long",
+    [RC_ZIS_SRVC_GPPRFSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+    [RC_ZIS_SRVC_GPPRFSRV_PROFILE_COUNT_NULL] = "Profile count is null"
+};
+
+int zisExtractGroupProfiles(const CrossMemoryServerName *serverName,
+                            const char *startGroup,
+                            unsigned int profilesToExtract,
+                            ZISGroupProfileEntry *resultBuffer,
+                            unsigned int *profilesExtracted,
+                            ZISGroupProfileServiceStatus *status,
+                            int traceLevel) {
+
+  ZISGroupProfileServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_GRPPROF_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+
+  if (startGroup != NULL) {
+    size_t profileLength = strlen(startGroup);
+    if (profileLength > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+      return RC_ZIS_SRVC_GPPRFSRV_GROUP_TOO_LONG;
+    }
+    parmList.startGroup.length = profileLength;
+    memcpy(parmList.startGroup.value, startGroup, profileLength);
+  }
+
+  parmList.profilesToExtract = profilesToExtract;
+
+  if (resultBuffer == NULL) {
+    return RC_ZIS_SRVC_GPPRFSRV_RESULT_BUFF_NULL;
+  }
+  parmList.resultBuffer = resultBuffer;
+
+  parmList.traceLevel = traceLevel;
+
+  if (profilesExtracted == NULL) {
+    return RC_ZIS_SRVC_GPPRFSRV_PROFILE_COUNT_NULL;
+  }
+
+  int serviceRC = RC_ZIS_UPRFSRV_OK;
+  int cmsCallRC = cmsCallService(
+      serverName,
+      ZIS_SERVICE_ID_GRPPROF_SRV,
+      &parmList,
+      &serviceRC
+  );
+
+  if (cmsCallRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsCallRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  } else if (serviceRC != RC_ZIS_SNRFSRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  } else {
+    *profilesExtracted = parmList.profilesExtracted;
+  }
+
+  return RC_ZIS_SRVC_OK;
+
+}
+
+const char *ZIS_GRPALSRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_GRPALSRV_OK] = "Ok",
+  [RC_ZIS_GRPALSRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_GRPALSRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_GRPALSRV_GROUP_TOO_LONG] = "Group is too long",
+  [RC_ZIS_GRPALSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+  [RC_ZIS_GRPALSRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_GRPALSRV_ALLOC_FAILED] = "Alloc function failed",
+  [RC_ZIS_GRPALSRV_INTERNAL_SERVICE_FAILED] = "R_admin failed",
+  [RC_ZIS_GRPALSRV_INSUFFICIENT_SPACE] = "Provided buffer is too small"
+};
+
+const char *ZIS_GRPALSRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_GRPALSRV_GROUP_NULL] = "Group is null",
+    [RC_ZIS_SRVC_GRPALSRV_GROUP_TOO_LONG] = "Group is too long",
+    [RC_ZIS_SRVC_GRPALSRV_RESULT_BUFF_NULL] = "Result buffer is null",
+    [RC_ZIS_SRVC_GRPALSRV_ENTRY_COUNT_NULL] = "Entry count is null",
+    [RC_ZIS_SRVC_GRPALSRV_INSUFFICIENT_BUFFER] = "Provided buffer is too small"
+};
+
+int zisExtractGroupAccessList(const CrossMemoryServerName *serverName,
+                              const char *group,
+                              ZISGroupAccessEntry *resultBuffer,
+                              unsigned int resultBufferCapacity,
+                              unsigned int *entriesExtracted,
+                              ZISGroupAccessListServiceStatus *status,
+                              int traceLevel) {
+
+  ZISGroupAccessListServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_GRPALST_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+
+  if (group == NULL) {
+    return RC_ZIS_SRVC_GRPALSRV_GROUP_NULL;
+  }
+
+  size_t profileLength = strlen(group);
+  if (profileLength > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_SRVC_GRPALSRV_GROUP_TOO_LONG;
+  }
+  parmList.group.length = profileLength;
+  memcpy(parmList.group.value, group, profileLength);
+
+  if (resultBuffer == NULL) {
+    return RC_ZIS_SRVC_GRPALSRV_RESULT_BUFF_NULL;
+  }
+  parmList.resultBuffer = resultBuffer;
+  parmList.resultBufferCapacity = resultBufferCapacity;
+
+  parmList.traceLevel = traceLevel;
+
+  if (entriesExtracted == NULL) {
+    return RC_ZIS_SRVC_GRPALSRV_ENTRY_COUNT_NULL;
+  }
+
+  int serviceRC = RC_ZIS_GRPALSRV_OK;
+  int cmsCallRC = cmsCallService(
+      serverName,
+      ZIS_SERVICE_ID_GRPALIST_SRV,
+      &parmList,
+      &serviceRC
+  );
+
+  if (cmsCallRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsCallRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  } else if (serviceRC == RC_ZIS_GRPALSRV_INSUFFICIENT_SPACE) {
+    *entriesExtracted = parmList.entriesFound;
+    return RC_ZIS_SRVC_GRPALSRV_INSUFFICIENT_BUFFER;
+  } else if (serviceRC != RC_ZIS_GRPALSRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  } else {
+    *entriesExtracted = parmList.entriesExtracted;
+  }
+
+  return RC_ZIS_SRVC_OK;
+}
+
+const char *ZIS_GRPASRV_SERVICE_RC_DESCRIPTION[] = {
+  [RC_ZIS_GRPASRV_OK] = "Ok",
+  [RC_ZIS_GRPASRV_PARMLIST_NULL] = "Parm list is null",
+  [RC_ZIS_GRPASRV_BAD_EYECATCHER] = "Bad eyecatcher",
+  [RC_ZIS_GRPASRV_GROUP_TOO_LONG] = "Group is too long",
+  [RC_ZIS_GRPASRV_SUPGROUP_TOO_LONG] = "Superior group is too long",
+  [RC_ZIS_GRPASRV_UNSUPPORTED_PRODUCT] = "Unsupported product",
+  [RC_ZIS_GRPASRV_USER_ID_TOO_LONG] = "User ID is too long",
+  [RC_ZIS_GRPASRV_IMPERSONATION_MISSING] = "Impersonation is required",
+  [RC_ZIS_GRPASRV_BAD_FUNCTION] = "Bad function",
+  [RC_ZIS_GRPASRV_BAD_ACCESS_TYPE] = "Bad access type",
+  [RC_ZIS_GRPASRV_INTERNAL_SERVICE_FAILED] = "R_admin failed",
+  [RC_ZIS_GRPASRV_PARM_INTERNAL_ERROR] = "Parm list creation failed",
+  [RC_ZIS_GRPASRV_USER_CLASS_TOO_LONG] = CMS_PROD_ID" class is too long",
+  [RC_ZIS_GRPASRV_USER_CLASS_NOT_READ] = CMS_PROD_ID" class read failed",
+  [RC_ZIS_GRPASRV_AUTOREFRESH_NOT_READ] = "Auto refresh option read failed"
+};
+
+const char *ZIS_GRPASRV_WRAPPER_RC_DESCRIPTION[] = {
+    [RC_ZIS_SRVC_GADMIN_GROUP_NULL] = "Group is null",
+    [RC_ZIS_SRVC_GADMIN_GROUP_TOO_LONG] = "Group is too long",
+    [RC_ZIS_SRVC_GADMIN_SUPGROUP_NULL] = "Superior group is null",
+    [RC_ZIS_SRVC_GADMIN_SUPGROUP_TOO_LONG] = "Superior group is too long",
+    [RC_ZIS_SRVC_GADMIN_SUPGROUP_NULL] = "Superior group is null",
+    [RC_ZIS_SRVC_GADMIN_SUPGROUP_TOO_LONG] = "Superior group is too long",
+    [RC_ZIS_SRVC_GADMIN_OPER_CMD_NULL] = "Operator command is null"
+};
+
+static int handleGroupAdminFunction(
+    ZISGroupAdminFunction function,
+    const CrossMemoryServerName *serverName,
+    const char *group,
+    const char *superiorGroup,
+    const char *userID,
+    ZISGroupAdminServiceAccessType accessType,
+    bool isDryRun,
+    ZISGroupAdminServiceMessage *operatorCommand,
+    ZISGroupAdminServiceStatus *status,
+    int traceLevel
+) {
+
+  if (status == NULL) {
+    return RC_ZIS_SRVC_STATUS_NULL;
+  }
+
+  size_t groupLength = 0;
+  size_t superiorGroupLength = 0;
+  size_t userIDLength = 0;
+
+  if (group == NULL) {
+    return RC_ZIS_SRVC_GADMIN_GROUP_NULL;
+  }
+  groupLength = strlen(group);
+  if (groupLength > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_SRVC_GADMIN_GROUP_TOO_LONG;
+  }
+
+  if (superiorGroup == NULL) {
+    return RC_ZIS_SRVC_GADMIN_GROUP_NULL;
+  }
+  superiorGroupLength = strlen(superiorGroup);
+  if (superiorGroupLength > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_SRVC_GADMIN_SUPGROUP_TOO_LONG;
+  }
+
+  if (userID == NULL) {
+    return RC_ZIS_SRVC_GADMIN_USERID_NULL;
+  }
+  userIDLength = strlen(userID);
+  if (userIDLength > ZIS_USER_ID_MAX_LENGTH) {
+    return RC_ZIS_SRVC_GADMIN_USERID_TOO_LONG;
+  }
+
+  if (isDryRun) {
+    if (operatorCommand == NULL) {
+      return RC_ZIS_SRVC_GADMIN_OPER_CMD_NULL;
+    }
+  }
+
+  ZISGroupAdminServiceParmList parmList = {0};
+
+  memcpy(parmList.eyecatcher, ZIS_GROUP_ADMIN_SERVICE_PARMLIST_EYECATCHER,
+         sizeof(parmList.eyecatcher));
+  parmList.flags = isDryRun ? ZIS_GROUP_ADMIN_FLAG_DRYRUN : 0x00;
+  parmList.function = function;
+  parmList.group.length = groupLength;
+  memcpy(parmList.group.value, group, groupLength);
+  parmList.superiorGroup.length = superiorGroupLength;
+  memcpy(parmList.superiorGroup.value, superiorGroup, superiorGroupLength);
+  parmList.user.length = userIDLength;
+  memcpy(parmList.user.value, userID, userIDLength);
+  parmList.accessType = accessType;
+  parmList.traceLevel = traceLevel;
+
+  int serviceRC = RC_ZIS_GRPASRV_OK;
+  int cmsRC = cmsCallService(serverName, ZIS_SERVICE_ID_GROUP_ADMIN_SRV,
+                             &parmList, &serviceRC);
+
+  if (cmsRC != RC_CMS_OK) {
+    status->baseStatus.cmsRC = cmsRC;
+    return RC_ZIS_SRVC_CMS_FAILED;
+  }
+
+  if (serviceRC != RC_ZIS_GRPASRV_OK) {
+    status->baseStatus.serviceRC = serviceRC;
+    status->internalServiceRC = parmList.internalServiceRC;
+    status->internalServiceRSN = parmList.internalServiceRSN;
+    status->safStatus = parmList.safStatus;
+    status->message = parmList.serviceMessage;
+    return RC_ZIS_SRVC_SERVICE_FAILED;
+  }
+
+  if (isDryRun) {
+    *operatorCommand = parmList.operatorCommand;
+  }
+
+  return RC_ZIS_SRVC_OK;
+}
+
+int zisAddGroup(const CrossMemoryServerName *serverName,
+                const char *groupName,
+                const char *superiorGroupName,
+                bool isDryRun,
+                ZISGroupAdminServiceMessage *operatorCommand,
+                ZISGroupAdminServiceStatus *status,
+                int traceLevel) {
+
+  const char *dummyUserID = "";
+  ZISGroupAdminServiceAccessType dummyAccessType =
+      ZIS_GROUP_ADMIN_ACESS_TYPE_UNKNOWN;
+
+  int handleRC = handleGroupAdminFunction(
+      ZIS_GROUP_ADMIN_SRV_FC_ADD,
+      serverName,
+      groupName,
+      superiorGroupName,
+      dummyUserID,
+      dummyAccessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+int zisDeleteGroup(const CrossMemoryServerName *serverName,
+                   const char *groupName,
+                   bool isDryRun,
+                   ZISGroupAdminServiceMessage *operatorCommand,
+                   ZISGroupAdminServiceStatus *status,
+                   int traceLevel) {
+
+  const char *dummySuperiorGroup = "";
+  const char *dummyUserID = "";
+  ZISGroupAdminServiceAccessType dummyAccessType =
+      ZIS_GROUP_ADMIN_ACESS_TYPE_UNKNOWN;
+
+  int handleRC = handleGroupAdminFunction(
+      ZIS_GROUP_ADMIN_SRV_FC_DELETE,
+      serverName,
+      groupName,
+      dummySuperiorGroup,
+      dummyUserID,
+      dummyAccessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+int zisConnectToGroup(const CrossMemoryServerName *serverName,
+                      const char *userID,
+                      const char *groupName,
+                      ZISGroupAdminServiceAccessType accessType,
+                      bool isDryRun,
+                      ZISGroupAdminServiceMessage *operatorCommand,
+                      ZISGroupAdminServiceStatus *status,
+                      int traceLevel) {
+
+  const char *dummySuperiorGroup = "";
+
+  int handleRC = handleGroupAdminFunction(
+      ZIS_GROUP_ADMIN_SRV_FC_CONNECT_USER,
+      serverName,
+      groupName,
+      dummySuperiorGroup,
+      userID,
+      accessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+int zisRemoveFromGroup(const CrossMemoryServerName *serverName,
+                       const char *userID,
+                       const char *groupName,
+                       bool isDryRun,
+                       ZISGroupAdminServiceMessage *operatorCommand,
+                       ZISGroupAdminServiceStatus *status,
+                       int traceLevel) {
+
+  const char *dummySuperiorGroup = "";
+  ZISGroupAdminServiceAccessType dummyAccessType =
+      ZIS_GROUP_ADMIN_ACESS_TYPE_UNKNOWN;
+
+  int handleRC = handleGroupAdminFunction(
+      ZIS_GROUP_ADMIN_SRV_FC_REMOVE_USER,
+      serverName,
+      groupName,
+      dummySuperiorGroup,
+      userID,
+      dummyAccessType,
+      isDryRun,
+      operatorCommand,
+      status,
+      traceLevel
+  );
+
+  return handleRC;
+}
+
+
 int zisCallNWMService(const CrossMemoryServerName *serverName,
                       ZISNWMJobName jobName,
                       char *nmiBuffer,
@@ -366,4 +1254,3 @@ int zisCallVersionedService(const CrossMemoryServerName *serverName,
   
   Copyright Contributors to the Zowe Project.
 */
-

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -41,6 +41,7 @@
 
 #include "zis/services/auth.h"
 #include "zis/services/nwm.h"
+#include "zis/services/secmgmt.h"
 #include "zis/services/snarfer.h"
 
 /*
@@ -163,6 +164,55 @@ static int registerCoreServices(ZISContext *context) {
     return RC_ZIS_ERROR;
   }
 
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_USERPROF_SRV,
+                             zisUserProfilesServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GRESPROF_SRV,
+                             zisGenresProfilesServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_ACSLIST_SRV,
+                             zisGenresAccessListServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GENRES_ADMIN_SRV,
+                             zisGenresProfileAdminServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GRPPROF_SRV,
+                             zisGroupProfilesServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GRPALIST_SRV,
+                             zisGroupAccessListServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
+
+  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GROUP_ADMIN_SRV,
+                             zisGroupAdminServiceFunction, NULL,
+                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  if (regRC != RC_CMS_OK) {
+    return RC_ZIS_ERROR;
+  }
 
   regRC = registerZISServiceRouter(server);
   if (regRC != RC_CMS_OK) {

--- a/c/zis/services/secmgmt.c
+++ b/c/zis/services/secmgmt.c
@@ -1,0 +1,1852 @@
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#include <metal/metal.h>
+#include <metal/stddef.h>
+#include <metal/stdio.h>
+#include <metal/string.h>
+
+#ifndef METTLE
+#error Non-metal C code is not supported
+#endif
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "crossmemory.h"
+#include "radmin.h"
+#include "recovery.h"
+#include "zos.h"
+
+#include "zis/utils.h"
+#include "zis/services/secmgmt.h"
+
+#define ZIS_PARMLIB_PARM_SECMGMT_USER_CLASS   CMS_PROD_ID".SECMGMT.CLASS"
+#define ZIS_PARMLIB_PARM_SECMGMT_AUTORESFRESH CMS_PROD_ID".SECMGMT.AUTOREFRESH"
+
+static bool getCallerUserID(RadminUserID *caller) {
+
+  ACEE aceeData = {0};
+  ACEE *aceeAddress = NULL;
+  cmGetCallerTaskACEE(&aceeData, &aceeAddress);
+  if (aceeAddress == NULL) {
+    return false;
+  }
+
+  caller->length = aceeData.aceeuser[0];
+  memcpy(caller->value, &aceeData.aceeuser[1], sizeof(caller->value));
+
+  return true;
+}
+
+static int validateUserProfileParmList(ZISUserProfileServiceParmList *parm) {
+
+  if (memcmp(parm->eyecatcher, ZIS_USERPROF_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parm->eyecatcher))) {
+    return RC_ZIS_UPRFSRV_BAD_EYECATCHER;
+  }
+
+  if (parm->startUserID.length > ZIS_USER_ID_MAX_LENGTH) {
+    return RC_ZIS_UPRFSRV_USER_ID_TOO_LONG;
+  }
+
+  if (parm->resultBuffer == NULL) {
+    return RC_ZIS_UPRFSRV_RESULT_BUFF_NULL;
+  }
+
+  return RC_ZIS_UPRFSRV_OK;
+}
+
+static void copyUserProfiles(ZISUserProfileEntry *dest,
+                             const RadminBasicUserPofileInfo *src,
+                             unsigned int count) {
+
+  for (unsigned int i = 0; i < count; i++) {
+    cmCopyToSecondaryWithCallerKey(dest[i].userID, src[i].userID,
+                                   sizeof(dest[i].userID));
+    cmCopyToSecondaryWithCallerKey(dest[i].defaultGroup, src[i].defaultGroup,
+                                   sizeof(dest[i].defaultGroup));
+    cmCopyToSecondaryWithCallerKey(dest[i].name, src[i].name,
+                                   sizeof(dest[i].name));
+  }
+
+}
+
+
+int zisUserProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                   CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_UPRFSRV_OK;
+  int radminExtractRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_UPRFSRV_PARMLIST_NULL;
+  }
+
+  ZISUserProfileServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateUserProfileParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_UPRFSRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_UPRFSRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel, "UPRFSRV: userID = \'%.*s\', "
+               "profilesToExtract = %u, result buffer = 0x%p\n",
+               localParmList.startUserID.length,
+               localParmList.startUserID.value,
+               localParmList.profilesToExtract,
+               localParmList.resultBuffer);
+    CMS_DEBUG2(globalArea, traceLevel, "UPRFSRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    char userIDBuffer[ZIS_USER_ID_MAX_LENGTH + 1] = {0};
+    memcpy(userIDBuffer, localParmList.startUserID.value,
+           localParmList.startUserID.length);
+    const char *startUserIDNullTerm = localParmList.startUserID.length > 0 ?
+                                      userIDBuffer : NULL;
+
+    size_t tmpResultBufferSize =
+        sizeof(RadminBasicUserPofileInfo) * localParmList.profilesToExtract;
+    int allocRC = 0, allocSysRC = 0, allocSysRSN = 0;
+    RadminBasicUserPofileInfo *tmpResultBuffer =
+        (RadminBasicUserPofileInfo *)safeMalloc64v3(tmpResultBufferSize, TRUE,
+                                                    "RadminBasicUserPofileInfo",
+                                                    &allocRC,
+                                                    &allocSysRSN,
+                                                    &allocSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "UPRFSRV: tmpBuff allocated @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               allocRC, allocSysRC, allocSysRSN);
+
+    if (tmpResultBuffer == NULL) {
+      status = RC_ZIS_UPRFSRV_ALLOC_FAILED;
+      break;
+    }
+
+    RadminStatus radminStatus;
+    size_t profilesExtracted = 0;
+
+    radminExtractRC = radminExtractBasicUserProfileInfo(
+        authInfo,
+        startUserIDNullTerm,
+        localParmList.profilesToExtract,
+        tmpResultBuffer,
+        &profilesExtracted,
+        &radminStatus
+    );
+
+    if (radminExtractRC == RC_RADMIN_OK) {
+      copyUserProfiles(localParmList.resultBuffer, tmpResultBuffer,
+                       profilesExtracted);
+      localParmList.profilesExtracted = profilesExtracted;
+    } else  {
+      localParmList.internalServiceRC = radminExtractRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_UPRFSRV_INTERNAL_SERVICE_FAILED;
+    }
+
+    int freeRC = 0, freeSysRC = 0, freeSysRSN = 0;
+    freeRC = safeFree64v3(tmpResultBuffer, tmpResultBufferSize,
+                          &freeSysRC, &freeSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "UPRFSRV: tmpBuff free'd @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               freeRC, freeSysRC, freeSysRSN);
+
+    tmpResultBuffer = NULL;
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISUserProfileServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "UPRFSRV: status = %d, extracted = %d, RC = %d, "
+             "internal RC = %d, RSN = %d, "
+             "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             status,
+             localParmList.profilesExtracted, radminExtractRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+static int validateGenresProfileParmList(ZISGenresProfileServiceParmList *parm)
+{
+
+  if (memcmp(parm->eyecatcher, ZIS_GRESPROF_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parm->eyecatcher))) {
+    return RC_ZIS_GRPRFSRV_BAD_EYECATCHER;
+  }
+
+  if (parm->class.length > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+    return RC_ZIS_GRPRFSRV_CLASS_TOO_LONG;
+  }
+
+  if (parm->startProfile.length > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+    return RC_ZIS_GRPRFSRV_PROFILE_TOO_LONG;
+  }
+
+  if (parm->resultBuffer == NULL) {
+    return RC_ZIS_GRPRFSRV_RESULT_BUFF_NULL;
+  }
+
+  return RC_ZIS_GRPRFSRV_OK;
+}
+
+static void copyGenresProfiles(ZISGenresProfileEntry *dest,
+                               const RadminBasicGenresPofileInfo *src,
+                               unsigned int count) {
+
+  for (unsigned int i = 0; i < count; i++) {
+    cmCopyToSecondaryWithCallerKey(dest[i].profile, src[i].profile,
+                                   sizeof(dest[i].profile));
+    cmCopyToSecondaryWithCallerKey(dest[i].owner, src[i].owner,
+                                   sizeof(dest[i].owner));
+  }
+
+}
+
+
+int zisGenresProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                     CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_GRPRFSRV_OK;
+  int radminExtractRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_GRPRFSRV_PARMLIST_NULL;
+  }
+
+  ZISGenresProfileServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateGenresProfileParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_GRPRFSRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_GRPRFSRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPRFSRV: profile = \'%.*s\'\n",
+               localParmList.startProfile.length,
+               localParmList.startProfile.value);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPRFSRV: class = \'%.*s\', profilesToExtract = %u,"
+               " result buffer = 0x%p\n",
+               localParmList.class.length, localParmList.class.value,
+               localParmList.profilesToExtract,
+               localParmList.resultBuffer);
+    CMS_DEBUG2(globalArea, traceLevel, "GRPRFSRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    RadminStatus radminStatus;
+    char classNullTerm[ZIS_SECURITY_CLASS_MAX_LENGTH + 1] = {0};
+    memcpy(classNullTerm, localParmList.class.value,
+           localParmList.class.length);
+    char profileNameBuffer[ZIS_SECURITY_PROFILE_MAX_LENGTH + 1] = {0};
+    memcpy(profileNameBuffer, localParmList.startProfile.value,
+           localParmList.startProfile.length);
+    const char *startProfileNullTerm = localParmList.startProfile.length > 0 ?
+                                       profileNameBuffer : NULL;
+
+    if (localParmList.class.length == 0) {
+      CrossMemoryServerConfigParm userClassParm = {0};
+      int getParmRC = cmsGetConfigParm(&globalArea->serverName,
+                                       ZIS_PARMLIB_PARM_SECMGMT_USER_CLASS,
+                                       &userClassParm);
+      if (getParmRC != RC_CMS_OK) {
+        localParmList.internalServiceRC = getParmRC;
+        status = RC_ZIS_GRPRFSRV_USER_CLASS_NOT_READ;
+        break;
+      }
+      if (userClassParm.valueLength > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+        status = RC_ZIS_GRPRFSRV_CLASS_TOO_LONG;
+        break;
+      }
+      memcpy(classNullTerm, userClassParm.charValueNullTerm,
+             userClassParm.valueLength);
+    }
+
+    size_t tmpResultBufferSize =
+        sizeof(RadminBasicGenresPofileInfo) * localParmList.profilesToExtract;
+    int allocRC = 0, allocSysRC = 0, allocSysRSN = 0;
+    RadminBasicGenresPofileInfo *tmpResultBuffer =
+        (RadminBasicGenresPofileInfo *)safeMalloc64v3(
+            tmpResultBufferSize, TRUE,
+            "RadminBasicGenresPofileInfo",
+            &allocRC,
+            &allocSysRSN,
+            &allocSysRSN
+        );
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPRFSRV: tmpBuff allocated @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               allocRC, allocSysRC, allocSysRSN);
+
+    if (tmpResultBuffer == NULL) {
+      status = RC_ZIS_GRPRFSRV_ALLOC_FAILED;
+      break;
+    }
+
+    size_t profilesExtracted = 0;
+
+    radminExtractRC = radminExtractBasicGenresProfileInfo(
+        authInfo,
+        classNullTerm,
+        startProfileNullTerm,
+        localParmList.profilesToExtract,
+        tmpResultBuffer,
+        &profilesExtracted,
+        &radminStatus
+    );
+
+    if (radminExtractRC == RC_RADMIN_OK) {
+      copyGenresProfiles(localParmList.resultBuffer, tmpResultBuffer,
+                         profilesExtracted);
+      localParmList.profilesExtracted = profilesExtracted;
+    } else  {
+      localParmList.internalServiceRC = radminExtractRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_GRPRFSRV_INTERNAL_SERVICE_FAILED;
+    }
+
+    int freeRC = 0, freeSysRC = 0, freeSysRSN = 0;
+    freeRC = safeFree64v3(tmpResultBuffer, tmpResultBufferSize,
+                          &freeSysRC, &freeSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel, "GRPRFSRV: tmpBuff free'd @ 0x%p (%zu %d %d %d)\n",
+              tmpResultBuffer, tmpResultBufferSize,
+              freeRC, freeSysRC, freeSysRSN);
+
+    tmpResultBuffer = NULL;
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISGenresProfileServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GRPRFSRV: status = %d, extracted = %d, RC = %d, "
+             "internal RC = %d, RSN = %d, "
+              "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             status,
+             localParmList.profilesExtracted, radminExtractRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+static int
+validateGenresAccessListParmList(ZISGenresAccessListServiceParmList *parm) {
+
+  if (memcmp(parm->eyecatcher, ZIS_ACSLIST_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parm->eyecatcher))) {
+    return RC_ZIS_ACSLSRV_BAD_EYECATCHER;
+  }
+
+  if (parm->class.length > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+    return RC_ZIS_ACSLSRV_CLASS_TOO_LONG;
+  }
+
+  if (parm->profile.length > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+    return RC_ZIS_ACSLSRV_PROFILE_TOO_LONG;
+  }
+
+  if (parm->resultBuffer == NULL) {
+    return RC_ZIS_ACSLSRV_RESULT_BUFF_NULL;
+  }
+
+  return RC_ZIS_ACSLSRV_OK;
+}
+
+static void copyGenresAccessList(ZISGenresAccessEntry *dest,
+                                 const RadminAccessListEntry *src,
+                                 unsigned int count) {
+
+  for (unsigned int i = 0; i < count; i++) {
+    cmCopyToSecondaryWithCallerKey(dest[i].id, src[i].id,
+                                   sizeof(dest[i].id));
+    cmCopyToSecondaryWithCallerKey(dest[i].accessType, src[i].accessType,
+                                   sizeof(dest[i].accessType));
+  }
+
+}
+
+int zisGenresAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                       CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_ACSLSRV_OK;
+  int radminExtractRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_ACSLSRV_PARMLIST_NULL;
+  }
+
+  ZISGenresAccessListServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateGenresAccessListParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_ACSLSRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_ACSLSRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel,
+               "ACSLSRV: class = \'%.*s\', result buffer = 0x%p (%u)\n",
+               localParmList.class.length, localParmList.class.value,
+               localParmList.resultBuffer,
+               localParmList.resultBufferCapacity);
+    CMS_DEBUG2(globalArea, traceLevel, "ACSLSRV: profile = \'%.*s\'\n",
+               localParmList.profile.length, localParmList.profile.value);
+    CMS_DEBUG2(globalArea, traceLevel, "ACSLSRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    size_t entriesExtracted = 0;
+
+    RadminStatus radminStatus;
+    char classNullTerm[ZIS_SECURITY_CLASS_MAX_LENGTH + 1] = {0};
+    memcpy(classNullTerm, localParmList.class.value,
+           localParmList.class.length);
+    char profileNullTerm[ZIS_SECURITY_PROFILE_MAX_LENGTH + 1] = {0};
+    memcpy(profileNullTerm, localParmList.profile.value,
+           localParmList.profile.length);
+
+    if (localParmList.class.length == 0) {
+      CrossMemoryServerConfigParm userClassParm = {0};
+      int getParmRC = cmsGetConfigParm(&globalArea->serverName,
+                                       ZIS_PARMLIB_PARM_SECMGMT_USER_CLASS,
+                                       &userClassParm);
+      if (getParmRC != RC_CMS_OK) {
+        localParmList.internalServiceRC = getParmRC;
+        status = RC_ZIS_ACSLSRV_USER_CLASS_NOT_READ;
+        break;
+      }
+      if (userClassParm.valueLength > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+        status = RC_ZIS_ACSLSRV_CLASS_TOO_LONG;
+        break;
+      }
+      memcpy(classNullTerm, userClassParm.charValueNullTerm,
+             userClassParm.valueLength);
+    }
+
+    size_t tmpResultBufferSize =
+        sizeof(RadminAccessListEntry) * localParmList.resultBufferCapacity;
+    int allocRC = 0, allocSysRC = 0, allocSysRSN = 0;
+    RadminAccessListEntry *tmpResultBuffer =
+        (RadminAccessListEntry *)safeMalloc64v3(tmpResultBufferSize, TRUE,
+                                                "RadminAccessListEntry",
+                                                 &allocRC,
+                                                 &allocSysRC,
+                                                 &allocSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "ACSLSRV: tmpBuff allocated @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               allocRC, allocSysRC, allocSysRSN);
+
+    if (tmpResultBuffer == NULL) {
+      status = RC_ZIS_ACSLSRV_ALLOC_FAILED;
+      break;
+    }
+
+    int radminExtractRC = radminExtractGenresAccessList(
+        authInfo,
+        classNullTerm,
+        profileNullTerm,
+        tmpResultBuffer,
+        localParmList.resultBufferCapacity,
+        &entriesExtracted,
+        &radminStatus
+    );
+
+    if (radminExtractRC == RC_RADMIN_OK) {
+      copyGenresAccessList(localParmList.resultBuffer, tmpResultBuffer,
+                     entriesExtracted);
+      localParmList.entriesExtracted = entriesExtracted;
+      localParmList.entriesFound = entriesExtracted;
+    } else if (radminExtractRC == RC_RADMIN_INSUFF_SPACE) {
+      localParmList.entriesExtracted = 0;
+      localParmList.entriesFound = radminStatus.reasonCode;
+      status = RC_ZIS_ACSLSRV_INSUFFICIENT_SPACE;
+    } else  {
+      localParmList.internalServiceRC = radminExtractRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_ACSLSRV_INTERNAL_SERVICE_FAILED;
+    }
+
+    int freeRC = 0, freeSysRC = 0, freeSysRSN = 0;
+    freeRC = safeFree64v3(tmpResultBuffer, tmpResultBufferSize,
+                          &freeSysRC, &freeSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "ACSLSRV: tmpBuff free'd @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               freeRC, freeSysRC, freeSysRSN);
+
+    tmpResultBuffer = NULL;
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISGenresAccessListServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "ACSLSRV: entriesExtracted = %u, RC = %d, "
+             "internal RC = %d, RSN = %d, "
+             "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             localParmList.entriesExtracted, radminExtractRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+static int validateGenresParmList(ZISGenresAdminServiceParmList *parmList) {
+
+  if (memcmp(parmList->eyecatcher,
+             ZIS_GENRES_ADMIN_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parmList->eyecatcher) != 0)) {
+    return RC_ZIS_GSADMNSRV_BAD_EYECATCHER;
+  }
+
+  if (parmList->function < ZIS_GENRES_ADMIN_SRV_FC_MIN ||
+      ZIS_GENRES_ADMIN_SRV_FC_MAX < parmList->function) {
+    return RC_ZIS_GSADMNSRV_BAD_FUNCTION;
+  }
+
+  if (parmList->profile.length > ZIS_SECURITY_PROFILE_MAX_LENGTH) {
+    return RC_ZIS_GSADMNSRV_PROF_TOO_LONG;
+  }
+
+  if (parmList->owner.length > ZIS_USER_ID_MAX_LENGTH) {
+    return RC_ZIS_GSADMNSRV_OWNER_TOO_LONG;
+  }
+
+  const char *productName = parmList->profile.value;
+  bool isProductSupported = false;
+  int productCount =
+      sizeof(ZIS_GENRES_PRODUCTS) / sizeof(ZIS_GENRES_PRODUCTS[0]);
+  for (int i = 0; i < productCount; i++) {
+
+    const char *currProductName = ZIS_GENRES_PRODUCTS[i];
+    size_t currProductNameLength = strlen(currProductName);
+    if (currProductNameLength > parmList->profile.length) {
+      continue;
+    }
+
+    if (memcmp(productName, currProductName, currProductNameLength) == 0 &&
+        productName[currProductNameLength] == '.') {
+      isProductSupported = true;
+      break;
+    }
+  }
+
+  if (isProductSupported == false) {
+    return RC_ZIS_GSADMNSRV_UNSUPPORTED_PRODUCT;
+  }
+
+  if (parmList->user.length > ZIS_USER_ID_MAX_LENGTH) {
+    return RC_ZIS_GSADMNSRV_USER_ID_TOO_LONG;
+  }
+
+  if (parmList->function == ZIS_GENRES_ADMIN_SRV_FC_GIVE_ACCESS) {
+    if (parmList->accessType < ZIS_GENRES_ADMIN_ACESS_TYPE_MIN ||
+        ZIS_GENRES_ADMIN_ACESS_TYPE_MAX < parmList->accessType) {
+      return RC_ZIS_GSADMNSRV_BAD_ACCESS_TYPE;
+    }
+  }
+
+  return RC_ZIS_GSADMNSRV_OK;
+}
+
+static RadminResAction mapZISToRadminResAction(ZISGenresAdminFunction function)
+{
+  switch (function) {
+  case ZIS_GENRES_ADMIN_SRV_FC_DEFINE:
+    return RADMIN_RES_ACTION_ADD_GENRES;
+  case ZIS_GENRES_ADMIN_SRV_FC_DELETE:
+    return RADMIN_RES_ACTION_DELETE_GENRES;
+  case ZIS_GENRES_ADMIN_SRV_FC_GIVE_ACCESS:
+    return RADMIN_RES_ACTION_PERMIT;
+  case ZIS_GENRES_ADMIN_SRV_FC_REVOKE_ACCESS:
+    return RADMIN_RES_ACTION_PROHIBIT;
+  default:
+    return RADMIN_RES_ACTION_NA;
+  }
+}
+
+typedef struct GenresOutputHandlerData_tag {
+  char eyecatcher[8];
+#define GENRES_OUT_HADNLER_DATA_EYECATCHER  "RSGRONDA"
+  CrossMemoryServerGlobalArea *globalArea;
+  size_t fullMessageLenght;
+  size_t fullCommandLength;
+  ZISGenresAdminServiceMessage message;
+  ZISGenresAdminServiceMessage command;
+} GenresOutputHandlerData;
+
+#define RADMIN_OUT_MAX_NODE_COUNT 16
+
+#define RC_GET_MSG_HADNLER_OK     0
+#define RC_GET_MSG_HADNLER_LOOP   8
+
+static int getMsgAndOperatorCommand(RadminAPIStatus status,
+                                    const RadminCommandOutput *out,
+                                    void *userData) {
+
+  GenresOutputHandlerData *handlerData = userData;
+  ZISGenresAdminServiceMessage *message = &handlerData->message;
+  ZISGenresAdminServiceMessage *command = &handlerData->command;
+
+  bool messageCopied = false, commandCopied = false;
+
+  const RadminCommandOutput *nextOutput = out;
+  int nodeCount = 0;
+  while (nextOutput != NULL) {
+
+    if (commandCopied && messageCopied) {
+      break;
+    }
+    if (nodeCount > RADMIN_OUT_MAX_NODE_COUNT) {
+      return RC_GET_MSG_HADNLER_LOOP;
+    }
+
+    if (memcmp(nextOutput->eyecatcher, RADMIN_COMMAND_OUTPUT_EYECATCHER_CMD,
+               sizeof(nextOutput->eyecatcher)) == 0) {
+      unsigned int copySize =
+          min(nextOutput->firstMessageEntry.length, sizeof(command->text));
+      memcpy(command->text, nextOutput->firstMessageEntry.text, copySize);
+      command->length = copySize;
+      handlerData->fullCommandLength = nextOutput->firstMessageEntry.length;
+      commandCopied = true;
+    }
+
+    if (memcmp(nextOutput->eyecatcher, RADMIN_COMMAND_OUTPUT_EYECATCHER_MSG,
+               sizeof(nextOutput->eyecatcher)) == 0) {
+      unsigned int copySize =
+          min(nextOutput->firstMessageEntry.length, sizeof(message->text));
+      memcpy(message->text, nextOutput->firstMessageEntry.text, copySize);
+      message->length = copySize;
+      handlerData->fullMessageLenght = nextOutput->firstMessageEntry.length;
+      messageCopied = true;
+    }
+
+    nodeCount++;
+    nextOutput = nextOutput->next;
+  }
+
+  return RC_GET_MSG_HADNLER_OK;
+}
+
+static const char *getAccessString(ZISGenresAdminServiceAccessType type) {
+  switch (type) {
+  case ZIS_GENRES_ADMIN_ACESS_TYPE_READ:
+    return "READ";
+  case ZIS_GENRES_ADMIN_ACESS_TYPE_UPDATE:
+    return "UPDATE";
+  case ZIS_GENRES_ADMIN_ACESS_TYPE_ALTER:
+    return "ALTER";
+  default:
+    return NULL;
+  }
+}
+
+#define RES_PARMLIST_MIN_SIZE 1024
+
+static RadminResParmList *constructResAdminParmList(
+    char parmListBuffer[],
+    size_t bufferSize,
+    RadminResAction action,
+    bool isDryRun,
+    const char class[],
+    size_t classLength,
+    const char profile[],
+    size_t profileLength,
+    const char owner[],
+    size_t ownerLength,
+    const char userID[],
+    size_t userIDLength,
+    ZISGenresAdminServiceAccessType accessType
+) {
+
+  if (bufferSize < RES_PARMLIST_MIN_SIZE) {
+    return NULL;
+  }
+
+  memset(parmListBuffer, ' ', bufferSize);
+
+  RadminResParmList *parmList = (RadminResParmList *)parmListBuffer;
+
+  parmList->classNameLength = classLength;
+  memcpy(parmList->className, class, sizeof(parmList->className));
+  if (isDryRun) {
+    parmList->flags |= RADMIN_RES_FLAG_NORUN;
+    parmList->flags |= RADMIN_RES_FLAG_RETCMD;
+  }
+  parmList->segmentCount = 1;
+  RadminSegment *segment = parmList->segmentData;
+  memcpy(segment->name, "BASE    ", sizeof(segment->name));
+  segment->flag |= RADMIN_SEGMENT_FLAG_Y;
+  segment->fieldCount = 1;
+  RadminField *field1 = segment->firstField;
+  memcpy(field1->name, "PROFILE ", sizeof(field1->name));
+  field1->flag |= RADMIN_FIELD_FLAG_Y;
+  field1->dataLength = profileLength;
+  memcpy(field1->data, profile, field1->dataLength);
+
+  if (action == RADMIN_RES_ACTION_ADD_GENRES) {
+
+    segment->fieldCount++;
+    RadminField *field2 =
+        (RadminField *)((char *)(field1 + 1) + field1->dataLength);
+    memcpy(field2->name, "UACC    ", sizeof(field2->name));
+    field2->flag |= RADMIN_FIELD_FLAG_Y;
+    field2->dataLength = 4;
+    memcpy(field2->data, "NONE", field2->dataLength);
+
+    segment->fieldCount++;
+    RadminField *field3 =
+        (RadminField *)((char *)(field2 + 1) + field2->dataLength);
+    memcpy(field3->name, "OWNER   ", sizeof(field3->name));
+    field3->flag |= RADMIN_FIELD_FLAG_Y;
+    field3->dataLength = ownerLength;
+    memcpy(field3->data, owner, field3->dataLength);
+
+  }
+
+  if (action == RADMIN_RES_ACTION_PERMIT ||
+      action == RADMIN_RES_ACTION_PROHIBIT) {
+
+    segment->fieldCount++;
+    RadminField *field2 =
+        (RadminField *)((char *)(field1 + 1) + field1->dataLength);
+    memcpy(field2->name, "ID      ", sizeof(field2->name));
+    field2->flag |= RADMIN_FIELD_FLAG_Y;
+    field2->dataLength = userIDLength;
+    memcpy(field2->data, userID, field2->dataLength);
+
+    segment->fieldCount++;
+    RadminField *field3 =
+        (RadminField *)((char *)(field2 + 1) + field2->dataLength);
+
+    if (action == RADMIN_RES_ACTION_PERMIT) {
+      const char *accessString = getAccessString(accessType);
+      size_t accessStringLength = strlen(accessString);
+      memcpy(field3->name, "ACCESS  ", sizeof(field3->name));
+      field3->flag |= RADMIN_FIELD_FLAG_Y;
+      field3->dataLength = accessStringLength;
+      memcpy(field3->data, accessString, field3->dataLength);
+    } else {
+      memcpy(field3->name, "DELETE  ", sizeof(field3->name));
+      field3->flag |= RADMIN_FIELD_FLAG_Y;
+      field3->dataLength = 0;
+    }
+
+  }
+
+  return parmList;
+}
+
+static int performRefreshIfNeeded(CrossMemoryServerGlobalArea *globalArea,
+                                  RadminCallerAuthInfo authInfo,
+                                  const char *classNullTerm,
+                                  ZISGenresAdminServiceParmList *parmList,
+                                  int traceLevel
+) {
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GSADMNSRV: RACLIST REFRESH for class \'%s\'\n", classNullTerm);
+
+  CrossMemoryServerConfigParm refreshParm = {0};
+  int getParmRC = cmsGetConfigParm(&globalArea->serverName,
+                                   ZIS_PARMLIB_PARM_SECMGMT_AUTORESFRESH,
+                                   &refreshParm);
+  if (getParmRC != RC_CMS_OK) {
+    if (getParmRC != RC_CMS_CONFIG_PARM_NOT_FOUND) {
+      CMS_DEBUG2(globalArea, traceLevel,
+                 "GSADMNSRV: AUTORESFRESH read error, RC = %d\n", getParmRC);
+      parmList->internalServiceRC = getParmRC;
+      return RC_ZIS_GSADMNSRV_AUTOREFRESH_NOT_READ;
+    }
+    CMS_DEBUG2(globalArea, traceLevel, "GSADMNSRV: AUTORESFRESH not found\n");
+    return RC_ZIS_GSADMNSRV_OK;
+  }
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GSADMNSRV: AUTORESFRESH=\'%s\'\n", refreshParm.charValueNullTerm);
+
+  if (strcmp(refreshParm.charValueNullTerm, "YES") != 0) {
+    return RC_ZIS_GSADMNSRV_OK;
+  }
+
+  GenresOutputHandlerData handlerData = {
+      .eyecatcher = GENRES_OUT_HADNLER_DATA_EYECATCHER,
+      .globalArea = globalArea,
+      .fullMessageLenght = 0,
+      .fullCommandLength = 0
+  };
+
+  RadminStatus radminStatus = {0};
+
+  char refreshCommand[RADMIN_CMD_MAX_COMMAND_LENGTH + 1];
+  snprintf(refreshCommand, sizeof(refreshCommand),
+           "SETROPTS REFRESH RACLIST(%s)", classNullTerm);
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GSADMNSRV: executing \'%s\'\n", refreshCommand);
+
+  int refreshRC = radminRunRACFCommand(
+      authInfo,
+      refreshCommand,
+      getMsgAndOperatorCommand,
+      &handlerData,
+      &radminStatus
+  );
+
+  parmList->serviceMessage = handlerData.message;
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GSADMNSRV: refresh RC = %d, RSN = %d, "
+             "msgLen = %zu, cmdLen = %zu, "
+             "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             refreshRC, radminStatus.reasonCode,
+             handlerData.message.length, handlerData.command.length,
+             radminStatus.apiStatus.safRC,
+             radminStatus.apiStatus.racfRC,
+             radminStatus.apiStatus.racfRSN);
+
+  if (refreshRC != RC_RADMIN_OK) {
+    parmList->internalServiceRC = refreshRC;
+    parmList->internalServiceRSN = radminStatus.reasonCode;
+    parmList->safStatus.safRC = radminStatus.apiStatus.safRC;
+    parmList->safStatus.racfRC = radminStatus.apiStatus.racfRC;
+    parmList->safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+    return RC_ZIS_GSADMNSRV_INTERNAL_SERVICE_FAILED;
+  }
+
+  return RC_ZIS_GSADMNSRV_OK;
+}
+
+int zisGenresProfileAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                   CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_GSADMNSRV_OK;
+  int radminActionRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_GSADMNSRV_PARMLIST_NULL;
+  }
+
+  ZISGenresAdminServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateGenresParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_GSADMNSRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_GSADMNSRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    if (localParmList.owner.length == 0) {
+      memcpy(localParmList.owner.value, caller.value, sizeof(caller.value));
+      localParmList.owner.length = caller.length;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GSADMNSRV: flags = 0x%X, function = %d, "
+               "owner = \'%.*s\', user = \'%.*s\', access = %d'\n",
+               localParmList.flags,
+               localParmList.function,
+               localParmList.owner.length, localParmList.owner.value,
+               localParmList.user.length, localParmList.user.value,
+               localParmList.accessType);
+    CMS_DEBUG2(globalArea, traceLevel, "GSADMNSRV: profile = \'%.*s\'\n",
+               localParmList.profile.length, localParmList.profile.value);
+    CMS_DEBUG2(globalArea, traceLevel, "GSADMNSRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    CrossMemoryServerConfigParm userClassParm = {0};
+    int getParmRC = cmsGetConfigParm(&globalArea->serverName,
+                                     ZIS_PARMLIB_PARM_SECMGMT_USER_CLASS,
+                                     &userClassParm);
+    if (getParmRC != RC_CMS_OK) {
+      localParmList.internalServiceRC = getParmRC;
+      status = RC_ZIS_GSADMNSRV_USER_CLASS_NOT_READ;
+      break;
+    }
+    if (userClassParm.valueLength > ZIS_SECURITY_CLASS_MAX_LENGTH) {
+      status = RC_ZIS_GSADMNSRV_USER_CLASS_TOO_LONG;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel, "GSADMNSRV: class = \'%.*s\'\n",
+               userClassParm.valueLength, userClassParm.charValueNullTerm);
+
+    RadminResAction action = mapZISToRadminResAction(localParmList.function);
+    if (action == RADMIN_RES_ACTION_NA) {
+      status = RC_ZIS_GSADMNSRV_BAD_FUNCTION;
+      break;
+    }
+
+    bool isDryRun = (localParmList.flags & ZIS_GENRES_ADMIN_FLAG_DRYRUN) ?
+                    true : false;
+    char parmListBuffer[2048];
+    RadminResParmList *parmList = constructResAdminParmList(
+        parmListBuffer,
+        sizeof(parmListBuffer),
+        action, isDryRun,
+        userClassParm.charValueNullTerm,
+        userClassParm.valueLength,
+        localParmList.profile.value,
+        localParmList.profile.length,
+        localParmList.owner.value,
+        localParmList.owner.length,
+        localParmList.user.value,
+        localParmList.user.length,
+        localParmList.accessType
+    );
+
+    if (parmList == NULL) {
+      status = RC_ZIS_GSADMNSRV_PARM_INTERNAL_ERROR;
+      break;
+    }
+
+    GenresOutputHandlerData handlerData = {
+        .eyecatcher = GENRES_OUT_HADNLER_DATA_EYECATCHER,
+        .globalArea = globalArea,
+        .fullMessageLenght = 0,
+        .fullCommandLength = 0
+    };
+
+    RadminStatus radminStatus;
+
+    radminActionRC = radminPerformResAction(
+        authInfo,
+        action,
+        parmList,
+        getMsgAndOperatorCommand,
+        &handlerData,
+        &radminStatus
+    );
+
+    localParmList.serviceMessage = handlerData.message;
+    localParmList.operatorCommand = handlerData.command;
+
+    if (radminActionRC != RC_RADMIN_OK) {
+      localParmList.internalServiceRC = radminActionRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_GSADMNSRV_INTERNAL_SERVICE_FAILED;
+      break;
+    }
+
+    if (isDryRun == false) {
+      status = performRefreshIfNeeded(globalArea,
+                                      authInfo,
+                                      userClassParm.charValueNullTerm,
+                                      &localParmList,
+                                      traceLevel);
+    }
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISGenresAdminServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GSADMNSRV: status = %d, msgLen = %zu, cmdLen = %zu, "
+             "RC = %d, internal RC = %d, RSN = %d, "
+             "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             status,
+             localParmList.serviceMessage.length,
+             localParmList.operatorCommand.length,
+             radminActionRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+static int validateGroupProfileParmList(ZISGroupProfileServiceParmList *parm)
+{
+
+  if (memcmp(parm->eyecatcher, ZIS_GRPPROF_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parm->eyecatcher))) {
+    return RC_ZIS_GPPRFSRV_BAD_EYECATCHER;
+  }
+
+  if (parm->startGroup.length > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_GPPRFSRV_GROUP_TOO_LONG;
+  }
+
+  if (parm->resultBuffer == NULL) {
+    return RC_ZIS_GPPRFSRV_RESULT_BUFF_NULL;
+  }
+
+  return RC_ZIS_GPPRFSRV_OK;
+}
+
+static void copyGroupProfiles(ZISGroupProfileEntry *dest,
+                              const RadminBasicGroupPofileInfo *src,
+                              unsigned int count) {
+
+  for (unsigned int i = 0; i < count; i++) {
+    cmCopyToSecondaryWithCallerKey(dest[i].group, src[i].group,
+                                   sizeof(dest[i].group));
+    cmCopyToSecondaryWithCallerKey(dest[i].owner, src[i].owner,
+                                   sizeof(dest[i].owner));
+    cmCopyToSecondaryWithCallerKey(dest[i].superiorGroup, src[i].superiorGroup,
+                                   sizeof(dest[i].superiorGroup));
+  }
+
+}
+
+int zisGroupProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                    CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_GPPRFSRV_OK;
+  int radminExtractRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_GPPRFSRV_PARMLIST_NULL;
+  }
+
+  ZISGroupProfileServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateGroupProfileParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_GPPRFSRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_GPPRFSRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GPPRFSRV: group = \'%.*s\', profilesToExtract = %u,"
+               " result buffer = 0x%p\n",
+               localParmList.startGroup.length,
+               localParmList.startGroup.value,
+               localParmList.profilesToExtract,
+               localParmList.resultBuffer);
+    CMS_DEBUG2(globalArea, traceLevel, "GPPRFSRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    RadminStatus radminStatus;
+    char groupNameBuffer[ZIS_SECURITY_GROUP_MAX_LENGTH + 1] = {0};
+    memcpy(groupNameBuffer, localParmList.startGroup.value,
+           localParmList.startGroup.length);
+    const char *startProfileNullTerm = localParmList.startGroup.length > 0 ?
+                                       groupNameBuffer : NULL;
+
+    size_t tmpResultBufferSize =
+        sizeof(RadminBasicGroupPofileInfo) * localParmList.profilesToExtract;
+    int allocRC = 0, allocSysRC = 0, allocSysRSN = 0;
+    RadminBasicGroupPofileInfo *tmpResultBuffer =
+        (RadminBasicGroupPofileInfo *)safeMalloc64v3(
+            tmpResultBufferSize, TRUE,
+            "RadminBasicGroupPofileInfo",
+            &allocRC,
+            &allocSysRSN,
+            &allocSysRSN
+        );
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GPPRFSRV: tmpBuff allocated @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               allocRC, allocSysRC, allocSysRSN);
+
+    if (tmpResultBuffer == NULL) {
+      status = RC_ZIS_GPPRFSRV_ALLOC_FAILED;
+      break;
+    }
+
+    size_t profilesExtracted = 0;
+
+    radminExtractRC = radminExtractBasicGroupProfileInfo(
+        authInfo,
+        startProfileNullTerm,
+        localParmList.profilesToExtract,
+        tmpResultBuffer,
+        &profilesExtracted,
+        &radminStatus
+    );
+
+    if (radminExtractRC == RC_RADMIN_OK) {
+      copyGroupProfiles(localParmList.resultBuffer, tmpResultBuffer,
+                        profilesExtracted);
+      localParmList.profilesExtracted = profilesExtracted;
+    } else  {
+      localParmList.internalServiceRC = radminExtractRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_GPPRFSRV_INTERNAL_SERVICE_FAILED;
+    }
+
+    int freeRC = 0, freeSysRC = 0, freeSysRSN = 0;
+    freeRC = safeFree64v3(tmpResultBuffer, tmpResultBufferSize,
+                          &freeSysRC, &freeSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GPPRFSRV: tmpBuff free'd @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               freeRC, freeSysRC, freeSysRSN);
+
+    tmpResultBuffer = NULL;
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISGroupProfileServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GPPRFSRV: status = %d, extracted = %d, RC = %d, "
+             "internal RC = %d, RSN = %d, "
+              "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             status,
+             localParmList.profilesExtracted, radminExtractRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+static int
+validateGroupAccessListParmList(ZISGroupAccessListServiceParmList *parm) {
+
+  if (memcmp(parm->eyecatcher, ZIS_GRPALST_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parm->eyecatcher))) {
+    return RC_ZIS_GRPALSRV_BAD_EYECATCHER;
+  }
+
+  if (parm->group.length > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_GRPALSRV_GROUP_TOO_LONG;
+  }
+
+  if (parm->resultBuffer == NULL) {
+    return RC_ZIS_GRPALSRV_RESULT_BUFF_NULL;
+  }
+
+  return RC_ZIS_GRPALSRV_OK;
+}
+
+static void copyGroupAccessList(ZISGroupAccessEntry *dest,
+                                const RadminAccessListEntry *src,
+                                unsigned int count) {
+
+  for (unsigned int i = 0; i < count; i++) {
+    cmCopyToSecondaryWithCallerKey(dest[i].id, src[i].id,
+                                   sizeof(dest[i].id));
+    cmCopyToSecondaryWithCallerKey(dest[i].accessType, src[i].accessType,
+                                   sizeof(dest[i].accessType));
+  }
+
+}
+
+int zisGroupAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                      CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_GRPALSRV_OK;
+  int radminExtractRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_GRPALSRV_PARMLIST_NULL;
+  }
+
+  ZISGroupAccessListServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateGroupAccessListParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_GRPALSRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_GRPALSRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPALSRV: group = \'%.*s\', result buffer = 0x%p (%u)\n",
+               localParmList.group.length, localParmList.group.value,
+               localParmList.resultBuffer,
+               localParmList.resultBufferCapacity);
+    CMS_DEBUG2(globalArea, traceLevel, "GRPALSRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    size_t entriesExtracted = 0;
+
+    RadminStatus radminStatus;
+    char groupNameNullTerm[ZIS_SECURITY_GROUP_MAX_LENGTH + 1] = {0};
+    memcpy(groupNameNullTerm, localParmList.group.value,
+           localParmList.group.length);
+
+    size_t tmpResultBufferSize =
+        sizeof(RadminAccessListEntry) * localParmList.resultBufferCapacity;
+    int allocRC = 0, allocSysRC = 0, allocSysRSN = 0;
+    RadminAccessListEntry *tmpResultBuffer =
+        (RadminAccessListEntry *)safeMalloc64v3(tmpResultBufferSize, TRUE,
+                                                "RadminGroupAccessListEntry",
+                                                 &allocRC,
+                                                 &allocSysRC,
+                                                 &allocSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPALSRV: tmpBuff allocated @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               allocRC, allocSysRC, allocSysRSN);
+
+    if (tmpResultBuffer == NULL) {
+      status = RC_ZIS_GRPALSRV_ALLOC_FAILED;
+      break;
+    }
+
+    int radminExtractRC = radminExtractGroupAccessList(
+        authInfo,
+        groupNameNullTerm,
+        tmpResultBuffer,
+        localParmList.resultBufferCapacity,
+        &entriesExtracted,
+        &radminStatus
+    );
+
+    if (radminExtractRC == RC_RADMIN_OK) {
+      copyGroupAccessList(localParmList.resultBuffer, tmpResultBuffer,
+                          entriesExtracted);
+      localParmList.entriesExtracted = entriesExtracted;
+      localParmList.entriesFound = entriesExtracted;
+    } else if (radminExtractRC == RC_RADMIN_INSUFF_SPACE) {
+      localParmList.entriesExtracted = 0;
+      localParmList.entriesFound = radminStatus.reasonCode;
+      status = RC_ZIS_GRPALSRV_INSUFFICIENT_SPACE;
+    } else  {
+      localParmList.internalServiceRC = radminExtractRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_GRPALSRV_INTERNAL_SERVICE_FAILED;
+    }
+
+    int freeRC = 0, freeSysRC = 0, freeSysRSN = 0;
+    freeRC = safeFree64v3(tmpResultBuffer, tmpResultBufferSize,
+                          &freeSysRC, &freeSysRSN);
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPALSRV: tmpBuff free'd @ 0x%p (%zu %d %d %d)\n",
+               tmpResultBuffer, tmpResultBufferSize,
+               freeRC, freeSysRC, freeSysRSN);
+
+    tmpResultBuffer = NULL;
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISGroupAccessListServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GRPALSRV: entriesExtracted = %u, RC = %d, "
+             "internal RC = %d, RSN = %d, "
+             "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             localParmList.entriesExtracted, radminExtractRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+static int validateGroupParmList(ZISGroupAdminServiceParmList *parmList) {
+
+  if (memcmp(parmList->eyecatcher,
+             ZIS_GROUP_ADMIN_SERVICE_PARMLIST_EYECATCHER,
+             sizeof(parmList->eyecatcher) != 0)) {
+    return RC_ZIS_GRPASRV_BAD_EYECATCHER;
+  }
+
+  if (parmList->function < ZIS_GROUP_ADMIN_SRV_FC_MIN ||
+      ZIS_GROUP_ADMIN_SRV_FC_MAX < parmList->function) {
+    return RC_ZIS_GRPASRV_BAD_FUNCTION;
+  }
+
+  if (parmList->group.length > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_GRPASRV_GROUP_TOO_LONG;
+  }
+
+  if (parmList->superiorGroup.length > ZIS_SECURITY_GROUP_MAX_LENGTH) {
+    return RC_ZIS_GRPASRV_SUPGROUP_TOO_LONG;
+  }
+
+  const char *productName = parmList->group.value;
+  bool isProductSupported = false;
+  int productCount =
+      sizeof(ZIS_GROUP_PRODUCTS) / sizeof(ZIS_GROUP_PRODUCTS[0]);
+  for (int i = 0; i < productCount; i++) {
+
+    const char *currProductName = ZIS_GROUP_PRODUCTS[i];
+    size_t currProductNameLength = strlen(currProductName);
+    if (currProductNameLength > parmList->group.length) {
+      continue;
+    }
+
+    if (memcmp(productName, currProductName, currProductNameLength) == 0) {
+      isProductSupported = true;
+      break;
+    }
+  }
+
+  if (isProductSupported == false) {
+    return RC_ZIS_GRPASRV_UNSUPPORTED_PRODUCT;
+  }
+
+  if (parmList->user.length > ZIS_USER_ID_MAX_LENGTH) {
+    return RC_ZIS_GRPASRV_USER_ID_TOO_LONG;
+  }
+
+  if (parmList->function == ZIS_GROUP_ADMIN_SRV_FC_CONNECT_USER) {
+    if (parmList->accessType < ZIS_GROUP_ADMIN_ACESS_TYPE_MIN ||
+        ZIS_GROUP_ADMIN_ACESS_TYPE_MAX < parmList->accessType) {
+      return RC_ZIS_GRPASRV_BAD_ACCESS_TYPE;
+    }
+  }
+
+  return RC_ZIS_GRPASRV_OK;
+}
+
+static RadminGroupAction
+mapZISToRadminGroupAction(ZISGroupAdminFunction function)
+{
+  switch (function) {
+  case ZIS_GROUP_ADMIN_SRV_FC_ADD:
+    return RADMIN_GROUP_ACTION_ADD_GROUP;
+  case ZIS_GROUP_ADMIN_SRV_FC_DELETE:
+    return RADMIN_GROUP_ACTION_DELETE_GROUP;
+  default:
+    return RADMIN_GROUP_ACTION_NA;
+  }
+}
+
+static RadminConnectionAction
+mapZISToRadminConnectionAction(ZISGroupAdminFunction function)
+{
+  switch (function) {
+  case ZIS_GROUP_ADMIN_SRV_FC_CONNECT_USER:
+    return RADMIN_CONNECTION_ACTION_ADD_CONNECTION;
+  case ZIS_GROUP_ADMIN_SRV_FC_REMOVE_USER:
+    return RADMIN_CONNECTION_ACTION_REMOVE_CONNECTION;
+  default:
+    return RADMIN_CONNECTION_ACTION_NA;
+  }
+}
+
+typedef struct GroupOutputHandlerData_tag {
+  char eyecatcher[8];
+#define GROUP_OUT_HADNLER_DATA_EYECATCHER  "RSGPONDA"
+  CrossMemoryServerGlobalArea *globalArea;
+  size_t fullMessageLenght;
+  size_t fullCommandLength;
+  ZISGroupAdminServiceMessage message;
+  ZISGroupAdminServiceMessage command;
+} GroupOutputHandlerData;
+
+static int getGroupMsgAndOperatorCommand(RadminAPIStatus status,
+                                         const RadminCommandOutput *out,
+                                         void *userData) {
+
+  GroupOutputHandlerData *handlerData = userData;
+  ZISGroupAdminServiceMessage *message = &handlerData->message;
+  ZISGroupAdminServiceMessage *command = &handlerData->command;
+
+  bool messageCopied = false, commandCopied = false;
+
+  const RadminCommandOutput *nextOutput = out;
+  int nodeCount = 0;
+  while (nextOutput != NULL) {
+
+    if (commandCopied && messageCopied) {
+      break;
+    }
+    if (nodeCount > RADMIN_OUT_MAX_NODE_COUNT) {
+      return RC_GET_MSG_HADNLER_LOOP;
+    }
+
+    if (memcmp(nextOutput->eyecatcher, RADMIN_COMMAND_OUTPUT_EYECATCHER_CMD,
+               sizeof(nextOutput->eyecatcher)) == 0) {
+      unsigned int copySize =
+          min(nextOutput->firstMessageEntry.length, sizeof(command->text));
+      memcpy(command->text, nextOutput->firstMessageEntry.text, copySize);
+      command->length = copySize;
+      handlerData->fullCommandLength = nextOutput->firstMessageEntry.length;
+      commandCopied = true;
+    }
+
+    if (memcmp(nextOutput->eyecatcher, RADMIN_COMMAND_OUTPUT_EYECATCHER_MSG,
+               sizeof(nextOutput->eyecatcher)) == 0) {
+      unsigned int copySize =
+          min(nextOutput->firstMessageEntry.length, sizeof(message->text));
+      memcpy(message->text, nextOutput->firstMessageEntry.text, copySize);
+      message->length = copySize;
+      handlerData->fullMessageLenght = nextOutput->firstMessageEntry.length;
+      messageCopied = true;
+    }
+
+    nodeCount++;
+    nextOutput = nextOutput->next;
+  }
+
+  return RC_GET_MSG_HADNLER_OK;
+}
+
+
+static const char *getGroupAccessString(ZISGroupAdminServiceAccessType type) {
+  switch (type) {
+  case ZIS_GROUP_ADMIN_ACESS_TYPE_USE:
+    return "USE";
+  case ZIS_GROUP_ADMIN_ACESS_TYPE_CREATE:
+    return "CREATE";
+  case ZIS_GROUP_ADMIN_ACESS_TYPE_CONNECT:
+    return "CONNECT";
+  case ZIS_GROUP_ADMIN_ACESS_TYPE_JOIN:
+    return "JOIN";
+  default:
+    return NULL;
+  }
+}
+
+#define GROUP_PARMLIST_MIN_SIZE 1024
+
+static RadminGroupParmList *constructGroupAdminParmList(
+    char parmListBuffer[],
+    size_t bufferSize,
+    RadminGroupAction action,
+    bool isDryRun,
+    const char group[],
+    size_t groupLength,
+    const char superiorGroup[],
+    size_t superiorGroupLength
+) {
+
+  if (bufferSize < GROUP_PARMLIST_MIN_SIZE) {
+    return NULL;
+  }
+
+  memset(parmListBuffer, ' ', bufferSize);
+
+  RadminGroupParmList *parmList = (RadminGroupParmList *)parmListBuffer;
+
+  parmList->groupNameLength = groupLength;
+  memcpy(parmList->groupName, group, groupLength);
+
+  if (isDryRun) {
+    parmList->flags |= RADMIN_GROUP_FLAG_NORUN;
+    parmList->flags |= RADMIN_GROUP_FLAG_RETCMD;
+  }
+
+  if (action == RADMIN_GROUP_ACTION_ADD_GROUP) {
+
+    parmList->segmentCount = 1;
+    RadminSegment *segment = parmList->segmentData;
+    memcpy(segment->name, "BASE    ", sizeof(segment->name));
+    segment->flag |= RADMIN_SEGMENT_FLAG_Y;
+    segment->fieldCount = 0;
+
+    segment->fieldCount++;
+    RadminField *field1 = segment->firstField;
+    memcpy(field1->name, "SUPGROUP", sizeof(field1->name));
+    field1->flag |= RADMIN_FIELD_FLAG_Y;
+    field1->dataLength = superiorGroupLength;
+    memcpy(field1->data, superiorGroup, field1->dataLength);
+
+    segment->fieldCount++;
+    RadminField *field2 =
+        (RadminField *)((char *)(field1 + 1) + field1->dataLength);
+    memcpy(field2->name, "UNIVERSL", sizeof(field2->name));
+    field2->flag |= RADMIN_FIELD_FLAG_Y;
+    field2->dataLength = 0;
+
+  }
+
+  return parmList;
+}
+
+static RadminConnectionParmList *constructConnectionAdminParmList(
+    char parmListBuffer[],
+    size_t bufferSize,
+    RadminGroupAction action,
+    bool isDryRun,
+    const char userID[],
+    size_t userIDLength,
+    const char group[],
+    size_t groupLength,
+    ZISGroupAdminServiceAccessType accessType
+) {
+
+  if (bufferSize < GROUP_PARMLIST_MIN_SIZE) {
+    return NULL;
+  }
+
+  memset(parmListBuffer, ' ', bufferSize);
+
+  RadminConnectionParmList *parmList =
+      (RadminConnectionParmList *)parmListBuffer;
+
+  parmList->userIDLength = userIDLength;
+  memcpy(parmList->userID, userID, userIDLength);
+
+  if (isDryRun) {
+    parmList->flags |= RADMIN_CONNECTION_FLAG_NORUN;
+    parmList->flags |= RADMIN_CONNECTION_FLAG_RETCMD;
+  }
+  parmList->segmentCount = 1;
+  RadminSegment *segment = parmList->segmentData;
+  memcpy(segment->name, "BASE    ", sizeof(segment->name));
+  segment->flag |= RADMIN_SEGMENT_FLAG_Y;
+  segment->fieldCount = 1;
+  RadminField *field1 = segment->firstField;
+  memcpy(field1->name, "GROUP   ", sizeof(field1->name));
+  field1->flag |= RADMIN_FIELD_FLAG_Y;
+  field1->dataLength = groupLength;
+  memcpy(field1->data, group, field1->dataLength);
+
+  if (action == RADMIN_CONNECTION_ACTION_ADD_CONNECTION) {
+
+    const char *accessString = getGroupAccessString(accessType);
+    size_t accessStringLength = strlen(accessString);
+
+    segment->fieldCount++;
+    RadminField *field2 =
+        (RadminField *)((char *)(field1 + 1) + field1->dataLength);
+    memcpy(field2->name, "AUTH    ", sizeof(field2->name));
+    field2->flag |= RADMIN_FIELD_FLAG_Y;
+    field2->dataLength = accessStringLength;
+    memcpy(field2->data, accessString, field2->dataLength);
+
+  }
+
+  return parmList;
+}
+
+int zisGroupAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                 CrossMemoryService *service, void *parm) {
+
+  int status = RC_ZIS_GRPASRV_OK;
+  int radminActionRC = RC_RADMIN_OK;
+
+  void *clientParmAddr = parm;
+  if (clientParmAddr == NULL) {
+    return RC_ZIS_GRPASRV_PARMLIST_NULL;
+  }
+
+  ZISGroupAdminServiceParmList localParmList;
+  cmCopyFromSecondaryWithCallerKey(&localParmList, clientParmAddr,
+                                   sizeof(localParmList));
+
+  int parmValidateRC = validateGroupParmList(&localParmList);
+  if (parmValidateRC != RC_ZIS_GRPASRV_OK) {
+    return parmValidateRC;
+  }
+
+  int traceLevel = localParmList.traceLevel;
+  if (globalArea->pcLogLevel > traceLevel) {
+    traceLevel = globalArea->pcLogLevel;
+  }
+
+  do {
+
+    RadminUserID caller;
+    if (!getCallerUserID(&caller)) {
+      status = RC_ZIS_GRPASRV_IMPERSONATION_MISSING;
+      break;
+    }
+
+    CMS_DEBUG2(globalArea, traceLevel,
+               "GRPASRV: flags = 0x%X, function = %d, group = \'%.*s\', "
+               "superior group = \'%.*s\', user = \'%.*s\', access = %d'\n",
+               localParmList.flags,
+               localParmList.function,
+               localParmList.group.length, localParmList.group.value,
+               localParmList.superiorGroup.length,
+               localParmList.superiorGroup.value,
+               localParmList.user.length, localParmList.user.value,
+               localParmList.accessType);
+    CMS_DEBUG2(globalArea, traceLevel, "GRPASRV: caller = \'%.*s\'\n",
+               caller.length, caller.value);
+
+    RadminCallerAuthInfo authInfo = {
+        .acee = NULL,
+        .userID = caller
+    };
+
+    GroupOutputHandlerData handlerData = {
+        .eyecatcher = GROUP_OUT_HADNLER_DATA_EYECATCHER,
+        .globalArea = globalArea,
+        .fullMessageLenght = 0,
+        .fullCommandLength = 0
+    };
+
+    RadminStatus radminStatus;
+
+    bool isDryRun = (localParmList.flags & ZIS_GROUP_ADMIN_FLAG_DRYRUN) ?
+                    true : false;
+    char parmListBuffer[2048];
+
+    if (localParmList.function == ZIS_GROUP_ADMIN_SRV_FC_ADD ||
+        localParmList.function == ZIS_GROUP_ADMIN_SRV_FC_DELETE) {
+
+      RadminGroupAction action =
+          mapZISToRadminGroupAction(localParmList.function);
+      if (action == RADMIN_GROUP_ACTION_NA) {
+        status = RC_ZIS_GRPASRV_BAD_FUNCTION;
+        break;
+      }
+
+      RadminGroupParmList *parmList = constructGroupAdminParmList(
+          parmListBuffer,
+          sizeof(parmListBuffer),
+          action, isDryRun,
+          localParmList.group.value,
+          localParmList.group.length,
+          localParmList.superiorGroup.value,
+          localParmList.superiorGroup.length
+      );
+
+      if (parmList == NULL) {
+        status = RC_ZIS_GRPASRV_PARM_INTERNAL_ERROR;
+        break;
+      }
+
+      radminActionRC = radminPerformGroupAction(
+          authInfo,
+          action,
+          parmList,
+          getGroupMsgAndOperatorCommand,
+          &handlerData,
+          &radminStatus
+      );
+
+    } else {
+
+      RadminConnectionAction action =
+          mapZISToRadminConnectionAction(localParmList.function);
+      if (action == RADMIN_CONNECTION_ACTION_NA) {
+        status = RC_ZIS_GRPASRV_BAD_FUNCTION;
+        break;
+      }
+
+      RadminConnectionParmList *parmList = constructConnectionAdminParmList(
+          parmListBuffer,
+          sizeof(parmListBuffer),
+          action, isDryRun,
+          localParmList.user.value,
+          localParmList.user.length,
+          localParmList.group.value,
+          localParmList.group.length,
+          localParmList.accessType
+      );
+
+      if (parmList == NULL) {
+        status = RC_ZIS_GRPASRV_PARM_INTERNAL_ERROR;
+        break;
+      }
+
+      radminActionRC = radminPerformConnectionAction(
+          authInfo,
+          action,
+          parmList,
+          getMsgAndOperatorCommand,
+          &handlerData,
+          &radminStatus
+      );
+
+    }
+
+    localParmList.serviceMessage = handlerData.message;
+    localParmList.operatorCommand = handlerData.command;
+
+    if (radminActionRC != RC_RADMIN_OK) {
+      localParmList.internalServiceRC = radminActionRC;
+      localParmList.internalServiceRSN = radminStatus.reasonCode;
+      localParmList.safStatus.safRC = radminStatus.apiStatus.safRC;
+      localParmList.safStatus.racfRC = radminStatus.apiStatus.racfRC;
+      localParmList.safStatus.racfRSN = radminStatus.apiStatus.racfRSN;
+      status = RC_ZIS_GRPASRV_INTERNAL_SERVICE_FAILED;
+      break;
+    }
+
+  } while (0);
+
+  cmCopyToSecondaryWithCallerKey(clientParmAddr, &localParmList,
+                                 sizeof(ZISGroupAdminServiceParmList));
+
+  CMS_DEBUG2(globalArea, traceLevel,
+             "GRPASRV: status = %d, msgLen = %zu, cmdLen = %zu, "
+             "RC = %d, internal RC = %d, RSN = %d, "
+             "SAF RC = %d, RACF RC = %d, RSN = %d\n",
+             status,
+             localParmList.serviceMessage.length,
+             localParmList.operatorCommand.length,
+             radminActionRC,
+             localParmList.internalServiceRC,
+             localParmList.internalServiceRSN,
+             localParmList.safStatus.safRC,
+             localParmList.safStatus.racfRC,
+             localParmList.safStatus.racfRSN);
+
+  return status;
+}
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+

--- a/c/zss.c
+++ b/c/zss.c
@@ -61,6 +61,7 @@
 #ifdef __ZOWE_OS_ZOS
 #include "datasetjson.h"
 #include "authService.h"
+#include "securityService.h"
 #include "zis/client.h"
 #endif
 
@@ -904,6 +905,7 @@ int main(int argc, char **argv){
       installDatasetMetadataService(server);
       installDatasetContentsService(server);
       installAuthCheckService(server);
+      installSecurityManagementServices(server);
       installOMVSService(server);
 #endif
       installLoginService(server);

--- a/h/securityService.h
+++ b/h/securityService.h
@@ -1,0 +1,44 @@
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifndef __SECURITY_SERVICE_H__
+#define __SECURITY_SERVICE_H__
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "utils.h"
+#ifdef __ZOWE_OS_ZOS
+#include "zos.h"
+#endif
+#include "logging.h"
+#include "json.h"
+#include "bpxnet.h"
+#include "socketmgmt.h"
+#include "httpserver.h"
+#include "dataservice.h"
+
+void installSecurityManagementServices(HttpServer *server);
+
+#endif
+
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+

--- a/h/zis/client.h
+++ b/h/zis/client.h
@@ -22,6 +22,7 @@
 
 #include "zis/services/auth.h"
 #include "zis/services/nwm.h"
+#include "zis/services/secmgmt.h"
 #include "zis/services/snarfer.h"
 
 #ifndef __LONGNAME__
@@ -35,6 +36,20 @@
 #define zisCheckEntity              ZISSAUTH
 #define zisGetSAFAccessLevel        ZISGETAC
 #define zisCallNWMService           ZISCNWMS
+#define zisExtractUserProfiles      ZISUPROF
+#define zisExtractGenresProfiles    ZISGRROF
+#define zisExtractGenresAccessList  ZISGRAST
+#define zisDefineProfile            ZISDFPRF
+#define zisDeleteProfile            ZISDLPRF
+#define zisGiveAccessToProfile      ZISGAPRF
+#define zisRevokeAccessToProfile    ZISRAPRF
+#define zisCheckAccessToProfile     ZISCAPRF
+#define zisExtractGroupProfiles     ZISXGRPP
+#define zisExtractGroupAccessList   ZISXGRPA
+#define zisAddGroup                 ZISADDGP
+#define zisDeleteGroup              ZISDELGP
+#define zisConnectToGroup           ZISADDCN
+#define zisRemoveFromGroup          ZISREMCN
 
 #endif
 
@@ -151,6 +166,234 @@ int zisGetSAFAccessLevel(const CrossMemoryServerName *serverName,
                          ZISSAFAccessLevel *access,
                          ZISAuthServiceStatus *status,
                          int traceLevel);
+
+typedef struct ZISUserProfileServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+} ZISUserProfileServiceStatus;
+
+int zisExtractUserProfiles(const CrossMemoryServerName *serverName,
+                           const char *startProfile,
+                           unsigned int profilesToExtract,
+                           ZISUserProfileEntry *resultBuffer,
+                           unsigned int *profilesExtracted,
+                           ZISUserProfileServiceStatus *status,
+                           int traceLevel);
+
+extern const char *ZIS_UPRFSRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_UPRFSRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_UPRFSRV_USER_ID_TOO_LONG        (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_UPRFSRV_RESULT_BUFF_NULL        (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_UPRFSRV_PROFILE_COUNT_NULL      (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_UPRFSRV_MAX_RC                  (ZIS_MAX_GEN_SRVC_RC + 3)
+
+typedef struct ZISGenresProfileServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+} ZISGenresProfileServiceStatus;
+
+int zisExtractGenresProfiles(const CrossMemoryServerName *serverName,
+                             const char *class,
+                             const char *startProfile,
+                             unsigned int profilesToExtract,
+                             ZISGenresProfileEntry *resultBuffer,
+                             unsigned int *profilesExtracted,
+                             ZISGenresProfileServiceStatus *status,
+                             int traceLevel);
+
+extern const char *ZIS_GRPRFSRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_GRPRFSRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_GRPRFSRV_CLASS_TOO_LONG        (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_GRPRFSRV_PROFILE_TOO_LONG      (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_GRPRFSRV_RESULT_BUFF_NULL      (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_GRPRFSRV_PROFILE_COUNT_NULL    (ZIS_MAX_GEN_SRVC_RC + 4)
+#define RC_ZIS_SRVC_GRPRFSRV_MAX_RC                (ZIS_MAX_GEN_SRVC_RC + 4)
+
+typedef struct ZISGenresAccessListServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+} ZISGenresAccessListServiceStatus;
+
+int zisExtractGenresAccessList(const CrossMemoryServerName *serverName,
+                               const char *class,
+                               const char *profile,
+                               ZISGenresAccessEntry *resultBuffer,
+                               unsigned int resultBufferCapacity,
+                               unsigned int *entriesExtracted,
+                               ZISGenresAccessListServiceStatus *status,
+                               int traceLevel);
+
+extern const char *ZIS_ACSLSRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_ACSLSRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_ACSLSRV_CLASS_TOO_LONG          (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_ACSLSRV_PROFILE_NULL            (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_ACSLSRV_PROFILE_TOO_LONG        (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_ACSLSRV_RESULT_BUFF_NULL        (ZIS_MAX_GEN_SRVC_RC + 4)
+#define RC_ZIS_SRVC_ACSLSRV_ENTRY_COUNT_NULL        (ZIS_MAX_GEN_SRVC_RC + 5)
+#define RC_ZIS_SRVC_ACSLSRV_INSUFFICIENT_BUFFER     (ZIS_MAX_GEN_SRVC_RC + 6)
+#define RC_ZIS_SRVC_ACSLSRV_MAX_RC                  (ZIS_MAX_GEN_SRVC_RC + 6)
+
+typedef struct ZISGenresAdminServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+  ZISGenresAdminServiceMessage message;
+} ZISGenresAdminServiceStatus;
+
+int zisDefineProfile(const CrossMemoryServerName *serverName,
+                     const char *profileName,
+                     const char *owner,
+                     bool isDryRun,
+                     ZISGenresAdminServiceMessage *operatorCommand,
+                     ZISGenresAdminServiceStatus *status,
+                     int traceLevel);
+
+int zisDeleteProfile(const CrossMemoryServerName *serverName,
+                     const char *profileName,
+                     bool isDryRun,
+                     ZISGenresAdminServiceMessage *operatorCommand,
+                     ZISGenresAdminServiceStatus *status,
+                     int traceLevel);
+
+int zisGiveAccessToProfile(const CrossMemoryServerName *serverName,
+                           const char *userID,
+                           const char *profileName,
+                           ZISGenresAdminServiceAccessType accessType,
+                           bool isDryRun,
+                           ZISGenresAdminServiceMessage *operatorCommand,
+                           ZISGenresAdminServiceStatus *status,
+                           int traceLevel);
+
+int zisRevokeAccessToProfile(const CrossMemoryServerName *serverName,
+                             const char *userID,
+                             const char *profileName,
+                             bool isDryRun,
+                             ZISGenresAdminServiceMessage *operatorCommand,
+                             ZISGenresAdminServiceStatus *status,
+                             int traceLevel);
+
+extern const char *ZIS_GSADMNSRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_GSADMNSRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_PADMIN_USERID_NULL            (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_PADMIN_USERID_TOO_LONG        (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_PADMIN_PROFILE_NULL           (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_PADMIN_PROFILE_TOO_LONG       (ZIS_MAX_GEN_SRVC_RC + 4)
+#define RC_ZIS_SRVC_PADMIN_OWNER_NULL             (ZIS_MAX_GEN_SRVC_RC + 5)
+#define RC_ZIS_SRVC_PADMIN_OWNER_TOO_LONG         (ZIS_MAX_GEN_SRVC_RC + 6)
+#define RC_ZIS_SRVC_PADMIN_OPER_CMD_NULL          (ZIS_MAX_GEN_SRVC_RC + 7)
+#define RC_ZIS_SRVC_PADMIN_MAX_RC                 (ZIS_MAX_GEN_SRVC_RC + 7)
+
+typedef struct ZISGroupProfileServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+} ZISGroupProfileServiceStatus;
+
+int zisExtractGroupProfiles(const CrossMemoryServerName *serverName,
+                            const char *startGroup,
+                            unsigned int profilesToExtract,
+                            ZISGroupProfileEntry *resultBuffer,
+                            unsigned int *profilesExtracted,
+                            ZISGroupProfileServiceStatus *status,
+                            int traceLevel);
+
+extern const char *ZIS_GPPRFSRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_GPPRFSRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_GPPRFSRV_CLASS_TOO_LONG         (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_GPPRFSRV_GROUP_TOO_LONG         (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_GPPRFSRV_RESULT_BUFF_NULL       (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_GPPRFSRV_PROFILE_COUNT_NULL     (ZIS_MAX_GEN_SRVC_RC + 4)
+#define RC_ZIS_SRVC_GPPRFSRV_MAX_RC                 (ZIS_MAX_GEN_SRVC_RC + 4)
+
+typedef struct ZISGroupAccessListServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+} ZISGroupAccessListServiceStatus;
+
+int zisExtractGroupAccessList(const CrossMemoryServerName *serverName,
+                              const char *group,
+                              ZISGroupAccessEntry *resultBuffer,
+                              unsigned int resultBufferCapacity,
+                              unsigned int *entriesExtracted,
+                              ZISGroupAccessListServiceStatus *status,
+                              int traceLevel);
+
+extern const char *ZIS_GRPALSRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_GRPALSRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_GRPALSRV_GROUP_NULL             (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_GRPALSRV_GROUP_TOO_LONG         (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_GRPALSRV_RESULT_BUFF_NULL       (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_GRPALSRV_ENTRY_COUNT_NULL       (ZIS_MAX_GEN_SRVC_RC + 4)
+#define RC_ZIS_SRVC_GRPALSRV_INSUFFICIENT_BUFFER    (ZIS_MAX_GEN_SRVC_RC + 5)
+#define RC_ZIS_SRVC_GRPALSRV_MAX_RC                 (ZIS_MAX_GEN_SRVC_RC + 6)
+
+typedef struct ZISGroupAdminServiceStatus_tag {
+  ZISServiceStatus baseStatus;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+  ZISGroupAdminServiceMessage message;
+} ZISGroupAdminServiceStatus;
+
+int zisAddGroup(const CrossMemoryServerName *serverName,
+                const char *groupName,
+                const char *superiorGroupName,
+                bool isDryRun,
+                ZISGroupAdminServiceMessage *operatorCommand,
+                ZISGroupAdminServiceStatus *status,
+                int traceLevel);
+
+int zisDeleteGroup(const CrossMemoryServerName *serverName,
+                   const char *groupName,
+                   bool isDryRun,
+                   ZISGroupAdminServiceMessage *operatorCommand,
+                   ZISGroupAdminServiceStatus *status,
+                   int traceLevel);
+
+int zisConnectToGroup(const CrossMemoryServerName *serverName,
+                      const char *userID,
+                      const char *groupName,
+                      ZISGroupAdminServiceAccessType accessType,
+                      bool isDryRun,
+                      ZISGroupAdminServiceMessage *operatorCommand,
+                      ZISGroupAdminServiceStatus *status,
+                      int traceLevel);
+
+int zisRemoveFromGroup(const CrossMemoryServerName *serverName,
+                       const char *userID,
+                       const char *groupName,
+                       bool isDryRun,
+                       ZISGroupAdminServiceMessage *operatorCommand,
+                       ZISGroupAdminServiceStatus *status,
+                       int traceLevel);
+
+extern const char *ZIS_GRPASRV_SERVICE_RC_DESCRIPTION[];
+extern const char *ZIS_GRPASRV_WRAPPER_RC_DESCRIPTION[];
+
+#define RC_ZIS_SRVC_GADMIN_GROUP_NULL             (ZIS_MAX_GEN_SRVC_RC + 1)
+#define RC_ZIS_SRVC_GADMIN_GROUP_TOO_LONG         (ZIS_MAX_GEN_SRVC_RC + 2)
+#define RC_ZIS_SRVC_GADMIN_SUPGROUP_NULL          (ZIS_MAX_GEN_SRVC_RC + 3)
+#define RC_ZIS_SRVC_GADMIN_SUPGROUP_TOO_LONG      (ZIS_MAX_GEN_SRVC_RC + 4)
+#define RC_ZIS_SRVC_GADMIN_USERID_NULL            (ZIS_MAX_GEN_SRVC_RC + 5)
+#define RC_ZIS_SRVC_GADMIN_USERID_TOO_LONG        (ZIS_MAX_GEN_SRVC_RC + 6)
+#define RC_ZIS_SRVC_GADMIN_OPER_CMD_NULL          (ZIS_MAX_GEN_SRVC_RC + 7)
+#define RC_ZIS_SRVC_GADMIN_MAX_RC                 (ZIS_MAX_GEN_SRVC_RC + 7)
 
 typedef struct ZISNWMJobName_tag {
   char value[8];

--- a/h/zis/services/auth.h
+++ b/h/zis/services/auth.h
@@ -84,7 +84,8 @@ int zisAuthServiceFunction(CrossMemoryServerGlobalArea *globalArea,
 #define RC_ZIS_AUTHSRV_SAF_NO_DECISION            17
 #define RC_ZIS_AUTHSRV_USER_CLASS_NOT_READ        18
 #define RC_ZIS_AUTHSRV_USER_CLASS_TOO_LONG        19
-#define RC_ZIS_AUTHSRV_MAX_RC                     19
+#define RC_ZIS_AUTHSRV_CUSTOM_CLASS_NOT_ALLOWED   20
+#define RC_ZIS_AUTHSRV_MAX_RC                     20
 
 #endif /* ZIS_SERVICES_AUTH_H_ */
 

--- a/h/zis/services/secmgmt.h
+++ b/h/zis/services/secmgmt.h
@@ -1,0 +1,499 @@
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifndef ZIS_SERVICES_SECMGMT_H_
+#define ZIS_SERVICES_SECMGMT_H_
+
+#include "zowetypes.h"
+#include "zos.h"
+
+/*** Common security structs and definitions ***/
+
+#define ZIS_SECURITY_CLASS_MAX_LENGTH       8
+#define ZIS_SECURITY_PROFILE_MAX_LENGTH     246
+#define ZIS_SECURITY_GROUP_MAX_LENGTH       8
+#define ZIS_USER_ID_MAX_LENGTH              8
+
+typedef struct SAFStatus_tag {
+  int safRC;
+  int racfRC;
+  int racfRSN;
+} SAFStatus;
+
+typedef struct ZISSecurityClass_tag {
+  uint8_t length;
+  char value[ZIS_SECURITY_CLASS_MAX_LENGTH];
+  char padding[7];
+} ZISSecurityClass;
+
+typedef struct ZISSecurityProfile_tag {
+  uint8_t length;
+  char value[ZIS_SECURITY_PROFILE_MAX_LENGTH];
+  char padding[1];
+} ZISSecurityProfile;
+
+typedef struct ZISSecurityGroup_tag {
+  uint8_t length;
+  char value[ZIS_SECURITY_GROUP_MAX_LENGTH];
+  char padding[7];
+} ZISSecurityGroup;
+
+typedef struct ZISUserID_tag {
+  uint8_t length;
+  char value[ZIS_USER_ID_MAX_LENGTH];
+  char padding[7];
+} ZISUserID;
+
+/*** User profile service ***/
+
+#define ZIS_SERVICE_ID_USERPROF_SRV               14
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISUserProfileEntry_tag {
+  char userID[8];
+  char defaultGroup[8];
+  char name[20];
+} ZISUserProfileEntry;
+
+typedef struct ZISUserProfileServiceParmList_tag {
+
+  /* input-output fields */
+  char eyecatcher[8];
+#define ZIS_USERPROF_SERVICE_PARMLIST_EYECATCHER "RSUPROFS"
+  int version;
+  int flags;
+  int traceLevel;
+
+  ZISUserID startUserID;
+  unsigned int profilesToExtract;
+  PAD_LONG(x00, ZISUserProfileEntry *resultBuffer);
+
+  /* output fields */
+  unsigned int profilesExtracted;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+
+} ZISUserProfileServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+#pragma map(zisUserProfilesServiceFunction, "ZISSXUPR")
+int zisUserProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                   CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_UPRFSRV_OK                         0
+#define RC_ZIS_UPRFSRV_PARMLIST_NULL              8
+#define RC_ZIS_UPRFSRV_BAD_EYECATCHER             9
+#define RC_ZIS_UPRFSRV_USER_ID_TOO_LONG           10
+#define RC_ZIS_UPRFSRV_RESULT_BUFF_NULL           11
+#define RC_ZIS_UPRFSRV_PROFILE_COUNT_NULL         12
+#define RC_ZIS_UPRFSRV_IMPERSONATION_MISSING      13
+#define RC_ZIS_UPRFSRV_INTERNAL_SERVICE_FAILED    14
+#define RC_ZIS_UPRFSRV_ALLOC_FAILED               15
+#define RC_ZIS_UPRFSRV_MAX_RC                     15
+
+/*** Genres profile service ***/
+
+#define ZIS_SERVICE_ID_GRESPROF_SRV               15
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISGenresProfileEntry_tag {
+  char profile[ZIS_SECURITY_PROFILE_MAX_LENGTH];
+  char owner[8];
+} ZISGenresProfileEntry;
+
+typedef struct ZISGenresProfileServiceParmList_tag {
+
+  /* input-output fields */
+  char eyecatcher[8];
+#define ZIS_GRESPROF_SERVICE_PARMLIST_EYECATCHER "RSGPROFS"
+  int version;
+  int flags;
+  int traceLevel;
+
+  ZISSecurityClass class;
+  ZISSecurityProfile startProfile;
+  unsigned int profilesToExtract;
+  PAD_LONG(x00, ZISGenresProfileEntry *resultBuffer);
+
+  /* output fields */
+  unsigned int profilesExtracted;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+
+} ZISGenresProfileServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+#pragma map(zisGenresProfilesServiceFunction, "ZISSXGRP")
+int zisGenresProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                     CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_GRPRFSRV_OK                        0
+#define RC_ZIS_GRPRFSRV_PARMLIST_NULL             8
+#define RC_ZIS_GRPRFSRV_BAD_EYECATCHER            9
+#define RC_ZIS_GRPRFSRV_CLASS_TOO_LONG            10
+#define RC_ZIS_GRPRFSRV_PROFILE_TOO_LONG          11
+#define RC_ZIS_GRPRFSRV_RESULT_BUFF_NULL          12
+#define RC_ZIS_GRPRFSRV_PROFILE_COUNT_NULL        14
+#define RC_ZIS_GRPRFSRV_IMPERSONATION_MISSING     15
+#define RC_ZIS_GRPRFSRV_INTERNAL_SERVICE_FAILED   16
+#define RC_ZIS_GRPRFSRV_ALLOC_FAILED              17
+#define RC_ZIS_GRPRFSRV_USER_CLASS_NOT_READ       18
+#define RC_ZIS_GRPRFSRV_MAX_RC                    18
+
+/*** General resource access list service ***/
+
+#define ZIS_SERVICE_ID_ACSLIST_SRV                16
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISGenresAccessEntry_tag {
+  char id[8];
+  char accessType[8];
+} ZISGenresAccessEntry;
+
+typedef struct ZISAccessListServiceParmList_tag {
+
+  /* input-output fields */
+  char eyecatcher[8];
+#define ZIS_ACSLIST_SERVICE_PARMLIST_EYECATCHER "RSACSLST"
+  int version;
+  int flags;
+  int traceLevel;
+
+  ZISSecurityClass class;
+  ZISSecurityProfile profile;
+  unsigned int resultBufferCapacity;
+  PAD_LONG(x00, ZISGenresAccessEntry *resultBuffer);
+
+  /* output fields */
+  unsigned int entriesExtracted;
+  unsigned int entriesFound;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+
+} ZISGenresAccessListServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+#pragma map(zisGenresAccessListServiceFunction, "ZISSXGAL")
+int zisGenresAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                       CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_ACSLSRV_OK                         0
+#define RC_ZIS_ACSLSRV_PARMLIST_NULL              8
+#define RC_ZIS_ACSLSRV_BAD_EYECATCHER             9
+#define RC_ZIS_ACSLSRV_CLASS_TOO_LONG             10
+#define RC_ZIS_ACSLSRV_PROFILE_TOO_LONG           11
+#define RC_ZIS_ACSLSRV_RESULT_BUFF_NULL           12
+#define RC_ZIS_ACSLSRV_IMPERSONATION_MISSING      13
+#define RC_ZIS_ACSLSRV_ALLOC_FAILED               14
+#define RC_ZIS_ACSLSRV_INTERNAL_SERVICE_FAILED    15
+#define RC_ZIS_ACSLSRV_INSUFFICIENT_SPACE         16
+#define RC_ZIS_ACSLSRV_USER_CLASS_NOT_READ        17
+#define RC_ZIS_ACSLSRV_MAX_RC                     17
+
+/*** General resource profile administration service ***/
+
+#define ZIS_SERVICE_ID_GENRES_ADMIN_SRV           17
+
+#pragma enum(2)
+
+typedef enum ZISGenresAdminFunction_tag {
+  ZIS_GENRES_ADMIN_SRV_FC_MIN = 0,
+  ZIS_GENRES_ADMIN_SRV_FC_DEFINE = 0,
+  ZIS_GENRES_ADMIN_SRV_FC_DELETE = 1,
+  ZIS_GENRES_ADMIN_SRV_FC_GIVE_ACCESS = 2,
+  ZIS_GENRES_ADMIN_SRV_FC_REVOKE_ACCESS = 3,
+  ZIS_GENRES_ADMIN_SRV_FC_MAX = 3,
+} ZISGenresAdminFunction;
+
+typedef enum ZISGenresAdminServiceAccessType_tag {
+  ZIS_GENRES_ADMIN_ACESS_TYPE_UNKNOWN = -1,
+  ZIS_GENRES_ADMIN_ACESS_TYPE_MIN = 0,
+  ZIS_GENRES_ADMIN_ACESS_TYPE_READ = 0,
+  ZIS_GENRES_ADMIN_ACESS_TYPE_UPDATE = 1,
+  ZIS_GENRES_ADMIN_ACESS_TYPE_ALTER = 2,
+  ZIS_GENRES_ADMIN_ACESS_TYPE_MAX = 2,
+} ZISGenresAdminServiceAccessType;
+
+#pragma enum(reset)
+
+static const char *ZIS_GENRES_PRODUCTS[] = {
+  "ZOWE"
+};
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISGenresAdminServiceMessage_tag {
+  uint16_t length;
+  char text[510];
+} ZISGenresAdminServiceMessage;
+
+typedef struct ZISGenresAdminServiceParmList_tag {
+
+  /* input fields */
+  char eyecatcher[8];
+#define ZIS_GENRES_ADMIN_SERVICE_PARMLIST_EYECATCHER "RSGRADMN"
+  int version;
+  int flags;
+#define ZIS_GENRES_ADMIN_FLAG_DRYRUN  0x00000001
+  int traceLevel;
+
+  ZISGenresAdminFunction function;
+  ZISSecurityProfile profile;
+  ZISUserID owner;
+  ZISUserID user;
+  ZISGenresAdminServiceAccessType accessType;
+
+  /* output fields */
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+  ZISGenresAdminServiceMessage serviceMessage;
+  ZISGenresAdminServiceMessage operatorCommand;
+
+} ZISGenresAdminServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+
+#pragma map(zisGenresProfileAdminServiceFunction, "ZISSXPAA")
+int zisGenresProfileAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                         CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_GSADMNSRV_OK                       0
+#define RC_ZIS_GSADMNSRV_PARMLIST_NULL            8
+#define RC_ZIS_GSADMNSRV_BAD_EYECATCHER           9
+#define RC_ZIS_GSADMNSRV_PROF_TOO_LONG            10
+#define RC_ZIS_GSADMNSRV_UNSUPPORTED_PRODUCT      11
+#define RC_ZIS_GSADMNSRV_USER_ID_NULL             12
+#define RC_ZIS_GSADMNSRV_USER_ID_TOO_LONG         13
+#define RC_ZIS_GSADMNSRV_IMPERSONATION_MISSING    14
+#define RC_ZIS_GSADMNSRV_BAD_FUNCTION             15
+#define RC_ZIS_GSADMNSRV_BAD_ACCESS_TYPE          16
+#define RC_ZIS_GSADMNSRV_INTERNAL_SERVICE_FAILED  17
+#define RC_ZIS_GSADMNSRV_PARM_INTERNAL_ERROR      18
+#define RC_ZIS_GSADMNSRV_USER_CLASS_TOO_LONG      19
+#define RC_ZIS_GSADMNSRV_USER_CLASS_NOT_READ      20
+#define RC_ZIS_GSADMNSRV_AUTOREFRESH_NOT_READ     21
+#define RC_ZIS_GSADMNSRV_OWNER_TOO_LONG           22
+#define RC_ZIS_GSADMNSRV_MAX_RC                   22
+
+/*** Group profile service ***/
+
+#define ZIS_SERVICE_ID_GRPPROF_SRV                18
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISGroupProfileEntry_tag {
+  char group[ZIS_SECURITY_GROUP_MAX_LENGTH];
+  char superiorGroup[ZIS_SECURITY_GROUP_MAX_LENGTH];
+  char owner[8];
+} ZISGroupProfileEntry;
+
+typedef struct ZISGroupProfileServiceParmList_tag {
+
+  /* input-output fields */
+  char eyecatcher[8];
+#define ZIS_GRPPROF_SERVICE_PARMLIST_EYECATCHER "RSGRPPRF"
+  int version;
+  int flags;
+  int traceLevel;
+
+  ZISSecurityGroup startGroup;
+  unsigned int profilesToExtract;
+  PAD_LONG(x00, ZISGroupProfileEntry *resultBuffer);
+
+  /* output fields */
+  unsigned int profilesExtracted;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+
+} ZISGroupProfileServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+#pragma map(zisGroupProfilesServiceFunction, "ZISSXGPP")
+int zisGroupProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                    CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_GPPRFSRV_OK                        0
+#define RC_ZIS_GPPRFSRV_PARMLIST_NULL             8
+#define RC_ZIS_GPPRFSRV_BAD_EYECATCHER            9
+#define RC_ZIS_GPPRFSRV_GROUP_TOO_LONG            10
+#define RC_ZIS_GPPRFSRV_RESULT_BUFF_NULL          11
+#define RC_ZIS_GPPRFSRV_PROFILE_COUNT_NULL        12
+#define RC_ZIS_GPPRFSRV_IMPERSONATION_MISSING     13
+#define RC_ZIS_GPPRFSRV_INTERNAL_SERVICE_FAILED   14
+#define RC_ZIS_GPPRFSRV_ALLOC_FAILED              15
+#define RC_ZIS_GPPRFSRV_MAX_RC                    16
+
+/*** Group access list service ***/
+
+#define ZIS_SERVICE_ID_GRPALIST_SRV               19
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISGroupAccessEntry_tag {
+  char id[8];
+  char accessType[8];
+} ZISGroupAccessEntry;
+
+typedef struct ZISGroupAccessListServiceParmList_tag {
+
+  /* input-output fields */
+  char eyecatcher[8];
+#define ZIS_GRPALST_SERVICE_PARMLIST_EYECATCHER "RSGRPALST"
+  int version;
+  int flags;
+  int traceLevel;
+
+  ZISSecurityGroup group;
+  unsigned int resultBufferCapacity;
+  PAD_LONG(x00, ZISGroupAccessEntry *resultBuffer);
+
+  /* output fields */
+  unsigned int entriesExtracted;
+  unsigned int entriesFound;
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+
+} ZISGroupAccessListServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+
+#pragma map(zisGroupAccessListServiceFunction, "ZISSXGPA")
+int zisGroupAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                      CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_GRPALSRV_OK                        0
+#define RC_ZIS_GRPALSRV_PARMLIST_NULL             8
+#define RC_ZIS_GRPALSRV_BAD_EYECATCHER            9
+#define RC_ZIS_GRPALSRV_GROUP_TOO_LONG            10
+#define RC_ZIS_GRPALSRV_RESULT_BUFF_NULL          11
+#define RC_ZIS_GRPALSRV_IMPERSONATION_MISSING     12
+#define RC_ZIS_GRPALSRV_ALLOC_FAILED              13
+#define RC_ZIS_GRPALSRV_INTERNAL_SERVICE_FAILED   14
+#define RC_ZIS_GRPALSRV_INSUFFICIENT_SPACE        15
+#define RC_ZIS_GRPALSRV_MAX_RC                    15
+
+/*** Group administration service ***/
+
+#define ZIS_SERVICE_ID_GROUP_ADMIN_SRV            20
+
+#pragma enum(2)
+
+typedef enum ZISGroupAdminFunction_tag {
+  ZIS_GROUP_ADMIN_SRV_FC_MIN = 0,
+  ZIS_GROUP_ADMIN_SRV_FC_ADD = 0,
+  ZIS_GROUP_ADMIN_SRV_FC_DELETE = 1,
+  ZIS_GROUP_ADMIN_SRV_FC_CONNECT_USER = 2,
+  ZIS_GROUP_ADMIN_SRV_FC_REMOVE_USER = 3,
+  ZIS_GROUP_ADMIN_SRV_FC_MAX = 3,
+} ZISGroupAdminFunction;
+
+typedef enum ZISGroupAdminServiceAccessType_tag {
+  ZIS_GROUP_ADMIN_ACESS_TYPE_UNKNOWN = -1,
+  ZIS_GROUP_ADMIN_ACESS_TYPE_MIN = 0,
+  ZIS_GROUP_ADMIN_ACESS_TYPE_USE = 0,
+  ZIS_GROUP_ADMIN_ACESS_TYPE_CREATE = 1,
+  ZIS_GROUP_ADMIN_ACESS_TYPE_CONNECT = 2,
+  ZIS_GROUP_ADMIN_ACESS_TYPE_JOIN = 3,
+  ZIS_GROUP_ADMIN_ACESS_TYPE_MAX = 3,
+} ZISGroupAdminServiceAccessType;
+
+#pragma enum(reset)
+
+static const char *ZIS_GROUP_PRODUCTS[] = {
+  "ZWE",
+  "ZOWE",
+  "MVD",
+  "ZIS"
+};
+
+ZOWE_PRAGMA_PACK
+
+typedef struct ZISGroupAdminServiceMessage_tag {
+  uint16_t length;
+  char text[510];
+} ZISGroupAdminServiceMessage;
+
+typedef struct ZISGroupAdminServiceParmList_tag {
+
+  /* input fields */
+  char eyecatcher[8];
+#define ZIS_GROUP_ADMIN_SERVICE_PARMLIST_EYECATCHER "RSGPADMN"
+  int version;
+  int flags;
+#define ZIS_GROUP_ADMIN_FLAG_DRYRUN  0x00000001
+  int traceLevel;
+
+  ZISGroupAdminFunction function;
+  ZISSecurityGroup group;
+  ZISSecurityGroup superiorGroup;
+  ZISUserID user;
+  ZISGroupAdminServiceAccessType accessType;
+
+  /* output fields */
+  int internalServiceRC;
+  int internalServiceRSN;
+  SAFStatus safStatus;
+  ZISGroupAdminServiceMessage serviceMessage;
+  ZISGroupAdminServiceMessage operatorCommand;
+
+} ZISGroupAdminServiceParmList;
+
+ZOWE_PRAGMA_PACK_RESET
+
+#pragma map(zisGroupAdminServiceFunction, "ZISSXPGA")
+int zisGroupAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
+                                 CrossMemoryService *service, void *parm);
+
+#define RC_ZIS_GRPASRV_OK                         0
+#define RC_ZIS_GRPASRV_PARMLIST_NULL              8
+#define RC_ZIS_GRPASRV_BAD_EYECATCHER             9
+#define RC_ZIS_GRPASRV_GROUP_TOO_LONG             10
+#define RC_ZIS_GRPASRV_SUPGROUP_TOO_LONG          11
+#define RC_ZIS_GRPASRV_UNSUPPORTED_PRODUCT        12
+#define RC_ZIS_GRPASRV_USER_ID_TOO_LONG           13
+#define RC_ZIS_GRPASRV_IMPERSONATION_MISSING      14
+#define RC_ZIS_GRPASRV_BAD_FUNCTION               15
+#define RC_ZIS_GRPASRV_BAD_ACCESS_TYPE            16
+#define RC_ZIS_GRPASRV_INTERNAL_SERVICE_FAILED    17
+#define RC_ZIS_GRPASRV_PARM_INTERNAL_ERROR        18
+#define RC_ZIS_GRPASRV_USER_CLASS_TOO_LONG        19
+#define RC_ZIS_GRPASRV_USER_CLASS_NOT_READ        20
+#define RC_ZIS_GRPASRV_AUTOREFRESH_NOT_READ       21
+#define RC_ZIS_GRPASRV_MAX_RC                     21
+
+#endif /* ZIS_SERVICES_SECMGMT_H_ */
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/

--- a/samplib/zis/ZWESIP00
+++ b/samplib/zis/ZWESIP00
@@ -16,9 +16,31 @@
 //*   ZWES - CORE PARAMETERS NAMESPACE.                              */
 //*     NAME - SERVER NAME. IF OMITTED, ZWESIS_STD IS USED.          */
 //*     PLUGIN - NAME OF A PLUG-IN LOAD MODULE.                      */
+//*     AUTH - AUTH SERVICES PARAMETERS NAMESPACE.                   */
+//*       CLASS -                                                    */
+//*         SAF CLASS USED BY THE AUTH SERVICES.                     */
+//*         IF NO CLASS IS PROVIDED BY A USER OF THE SERVICES        */
+//*         THE PARMLIB CLASS VALUE IS USED.                         */
+//*     SECMGMT - SECURITY SERVICES PARAMETERS NAMESPACE.            */
+//*       CLASS -                                                    */
+//*         SAF CLASS USED BY THE PROFILE MANAGEMENT SERVICES.       */
+//*         ANY PROFILE OPERATIONS WILL BE PERFORMED WITHIN          */
+//*         THIS CLASS ONLY. IF OMITTED, THE PROFILE SERVICES        */
+//*         WILL RETURN THE CORRESPONDING ERROR CODE.                */
+//*       AUTOREFRESH -                                              */
+//*         IF SET TO YES, THE PROFILE MANAGEMENT SERVICES           */
+//*         WILL REFRESH THE PROFILES AFTER ANY PROFILE              */
+//*         OPERATION IN THE CLASS FROM ZWES.SECMGMT.CLASS.          */
+//*         THE DEFAULT VALUE IS NO.                                 */
 //*                                                                  */
 //********************************************************************/
 
 * ZWES.PLUGIN.ECHO=ECHOPL01
 * ZWES.PLUGIN.MAGICNUMBER=MNUMBER
+
+ZWES.AUTH.CLASS=ZOWE
+
+ZWES.SECMGMT.CLASS=ZOWE
+
+ZWES.SECMGMT.AUTOREFRESH=NO
 


### PR DESCRIPTION
The following new REST and cross-memory services have been added:
* Extract user profiles
* Define/delete/permit general resource profiles (limited to a single class)
* Add/remove groups
* Connect users to groups (for a limited set of group prefixes)
* Check user access levels (limited to a single class)

The documentation can be found [here](https://github.com/zowe/zlux-app-server/blob/master/doc/swagger/security-mgmt-api.yaml).

Depends on https://github.com/zowe/zowe-common-c/pull/35