### PR TITLE
Adds dynamic logging functionality for plugins

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -561,11 +561,11 @@ static void installWebPluginDefintionsService(WebPluginListElt *webPlugins, Http
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG2, "end %s\n", __FUNCTION__);
 }
 
-static void createLoggingIdentifier(char *identifier, hashtable *pluginLoggingTable,int level,int i) {
+static void createLoggingIdentifier(char *identifier, hashtable *pluginLoggingTable,int level,int idMultiplier) {
   PluginLoggingData *newData = (PluginLoggingData*) safeMalloc(sizeof(PluginLoggingData),"PluginLoggingData");
   if(newData != NULL){
     newData->level = level;
-    uint64 newId = LOG_PROD_PLUGINS + (0x10000 * i); // creates unique logging id
+    uint64 newId = LOG_PROD_PLUGINS + (0x10000 * idMultiplier); // creates unique logging id
     newData->id = newId;
     htPut(pluginLoggingTable, identifier, newData);
     logConfigureComponent(NULL, newId, identifier, LOG_DEST_PRINTF_STDOUT, level);

--- a/c/zss.c
+++ b/c/zss.c
@@ -94,25 +94,12 @@ static WebPluginListElt* readWebPluginDefinitions(HttpServer* server, ShortLived
 static JsonObject *readServerSettings(ShortLivedHeap *slh, const char *filename);
 static InternalAPIMap *makeInternalAPIMap();
  
- //redo
   static int keyCompare(void *key1, void *key2) {
   if (strcmp(key1,key2) == 0){
     return TRUE;
   }  
   return FALSE;
 }
-/*
-// copied from collections
-static int identifierHash(void *key){
-  char *digest = (char*)key;
-  int hash = 0;
-  int i;
-  for (i=0; i<LRU_DIGEST_LENGTH; i+=sizeof(int)){
-    hash = hash ^ *((int*)(digest+i));
-  }
-  return (hash & 0x7FFFFFFF);
-}
-*/
 
 static int servePluginDefinitions(HttpService *service, HttpResponse *response){
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG2, "begin %s\n", __FUNCTION__);
@@ -375,9 +362,7 @@ static JsonObject *readServerSettings(ShortLivedHeap *slh, const char *filename)
       zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "error in file %s: expected top level object\n", filename);
     }
     JsonObject *logLevels = jsonObjectGetObject(mvdSettingsJsonObject, "logLevels");
-    
     if (logLevels) {
-      
       TraceDefinition *traceDef = traceDefs;
       while (traceDef->name != 0) {
 	int traceLevel = jsonObjectGetNumber(logLevels, (char*) traceDef->name);
@@ -582,8 +567,6 @@ static void installWebPluginDefintionsService(WebPluginListElt *webPlugins, Http
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG2, "end %s\n", __FUNCTION__);
 }
 
-
-//pass on the configuration file
 static void parseLoggingData(HttpServer *server, ShortLivedHeap *slh, const char *filename) {
 
   char errorBuffer[512] = { 0 };
@@ -603,12 +586,12 @@ static void parseLoggingData(HttpServer *server, ShortLivedHeap *slh, const char
     while(property != NULL) {
       char *key = jsonPropertyGetKey(property); 
       int value = jsonObjectGetNumber(logLevels, key);
-      loggingData *newData = (loggingData*) malloc(sizeof(loggingData));
+      PluginLoggingData *newData = (PluginLoggingData*) safeMalloc(sizeof(PluginLoggingData),"PluginLoggingData");
       newData->level = jsonObjectGetNumber(logLevels, key);
       uint64 newId = LOG_PROD_PLUGINS + (0x10000 * i); // creates unique logging id
       i+=1;
       newData->id = newId;
-      htPut(server->loggingTable, key, newData);
+      htPut(server->PluginLoggingTable, key, newData);
       logConfigureComponent(NULL, newId, key, LOG_DEST_PRINTF_STDOUT, value);
       zowelog(NULL, newId, ZOWE_LOG_INFO, "Added %s to logging table\n", key);
       property = jsonObjectGetNextProperty(property);
@@ -947,9 +930,8 @@ int main(int argc, char **argv){
 
     zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS server settings: address=%s, port=%d\n", address, port);
     server = makeHttpServer2(base,inetAddress,port,requiredTLSFlag,&returnCode,&reasonCode);
-        
     if (server){
-      server->loggingTable = htCreate(17, stringHash, keyCompare, NULL, NULL); //creates hash table for zowe log
+      server->PluginLoggingTable = htCreate(17, stringHash, keyCompare, NULL, NULL); //creates hash table for zowe log
       parseLoggingData(server, slh, serverConfigFile); //populates table with logging id's
       server->defaultProductURLPrefix = PRODUCT;
       loadWebServerConfig(server, mvdSettings);

--- a/c/zss.c
+++ b/c/zss.c
@@ -93,6 +93,26 @@ static JsonObject *readPluginDefinition(ShortLivedHeap *slh, char *pluginIdentif
 static WebPluginListElt* readWebPluginDefinitions(HttpServer* server, ShortLivedHeap *slh, char *dirname);
 static JsonObject *readServerSettings(ShortLivedHeap *slh, const char *filename);
 static InternalAPIMap *makeInternalAPIMap();
+ 
+ //redo
+  static int keyCompare(void *key1, void *key2) {
+  if (strcmp(key1,key2) == 0){
+    return TRUE;
+  }  
+  return FALSE;
+}
+/*
+// copied from collections
+static int identifierHash(void *key){
+  char *digest = (char*)key;
+  int hash = 0;
+  int i;
+  for (i=0; i<LRU_DIGEST_LENGTH; i+=sizeof(int)){
+    hash = hash ^ *((int*)(digest+i));
+  }
+  return (hash & 0x7FFFFFFF);
+}
+*/
 
 static int servePluginDefinitions(HttpService *service, HttpResponse *response){
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG2, "begin %s\n", __FUNCTION__);
@@ -355,7 +375,9 @@ static JsonObject *readServerSettings(ShortLivedHeap *slh, const char *filename)
       zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "error in file %s: expected top level object\n", filename);
     }
     JsonObject *logLevels = jsonObjectGetObject(mvdSettingsJsonObject, "logLevels");
+    
     if (logLevels) {
+      
       TraceDefinition *traceDef = traceDefs;
       while (traceDef->name != 0) {
 	int traceLevel = jsonObjectGetNumber(logLevels, (char*) traceDef->name);
@@ -558,6 +580,43 @@ static void installWebPluginDefintionsService(WebPluginListElt *webPlugins, Http
   httpService->authType = SERVICE_AUTH_NONE;
   registerHttpService(server, httpService);
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG2, "end %s\n", __FUNCTION__);
+}
+
+
+//pass on the configuration file
+static void parseLoggingData(HttpServer *server, ShortLivedHeap *slh, const char *filename) {
+
+  char errorBuffer[512] = { 0 };
+  JsonObject *jsonObject = NULL;
+  
+  Json *json = jsonParseFile(slh, filename, errorBuffer, sizeof(errorBuffer));
+  if (json) {
+    if (jsonIsObject(json)) {
+      jsonObject = jsonAsObject(json);
+    }
+    else {
+      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "error while parsing %s: %s\n", errorBuffer);
+    }
+    JsonObject *logLevels = jsonObjectGetObject(jsonObject, "logLevels");
+    JsonProperty *property = jsonObjectGetFirstProperty(logLevels);
+    int i = 1;
+    while(property != NULL) {
+      char *key = jsonPropertyGetKey(property); 
+      int value = jsonObjectGetNumber(logLevels, key);
+      loggingData *newData = (loggingData*) malloc(sizeof(loggingData));
+      newData->level = jsonObjectGetNumber(logLevels, key);
+      uint64 newId = LOG_PROD_PLUGINS + (0x10000 * i); // creates unique logging id
+      i+=1;
+      newData->id = newId;
+      htPut(server->loggingTable, key, newData);
+      logConfigureComponent(NULL, newId, key, LOG_DEST_PRINTF_STDOUT, value);
+      zowelog(NULL, newId, ZOWE_LOG_INFO, "Added %s to logging table\n", key);
+      property = jsonObjectGetNextProperty(property);
+    }
+  }
+  else {
+   zowelog(NULL,LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "error while parsing %s: %s\n",errorBuffer);
+  }
 }
 
 static WebPluginListElt* readWebPluginDefinitions(HttpServer *server, ShortLivedHeap *slh, char *dirname) {
@@ -888,7 +947,10 @@ int main(int argc, char **argv){
 
     zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS server settings: address=%s, port=%d\n", address, port);
     server = makeHttpServer2(base,inetAddress,port,requiredTLSFlag,&returnCode,&reasonCode);
+        
     if (server){
+      server->loggingTable = htCreate(17, stringHash, keyCompare, NULL, NULL); //creates hash table for zowe log
+      parseLoggingData(server, slh, serverConfigFile); //populates table with logging id's
       server->defaultProductURLPrefix = PRODUCT;
       loadWebServerConfig(server, mvdSettings);
       readWebPluginDefinitions(server, slh, pluginsDir);


### PR DESCRIPTION
Added new function to zss.c that creates logging id's for plugins that have specified logging levels.  Id's are stored in a hashtable in the httpserver struct.  The hashtable uses the plugin identifier as the key and stores a struct for the value that contains the created logging id and the log level. 