### PR TITLE
Fix incorrect variables passed to zowelog calls.

### DIFF
--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -773,14 +773,14 @@ static ZISPlugin *tryLoadingPlugin(const char *pluginName,
         zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_WARNING,
                 ZIS_LOG_PLUGIN_FAILURE_MSG_PREFIX" plug-in descriptor not "
                 "received from module '%8.8s'",
-                pluginName, moduleName);
+                pluginName, moduleName.text);
       }
 
     } else {
       zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_WARNING,
               ZIS_LOG_PLUGIN_FAILURE_MSG_PREFIX" plug-in EP not executed, "
               "module '%8.8s', recovery RC = %d, ABEND %03X-%02X",
-              pluginName, moduleName, recoveryRC, abendInfo.completionCode,
+              pluginName, moduleName.text, recoveryRC, abendInfo.completionCode,
               abendInfo.reasonCode);
     }
   }


### PR DESCRIPTION
In case of an ABEND or error in a ZIS plug-in, error messages are
supposed to be printed in the ZIS code. The corresponding zowelog calls
have incorrect strings passed to them which leads to an ABEND in the
server itself.