### PR TITLE
Added Unix file/directory response info for use in Editor

### DIFF
--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -50,7 +50,7 @@ typedef struct UploadSession_tag {
   unsigned int sessionID;
   int targetCCSID;
   int sourceCCSID;
-  enum TransferType tType;
+ enum TransferType tType;
   char userName[9];
 } UploadSession;
 
@@ -712,7 +712,7 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
         deleteUnixFileAndRespond(response, routeFileName);
       }
     }
-    else {
+  else {
       respondWithUnixFileNotFound(response, 1);
     }
   }

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -50,7 +50,7 @@ typedef struct UploadSession_tag {
   unsigned int sessionID;
   int targetCCSID;
   int sourceCCSID;
- enum TransferType tType;
+  enum TransferType tType;
   char userName[9];
 } UploadSession;
 
@@ -712,7 +712,7 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
         deleteUnixFileAndRespond(response, routeFileName);
       }
     }
-  else {
+    else {
       respondWithUnixFileNotFound(response, 1);
     }
   }
@@ -754,15 +754,15 @@ static int serveUnixFileCopy(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-	if (doesFileExist(routeFileName) == true) {
-	  if (isDir(routeFileName) == true) {
-	    copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
-	  }
-	  else {
-	    copyUnixFileAndRespond(response, routeFileName, newName, force);
-	  }
-	}
-	else {
+    if (doesFileExist(routeFileName) == true) {
+      if (isDir(routeFileName) == true) {
+        copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
+      }
+      else {
+        copyUnixFileAndRespond(response, routeFileName, newName, force);
+      }
+    }
+    else {
       respondWithUnixFileNotFound(response, 1);
     }
   }
@@ -802,15 +802,15 @@ static int serveUnixFileRename(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-	if (doesFileExist(routeFileName) == true) {
-	  if (isDir(routeFileName) == true) {
-	    renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
-	  }
-	  else {
-	    renameUnixFileAndRespond(response, routeFileName, newName, force);
-	  }
-	}
-	else {
+    if (doesFileExist(routeFileName) == true) {
+      if (isDir(routeFileName) == true) {
+        renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
+      }
+      else {
+        renameUnixFileAndRespond(response, routeFileName, newName, force);
+      }
+    }
+    else {
       respondWithUnixFileNotFound(response, 1);
     }
   }

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -704,8 +704,8 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
     respondWithUnixFileContentsWithAutocvtMode(NULL, response, routeFileName, TRUE, 0);
   }
   else if (!strcmp(request->method, methodDELETE)) {
-    if (doesFileExist(routeFileName) == TRUE) {
-	  if (isDir(routeFileName) == TRUE) {
+    if (doesFileExist(routeFileName) == true) {
+	  if (isDir(routeFileName) == true) {
 		deleteUnixDirectoryAndRespond(response, routeFileName);
 	  }
 	  else {
@@ -754,8 +754,8 @@ static int serveUnixFileCopy(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-	if (doesFileExist(routeFileName) == TRUE) {
-	  if (isDir(routeFileName) == TRUE) {
+	if (doesFileExist(routeFileName) == true) {
+	  if (isDir(routeFileName) == true) {
 	    copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
 	  }
 	  else {
@@ -802,8 +802,8 @@ static int serveUnixFileRename(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-	if (doesFileExist(routeFileName) == TRUE) {
-	  if (isDir(routeFileName) == TRUE) {
+	if (doesFileExist(routeFileName) == true) {
+	  if (isDir(routeFileName) == true) {
 	    renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
 	  }
 	  else {

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -704,13 +704,15 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
     respondWithUnixFileContentsWithAutocvtMode(NULL, response, routeFileName, TRUE, 0);
   }
   else if (!strcmp(request->method, methodDELETE)) {
-    if (isDir(routeFileName) == 1) {
-      deleteUnixDirectoryAndRespond(response, routeFileName);
-    }
-    else if (isDir(routeFileName) == 0) {
-      deleteUnixFileAndRespond(response, routeFileName);
-    }
-    else {
+	if (doesFileExist(routeFileName) == 1) {
+		if (isDir(routeFileName) == 1) {
+			deleteUnixDirectoryAndRespond(response, routeFileName);
+		}
+		else {
+			deleteUnixFileAndRespond(response, routeFileName);
+		}
+	}
+	else {
       respondWithUnixFileNotFound(response, 1);
     }
   }
@@ -752,13 +754,15 @@ static int serveUnixFileCopy(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-    if (isDir(routeFileName) == 1) {
-     copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
-    }
-    else if (isDir(routeFileName) == 0) {
-     copyUnixFileAndRespond(response, routeFileName, newName, force);
-    }
-    else {
+	if (doesFileExist(routeFileName) == 1) {
+		if (isDir(routeFileName) == 1) {
+			copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
+		}
+		else {
+			copyUnixFileAndRespond(response, routeFileName, newName, force);
+		}
+	}
+	else {
       respondWithUnixFileNotFound(response, 1);
     }
   }
@@ -798,13 +802,15 @@ static int serveUnixFileRename(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-    if (isDir(routeFileName) == 1) {
-     renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
-    }
-    else if (isDir(routeFileName) == 0) {
-      renameUnixFileAndRespond(response, routeFileName, newName, force);
-    }
-    else {
+	if (doesFileExist(routeFileName) == 1) {
+		if (isDir(routeFileName) == 1) {
+			renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
+		}
+		else {
+			renameUnixFileAndRespond(response, routeFileName, newName, force);
+		}
+	}
+	else {
       respondWithUnixFileNotFound(response, 1);
     }
   }

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -704,13 +704,13 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
     respondWithUnixFileContentsWithAutocvtMode(NULL, response, routeFileName, TRUE, 0);
   }
   else if (!strcmp(request->method, methodDELETE)) {
-	if (doesFileExist(routeFileName) == 1) {
-		if (isDir(routeFileName) == 1) {
-			deleteUnixDirectoryAndRespond(response, routeFileName);
-		}
-		else {
-			deleteUnixFileAndRespond(response, routeFileName);
-		}
+    if (doesFileExist(routeFileName) == TRUE) {
+	  if (isDir(routeFileName) == TRUE) {
+		deleteUnixDirectoryAndRespond(response, routeFileName);
+	  }
+	  else {
+		deleteUnixFileAndRespond(response, routeFileName);
+	  }
 	}
 	else {
       respondWithUnixFileNotFound(response, 1);
@@ -754,13 +754,13 @@ static int serveUnixFileCopy(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-	if (doesFileExist(routeFileName) == 1) {
-		if (isDir(routeFileName) == 1) {
-			copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
-		}
-		else {
-			copyUnixFileAndRespond(response, routeFileName, newName, force);
-		}
+	if (doesFileExist(routeFileName) == TRUE) {
+	  if (isDir(routeFileName) == TRUE) {
+	    copyUnixDirectoryAndRespond(response, routeFileName, newName, force);
+	  }
+	  else {
+	    copyUnixFileAndRespond(response, routeFileName, newName, force);
+	  }
 	}
 	else {
       respondWithUnixFileNotFound(response, 1);
@@ -802,13 +802,13 @@ static int serveUnixFileRename(HttpService *service, HttpResponse *response) {
   }
 
   if (!strcmp(request->method, methodPOST)) {
-	if (doesFileExist(routeFileName) == 1) {
-		if (isDir(routeFileName) == 1) {
-			renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
-		}
-		else {
-			renameUnixFileAndRespond(response, routeFileName, newName, force);
-		}
+	if (doesFileExist(routeFileName) == TRUE) {
+	  if (isDir(routeFileName) == TRUE) {
+	    renameUnixDirectoryAndRespond(response, routeFileName, newName, force);
+	  }
+	  else {
+	    renameUnixFileAndRespond(response, routeFileName, newName, force);
+	  }
 	}
 	else {
       respondWithUnixFileNotFound(response, 1);

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -705,14 +705,14 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
   }
   else if (!strcmp(request->method, methodDELETE)) {
     if (doesFileExist(routeFileName) == true) {
-	  if (isDir(routeFileName) == true) {
-		deleteUnixDirectoryAndRespond(response, routeFileName);
-	  }
-	  else {
-		deleteUnixFileAndRespond(response, routeFileName);
-	  }
-	}
-	else {
+      if (isDir(routeFileName) == true) {
+        deleteUnixDirectoryAndRespond(response, routeFileName);
+      }
+      else {
+        deleteUnixFileAndRespond(response, routeFileName);
+      }
+    }
+    else {
       respondWithUnixFileNotFound(response, 1);
     }
   }


### PR DESCRIPTION
- Reorganized logic to use boolean better and changed a 500 to a 400 to better differentiate a probable permission problem from a general server error.
- Addressed comments & suggestions
- Fixed sign off

PR 1 of 2
PR 2 https://github.com/zowe/zowe-common-c/pull/89

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>