### PR TITLE
Add scripts to deploy ZIS-related load libraries and update ZIS PARMLIB.

### DIFF
--- a/bin/zis-parmlib-update.sh
+++ b/bin/zis-parmlib-update.sh
@@ -1,0 +1,284 @@
+#!/bin/sh
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+
+# This script adds or updates pramaters in ZIS PARMLIB member specified in
+# the provided SAMPLIB file.
+
+# Make sure all files created in this script are only accesible by the owner.
+umask go-rwx
+
+# Prohibit undefined variables.
+set -u
+
+# ZIS-related global variables.
+ZIS_PREFIX=${ZIS_PREFIX:-$USER.DEV}
+ZIS_PARMLIB=${ZIS_PARMLIB:-$ZIS_PREFIX.PARMLIB}
+ZIS_PARMLIB_MEMBER=${ZIS_PARMLIB_MEMBER:-ZWESIP00}
+
+#################################################
+# Generate a name for a temporary file in /tmp
+#
+# Globals:
+#   RANDOM
+# Arguments:
+#   None
+# Returns:
+#   The generated file name
+#################################################
+make_temp_filename() {
+  name=/tmp/zis-sample-install-$$-$RANDOM
+  while [ -e $name ]
+  do
+    name=/tmp/zis-sample-install-$$-$RANDOM
+  done
+  echo $name
+}
+
+#################################################
+# Try to resolve values that are defined using
+# environmental variables, otherwise return
+# the original value
+#
+# Globals:
+#   None
+# Arguments:
+#   $1 Value from a key-value pair
+# Returns:
+#   * If an env variable is provided, its value
+#     is returned on success
+#   * If an env varible if provided and
+#     the variable is not defined,
+#     string VALUE_NOT_FOUND is returned
+#   * The original value is returned
+#################################################
+resolve_env_parameter() {
+
+  parm=$1
+
+  # Are we dealing with an env variable based value?
+  echo $parm | grep -E "^[$]{1}[A-Z0-9_]+$" 1>/dev/null
+  # Yes, resolve the value using eval, otherwise return the value itself.
+  if [ $? -eq 0 ]; then
+    ( eval "echo $parm" 2>/dev/null )
+    if [ $? -ne 0 ]; then
+      echo "VALUE_NOT_FOUND"
+    fi
+  else
+    echo $parm
+  fi
+
+}
+
+#################################################
+# Add (or update) a key-value pair to a PARMLIB
+# member.
+#
+# Globals:
+#   RANDOM
+# Arguments:
+#   $1 PARMLIB file to be updated
+#   $2 Parameter to be added/updated
+#   $3 Parameter value
+# Returns:
+#   0 on success, 8 on error.
+#################################################
+add_key_value_parm_to_parmlib() {(
+
+  # Input parameters.
+  parm_file=$1
+  parm_key=$2
+  parm_value=$(resolve_env_parameter $3)
+
+  # Check if we recevied a non-empty value for the key (if the value has been
+  # defined using an environmental variable).
+  if [ "$parm_value" = "VALUE_NOT_FOUND" ]; then
+    echo "error: value for $parm_key has not been provided"
+    exit 8
+  fi
+
+  key_value="$parm_key=$parm_value"
+  parm_file_updated="$parm_file"_updated
+
+  # Make a temp file for sed.
+  touch $parm_file_updated
+  if [ $? -ne 0 ]; then
+    exit 8
+  fi
+
+  # Make sure the temporary file produced by sed is removed.
+  trap "rm $parm_file_updated" EXIT
+
+  echo "info: adding/updaing $parm_key with value $parm_value"
+
+  # Try to find the key in our parameter file.
+  grep "^[[:blank:]]*$parm_key=" $parm_file 1>/dev/null
+
+  # Does the key already exist? If yes, subtitute the value.
+  if [ $? -eq 0 ]; then
+
+    echo "info: parameter $parm_key found, updating its value"
+
+    sed -E "s/(^[[:blank:]]*)$parm_key=(.*$)/$key_value/g" \
+      $parm_file > $parm_file_updated
+    if [ $? -ne 0 ]; then
+      exit 8
+    fi
+
+    # Copy the updated file. Make sure the cp knows it's text and does the
+    # correct conversion.
+    cp -T -O u $parm_file_updated $parm_file
+    if [ $? -ne 0 ]; then
+      exit 8
+    fi
+
+  # The key is new, add it to the parameter file.
+  elif [ $? -eq 1 ]; then
+
+    echo "info: parameter $parm_key not found, adding it as a new value"
+    echo $key_value >> $parm_file
+
+  else
+    exit 8
+  fi
+
+  exit 0
+)}
+
+#################################################
+# Clean up and print info/error messages upon
+# return from update_parmlib()
+#
+# Globals:
+#   TEMP_PARMLIB_MEMBER
+#   LINENO
+# Arguments:
+#   None
+# Returns:
+#   0 on success, 8 on error.
+#################################################
+handle_update_parmlib_exit() {
+
+  function_rc=$?
+  trap_rc=0
+
+  if [ $function_rc -eq 0 ]; then
+    echo "info: successfully updated $ZIS_PARMLIB($ZIS_PARMLIB_MEMBER)"
+    trap_rc=0
+  else
+    >&2 echo "error: script failed, RC = $function_rc"
+    trap_rc=8
+  fi
+
+  if [ -e $TEMP_PARMLIB_MEMBER ]; then
+    rm $TEMP_PARMLIB_MEMBER
+  fi
+
+  exit $trap_rc
+}
+
+#################################################
+# Update the ZIS PARMLIB member with the values
+# from the specified SAMPLIB file.
+#
+# Globals:
+#   ZIS_PARMLIB
+#   ZIS_PARMLIB_MEMBER
+#   TEMP_PARMLIB_MEMBER
+#   BASH_REMATCH
+# Arguments:
+#   $1 SAMPLIB file
+# Returns:
+#   0 on success, 8 on error.
+#################################################
+update_parmlib() {(
+
+  # Generate a name for the temporary PARMLIB file.
+  TEMP_PARMLIB_MEMBER=$(make_temp_filename)
+
+  # Setup out exit handler.
+  trap "handle_update_parmlib_exit" EXIT
+
+  # Copy the ZIS PARMLIB member to a temporary file.
+  cp -T "//'$ZIS_PARMLIB($ZIS_PARMLIB_MEMBER)'" $TEMP_PARMLIB_MEMBER
+  if [ $? -ne 0 ]; then
+    exit 8
+  fi
+
+
+  # Input parameters.
+  parm_file=$1
+
+  echo "info: updating $ZIS_PARMLIB($ZIS_PARMLIB_MEMBER) with the values from\
+  $parm_file"
+
+  # Go over the provided SAMPLIB file, pick key-value pairs and update the ZIS
+  # PARMLIB member with those new values.
+  while IFS= read -r line; do
+    key_value_pattern="^[[:blank:]]*[[:alnum:].]*[[:blank:]]*=\
+[[:blank:]]*[[:graph:]]*[[:blank:]]*$"
+    echo $line | grep $key_value_pattern 1>/dev/null
+    if [ $? -eq 0 ]; then
+      # Extract the key/value and update the PARMLIB.
+      echo $line | \
+        (
+          IFS='=' read key value ;
+          add_key_value_parm_to_parmlib $TEMP_PARMLIB_MEMBER $key $value
+        )
+      if [ $? -ne 0 ]; then
+        exit 8
+      fi
+    fi
+  done < $parm_file
+
+  # Copy the updated PARMLIB member back to the original location.
+  cp -T -O u -v $TEMP_PARMLIB_MEMBER "//'$ZIS_PARMLIB($ZIS_PARMLIB_MEMBER)'"
+  if [ $? -ne 0 ]; then
+    >&2  echo "error: failed to update PARMLIB. Make sure no running ZIS" \
+              "instance or any other process (e.g. ISPF Editor) has locked" \
+              "$ZIS_PARMLIB."
+    exit 8
+  fi
+
+  exit 0
+)}
+
+# Check the input parameters and print the help info if necessary.
+if [ "$#" -lt 1 ]
+then
+  1>&2 cat <<EOF
+Usage: $0 <samplib_file>
+Environment variables:
+        ZIS_PREFIX: install destination. The default value is $USER.DEV, if
+          ZIS_PREFIX is set, it overrides the default destination.
+        ZIS_PARMLIB: PARMLIB destination. The default value is
+          <ZIS_PREFIX>.PARMLIB. If ZIS_PARMLIB is set then it overrides
+          the default value.
+        ZIS_PARMLIB_MEMBER: PARMLIB member to be updated. The default value is
+          ZWESIP00. If ZIS_PARMLIB_MEMBER is set then it overrides the default
+          value.
+EOF
+  exit 8
+fi
+
+# Input parameters of the script.
+samplib_file=$1
+
+# Go update the ZIS PARMLIB member with the specified SAMPLIB file's values.
+update_parmlib $samplib_file
+exit $?
+
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+

--- a/bin/zis-plugin-install.sh
+++ b/bin/zis-plugin-install.sh
@@ -9,6 +9,7 @@
 
 ZIS_PREFIX=${ZIS_PREFIX:-$USER.DEV}
 ZIS_PARMLIB=${ZIS_PARMLIB:-$ZIS_PREFIX.PARMLIB}
+ZIS_PARMLIB_MEMBER=${ZIS_PARMLIB_MEMBER:-ZWESIP00}
 ZIS_LOADLIB=${ZIS_LOADLIB:-$ZIS_PREFIX.LOADLIB}
 
 mktemp1()
@@ -57,15 +58,15 @@ add-plugin-to-libs()
 
   trap "handle-failure" ERR
 
-  cp -T "//'$ZIS_PARMLIB(ZWESIP00)'" $TMPFILE
+  cp -T "//'$ZIS_PARMLIB($ZIS_PARMLIB_MEMBER)'" $TMPFILE
   trap "rm $TMPFILE" EXIT
 
   chmod go-rwx $TMPFILE
 
   if add-plugin-to-parmfile $TMPFILE
   then
-    >&2  echo "Updating $ZIS_PARMLIB(ZWESIP00)..."
-    cp -T -v $TMPFILE "//'$ZIS_PARMLIB(ZWESIP00)'"
+    >&2  echo "Updating $ZIS_PARMLIB($ZIS_PARMLIB_MEMBER)..."
+    cp -T -v $TMPFILE "//'$ZIS_PARMLIB($ZIS_PARMLIB_MEMBER)'"
   fi
   
   >&2 echo "Installing plugin $LMODFILE to $ZIS_LOADLIB($LMODNAME) and $ZIS_PARMLIB"
@@ -74,24 +75,171 @@ add-plugin-to-libs()
 
 trap "exit 1" ERR
 
-if [ "$#" -lt 2 ] 
-then
+#################################################
+# Deploy the load libraries into the ZIS LOADLIB.
+#
+# Globals:
+#   ZIS_LOADLIB
+# Arguments:
+#   $1 directory with the load libraries to be
+#      deployed
+# Returns:
+#   0 on success, 8 on error.
+#################################################
+deploy-loadlib() {
+
+  loadlib_dir=$1
+
+  cp -X -v $loadlib_dir/* "//'$ZIS_LOADLIB'"
+  if [ $? -ne 0 ]; then
+    >&2  echo "error: failed to update LOADLIB. Make sure no running ZIS" \
+              "instance or any other process (e.g. ISPF Editor) has locked" \
+               "$ZIS_LOADLIB."
+    return 8
+  fi
+
+  echo "info: copied load libraries from $loadlib_dir to $ZIS_LOADLIB"
+
+  return 0
+}
+
+#################################################
+# Deploy the sample libraries into the ZIS PARMLIB.
+#
+# Globals:
+#   None
+# Arguments:
+#   $1 directory with the sample libraries to be
+#      deployed
+# Returns:
+#   0 on success, 8 on error.
+#################################################
+deploy-samplib() {
+
+  samplib_dir=$1
+
+  for samp_file in $samplib_dir/*; do
+    sh zis-parmlib-update.sh $samp_file
+    if [ $? -ne 0 ]; then
+      return 8
+    fi
+  done
+
+  return 0
+}
+
+#################################################
+# Perform simple installation.
+#
+# Globals:
+#   None
+# Arguments:
+#   $1 plug-in load library to be installed
+# Returns:
+#   0 on success, 255 on error.
+#################################################
+handle-simple-install() {
+
+  LMODFILE=$1
+  PLUGINID=$2
+
+  LMODNAME=`basename $LMODFILE |tr a-z A-Z`
+
+  add-plugin-to-libs
+
+  return $?
+}
+
+#################################################
+# Perform extended installation.
+#
+# Globals:
+#   None
+# Arguments:
+#   $1 directory with the load libraries to be
+#      deployed
+#   $2 directory with the sample libraries to be
+#      deployed
+# Returns:
+#   0 on success, 8 on error.
+#################################################
+handle-extended-intall() {(
+
+  loadlib_dir=$1
+  samplib_dir=$2
+
+  deploy-loadlib $loadlib_dir
+  loadlib_rc=$?
+  if [ $loadlib_rc -ne 0 ]; then
+    return $loadlib_rc
+  fi
+
+  deploy-samplib $samplib_dir
+  samplib_rc=$?
+  if [ $samplib_rc -ne 0 ]; then
+    return $samplib_rc
+  fi
+
+  return 0
+)}
+
+print-usage() {
   >&2  cat <<EOF
 Usage: $0 <file> <plugin name>
+       $0 simple-install <file> <plugin name>
+       $0 extended-install <loadlib-directory> <samplib-directory>
 Environment variables: 
-        ZIS_PREFIX: default destination. <ZIS_PREFIX>.LOADLIB and <ZIS_PREFIX>.PARMLIB are used
-        if ZIS_PARMLIB is set then it overrides the parmlib
-        if ZIS_LOADLIB is set then it overrides the loadlib
+        ZIS_PREFIX: install destination. The default value is $USER.DEV, if
+          ZIS_PREFIX is set, it overrides the default destination.
+        ZIS_PARMLIB: PARMLIB destination. The default value is
+          <ZIS_PREFIX>.PARMLIB. If ZIS_PARMLIB is set then it overrides
+          the default value.
+        ZIS_PARMLIB_MEMBER: PARMLIB member to be updated. The default value is
+          ZWESIP00. If ZIS_PARMLIB_MEMBER is set then it overrides the default
+          value.
+        ZIS_LOADLIB: LOADLIB destination. The default value is
+          <ZIS_PREFIX>.LOADLIB. If ZIS_LOADLIB is set then it overrides
+          the default value.
 EOF
+}
+
+if [ "$#" -lt 2 ]; then
+  print-usage
   exit 1
 fi
 
-LMODFILE=$1
-PLUGINID=$2
+if [ $1 = "simple-install" ]; then
 
-LMODNAME=`basename $LMODFILE |tr a-z A-Z`
+  if [ "$#" -lt 3 ]; then
+    print-usage
+    exit 1
+  fi
 
-add-plugin-to-libs
+  handle-simple-install $2 $3
+  exit $?
+
+elif [ $1 = "extended-install" ]; then
+
+  if [ "$#" -lt 3 ]; then
+    print-usage
+    exit 1
+  fi
+
+  handle-extended-intall $2 $3
+  exit $?
+
+else
+
+  if [ "$#" -lt 2 ]; then
+    print-usage
+    exit 1
+  fi
+
+  # Handle simple-install, which is also the default behavior of the script.
+  handle-simple-install $1 $2
+  exit $?
+
+fi
 
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies


### PR DESCRIPTION
Changes:
* A new script has been added. It allows users to specify a SAMPLIB file with which they want to update their ZIS PARMLIB member.
* Adjust the existing ZIS plugin install script to have an "extended install" option for LOADLIB and SAMPLIB deployment.

Using the extended install option:
* Use have a directory with load libraries for ZIS (multiple plugins) called ```dev_load```
* Use have a directory with sample files for ZIS called ```dev_sample```
* Issue the following command:
```
./zis-plugin-install.sh extended-install ./dev_load ./dev_sample
```
* The script will copy the load libraries to the ZIS LOADLIB
* The script will update the ZIS PARMLIB member with the content of the sample files in ```dev_sample```
  * If a key-value pair exists in the ZIS PARMLIB member, the script will update the value
  * If a key-value pair doesn't exist in the ZIS PARMLIB member, the script will append it

Additional features:
* If a key-value pair in your sample file is defined using the shell variable syntax (e.g. ZWES.FOO.VERSION=$VER), the script will dereference environmental variable $VER and use that value to update the ZIS PARMLIB member