### PR TITLE
Fix ZIS debug mode activation

### DIFF
--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -1220,7 +1220,7 @@ static int getCMSConfigFlags(const ZISParmSet *zisParms) {
   }
 
   const char *debugValue = zisGetParmValue(zisParms, ZIS_PARM_DEBUG_MODE);
-  if (coldStartValue && strlen(coldStartValue) == 0) {
+  if (debugValue && strlen(debugValue) == 0) {
     flags |= CMS_SERVER_FLAG_DEBUG;
   }
 


### PR DESCRIPTION
A fix to activate debug mode using DEBUG parameter keyword for the ZWESIS01 program.