### PR TITLE
Add insightful port message

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -1107,7 +1107,10 @@ int main(int argc, char **argv){
       mainHttpLoop(server);
 
     } else{
-      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "server startup problem ret=%d reason=0x%x\n", returnCode, reasonCode);
+      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "Server startup problem ret=%d reason=0x%x\n", returnCode, reasonCode);
+      if (returnCode==1115) {
+        zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "This is usually due to the server port (%d) already being occupied. Is ZSS running twice?\n",port);
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

Before:
```
ZSS server settings: address=0.0.0.0, port=12224
Server startup problem ret=1115 reason=0x744c7247
```

After:
```
ZSS server settings: address=0.0.0.0, port=12224
Server startup problem ret=1115 reason=0x744c7247
This is usually due to the server port (12224) already being occupied. Is ZSS running twice?
```