### PR TITLE
Fix overwriting of environ variable due to strtok

### DIFF
--- a/c/envService.c
+++ b/c/envService.c
@@ -33,7 +33,7 @@ static bool startsWith(const char *pre, const char *str) {
     return lenstr < lenpre ? false : memcmp(pre, str, lenpre) == 0;
 }
 
-static void splitEnvKeyValue(char buf[], char* array[]) {
+static char* splitEnvKeyValue(char buf[], char* array[]) {
   char *bufCpy;
   if(buf != NULL){
     int bufferLen = strlen(buf);
@@ -42,6 +42,7 @@ static void splitEnvKeyValue(char buf[], char* array[]) {
     array[0] = strtok (bufCpy, "=");
     array[1] = strtok (NULL, "=");
   }
+  return bufCpy;
 }
 
 static char* returnJSONRow(const char* key, const char* val) {
@@ -88,7 +89,7 @@ static JsonObject *envVarsToObject(const char *prefix) {
   while(environ[i] != NULL)
   {
     if(startsWith(prefix, environ[i])) {
-      splitEnvKeyValue(environ[i], array);
+      char* buffer = splitEnvKeyValue(environ[i], array);
       if(array[1]!=NULL) {
         j++;
         foo = returnJSONRow(array[0], array[1]);
@@ -100,6 +101,7 @@ static JsonObject *envVarsToObject(const char *prefix) {
           free(foo);
         }
       }
+      free(buffer);
     }
     i++;
   }

--- a/c/envService.c
+++ b/c/envService.c
@@ -133,7 +133,26 @@ JsonObject *readEnvSettings(const char *prefix) {
 
 /*int main(int argc, char *argv[])
 {
-    JsonObject *envSettings=envVarsToObject("ZWED");
+    JsonObject *envSettings = envVarsToObject("ZWED");
+    JsonObject *envSettingsDup = envVarsToObject("ZWED");
+    JsonProperty *currentPropOrig = jsonObjectGetFirstProperty(envSettings);
+    JsonProperty *currentPropDup = jsonObjectGetFirstProperty(envSettingsDup);
+    //this loop tests whether the length of each JsonObject is the same
+    while (currentPropOrig != NULL) {
+      if (currentPropDup == NULL) {
+        printf("EXTERN CHAR **ENVRION TEST FAILED\n");
+        break;
+      }
+      if ((jsonObjectGetNextProperty(currentPropOrig) == NULL
+            && jsonObjectGetNextProperty(currentPropDup) != NULL)
+            || (jsonObjectGetNextProperty(currentPropOrig) != NULL
+            && jsonObjectGetNextProperty(currentPropDup) == NULL)) {
+        printf("EXTERN CHAR **ENVRION TEST FAILED\n");
+        break;
+      }
+      currentPropDup = jsonObjectGetNextProperty(currentPropDup);
+      currentPropOrig = jsonObjectGetNextProperty(currentPropOrig);
+    }
     printf("Port: %d\n", jsonObjectGetNumber(envSettings, "ZWED_AGENT_PORT"));
     printf("Plugin Dir: %s\n", jsonObjectGetString(envSettings, "ZWED_PLUGIN_PATH"));
     printf("TRUE TEST: %s\n", jsonObjectGetBoolean(envSettings, "ZWED_BOOLEAN_TRUE_TEST")? "true":"false");

--- a/c/envService.c
+++ b/c/envService.c
@@ -34,8 +34,14 @@ static bool startsWith(const char *pre, const char *str) {
 }
 
 static void splitEnvKeyValue(char buf[], char* array[]) {
-  array[0] = strtok (buf, "=");
-  array[1] = strtok (NULL, "=");
+  char *bufCpy;
+  if(buf != NULL){
+    int bufferLen = strlen(buf);
+    bufCpy = safeMalloc(bufferLen + 1, "buffer copy");
+    memcpy(bufCpy, buf, bufferLen);
+    array[0] = strtok (bufCpy, "=");
+    array[1] = strtok (NULL, "=");
+  }
 }
 
 static char* returnJSONRow(const char* key, const char* val) {


### PR DESCRIPTION
This pull request fixes the following bug:

- GET requests to /server/agent/environment missing environment variables

This was due to the use of strtok which replaces each matched delimiter with a null term, thus making the "environ" global var unusable after a single successful iteration.