### PR TITLE
Added Support for Changing Log Levels via REST API

### DIFF
--- a/build/build_zss.sh
+++ b/build/build_zss.sh
@@ -123,8 +123,9 @@ c89 \
   ${ZSS}/c/zosDiscovery.c \
   ${ZSS}/c/securityService.c \
   ${ZSS}/c/zis/client.c \
-  ${ZSS}/c/serverStatusService.c
-
+  ${ZSS}/c/serverStatusService.c \
+  ${ZSS}/c/rasService.c
+  
 extattr +p ${ZSS}/bin/zssServer
 
 echo "Build successfull"

--- a/h/rasService.h
+++ b/h/rasService.h
@@ -18,6 +18,7 @@
 #define CLIENT_TRACE_LEVEL_FINER    4
 #define CLIENT_TRACE_LEVEL_FINEST   5
 
+int installRASService(HttpServer *server);
 
 /*
   This program and the accompanying materials are


### PR DESCRIPTION
We used to use, "rasService.c", but we don't anymore. I have a dire need to change the logging levels of data services while zss is running, so I added support for that in the process.

https://github.com/zowe/zowe-common-c/pull/136

To test via Postman:

Retrieve current logging level:
GET {host}:{port}/ras/traceLevel?componentName={plugin_id}:{dataservice_name}

Set new logging level:
PUT {host}:{port}/ras/traceLevel?componentName={plugin_id}:{dataservice_name}&level={0-5}