### PR TITLE
Pick up ZIS version information during the build process.

### DIFF
--- a/build/build_zis.sh
+++ b/build/build_zis.sh
@@ -23,7 +23,17 @@ echo "**************************************************************************
 echo "Building ZIS..."
 
 mkdir -p "${WORKING_DIR}/tmp-zis" && cd "$_"
+
+IFS='.' read -r major minor micro < "${ZSS}/version.txt"
+date_stamp=$(date +%Y%m%d)
+echo "Version: $major.$minor.$micro"
+echo "Date stamp: $date_stamp"
+
 xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
+  -DZIS_MAJOR_VERSION="$major" \
+  -DZIS_MINOR_VERSION="$minor" \
+  -DZIS_REVISION="$micro" \
+  -DZIS_VERSION_DATE_STAMP="$date_stamp" \
   -DRADMIN_XMEM_MODE \
   -DRCVR_CPOOL_STATES \
   -qreserved_reg=r12 \

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -1038,8 +1038,16 @@ static void initLoggin() {
 }
 
 static void printStartMessage() {
-  wtoPrintf(ZIS_LOG_STARTUP_MSG);
-  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, ZIS_LOG_STARTUP_MSG);
+  wtoPrintf(ZIS_LOG_STARTUP_MSG,
+            ZIS_MAJOR_VERSION,
+            ZIS_MINOR_VERSION,
+            ZIS_REVISION,
+            ZIS_VERSION_DATE_STAMP);
+  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, ZIS_LOG_STARTUP_MSG,
+          ZIS_MAJOR_VERSION,
+          ZIS_MINOR_VERSION,
+          ZIS_REVISION,
+          ZIS_VERSION_DATE_STAMP);
 }
 
 static void printStopMessage(int status) {

--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -30,9 +30,9 @@
 /* keep this in sync with the default messages IDs from crossmemory.h and zssLogging.h */
 #define ZIS_LOG_STARTUP_MSG_ID                  ZIS_MSG_PRFX"0001I"
  #ifdef CROSS_MEMORY_SERVER_DEBUG
-  #define ZIS_LOG_STARTUP_MSG_TEXT              "ZSS Cross-Memory Server starting in debug mode, version is "ZIS_VERSION"\n"
+  #define ZIS_LOG_STARTUP_MSG_TEXT              "ZSS Cross-Memory Server starting in debug mode, version is %d.%d.%d+%d\n"
  #else
-  #define ZIS_LOG_STARTUP_MSG_TEXT              "ZSS Cross-Memory Server starting, version is "ZIS_VERSION"\n"
+  #define ZIS_LOG_STARTUP_MSG_TEXT              "ZSS Cross-Memory Server starting, version is %d.%d.%d+%d\n"
  #endif
 #define ZIS_LOG_STARTUP_MSG                     ZIS_LOG_STARTUP_MSG_ID" "ZIS_LOG_STARTUP_MSG_TEXT
 
@@ -111,7 +111,7 @@
 /* ZIS AUX messages */
 
 #define ZISAUX_LOG_STARTUP_MSG_ID               ZIS_MSG_PRFX"0050I"
-#define ZISAUX_LOG_STARTUP_MSG_TEXT             "ZIS AUX Server starting, version is %s"
+#define ZISAUX_LOG_STARTUP_MSG_TEXT             "ZIS AUX Server starting, version is %d.%d.%d+%d"
 #define ZISAUX_LOG_STARTUP_MSG                  ZISAUX_LOG_STARTUP_MSG_ID" "ZISAUX_LOG_STARTUP_MSG_TEXT
 
 #define ZISAUX_LOG_TERM_OK_MSG_ID               ZIS_MSG_PRFX"0051I"

--- a/h/zis/version.h
+++ b/h/zis/version.h
@@ -13,7 +13,21 @@
 #ifndef ZIS_VERSION_H_
 #define ZIS_VERSION_H_
 
-#define ZIS_VERSION "1.9.0"
+#ifndef ZIS_MAJOR_VERSION
+#define ZIS_MAJOR_VERSION 0
+#endif
+
+#ifndef ZIS_MINOR_VERSION
+#define ZIS_MINOR_VERSION 0
+#endif
+
+#ifndef ZIS_REVISION
+#define ZIS_REVISION 0
+#endif
+
+#ifndef ZIS_VERSION_DATE_STAMP
+#define ZIS_VERSION_DATE_STAMP 0
+#endif
 
 #endif /* ZIS_VERSION_H_ */
 

--- a/zis-aux/include/aux-host.h
+++ b/zis-aux/include/aux-host.h
@@ -5,6 +5,7 @@
 #include "crossmemory.h"
 #include "resmgr.h"
 #include "zis/parm.h"
+#include "zis/version.h"
 
 #include "aux-manager.h"
 #include "aux-utils.h"
@@ -17,7 +18,10 @@
 #error Non-metal C code is not supported
 #endif
 
-#define ZISAUX_VERSION "1.9.0"
+#define ZISAUX_MAJOR_VERSION        ZIS_MAJOR_VERSION
+#define ZISAUX_MINOR_VERSION        ZIS_MINOR_VERSION
+#define ZISAUX_REVISION             ZIS_REVISION
+#define ZISAUX_VERSION_DATE_STAMP   ZIS_VERSION_DATE_STAMP
 
 typedef struct ZISAUXContext_tag {
 

--- a/zis-aux/src/aux-host.c
+++ b/zis-aux/src/aux-host.c
@@ -60,8 +60,11 @@ static void initLogging(void) {
 }
 
 static void printStartMessage(void) {
-  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO,
-          ZISAUX_LOG_STARTUP_MSG, ZISAUX_VERSION);
+  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, ZISAUX_LOG_STARTUP_MSG,
+          ZISAUX_MAJOR_VERSION,
+          ZISAUX_MINOR_VERSION,
+          ZISAUX_REVISION,
+          ZISAUX_VERSION_DATE_STAMP);
 }
 
 static void printStopMessage(void) {


### PR DESCRIPTION
**Overview**
Currently, ZIS doesn't use the version information provided in `zss/version.txt`. The ZIS and AUX versions are updated manually but not during every build. This leads to the wrong version infomation in the log. This pull-request changes the ZIS build to use version.txt the same way ZSS uses it.

New versions in the ZIS and AUX logs:
```
MSGID     MSGTEXT                                                     
ZWES0001I ZSS Cross-Memory Server starting, version is 1.12.0+20200518
ZWES0002I Input parameters at 0x6FE6:                                 
...
MSGID     MSGTEXT                                                                        
ZWES0050I ZIS AUX Server starting, version is 1.12.0+20200518                            
IZPP0013I Consumer group name is not specified, using the cross-memory name as group name
...
```
