### PR TITLE
ZIS dev mode

### DIFF
--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -76,7 +76,16 @@ See details in the ZSS Cross Memory Server installation guide
 #define ZIS_PARM_CHECKAUTH                    CMS_PROD_ID".CHECKAUTH"
   #define ZIS_PARM_CHECKAUTH_VALUE_ON           "YES"
 
+#define ZIS_PARM_DEV_MODE                     CMS_PROD_ID".DEV_MODE"
+#define ZIS_PARM_DEV_MODE_LPA                 CMS_PROD_ID".DEV_MODE.LPA"
+  #define ZIS_PARM_DEV_MODE_ON                  "YES"
+
 #define ZIS_PARMLIB_PARM_SERVER_NAME          CMS_PROD_ID".NAME"
+
+/* Check this for backward compatibility with the compile-time dev mode. */
+#ifndef ZIS_LPA_DEV_MODE
+#define ZIS_LPA_DEV_MODE 0
+#endif
 
 static int zisRouteService(struct CrossMemoryServerGlobalArea_tag *globalArea,
                            struct CrossMemoryService_tag *service,
@@ -322,12 +331,16 @@ static int cleanPluginAnchor(ZISPluginAnchor *anchor) {
   return RC_ZIS_OK;
 }
 
+static int removePluginFromLPAIfNeeded(ZISContext *context,
+                                       ZISPluginAnchor *anchor);
+
 static void cleanPlugins(ZISContext *context) {
 
   ZISServerAnchor *serverAnchor = context->zisAnchor;
   ZISPluginAnchor *currPlugin = serverAnchor->firstPlugin;
   while (currPlugin != NULL) {
     cleanPluginAnchor(currPlugin);
+    removePluginFromLPAIfNeeded(context, currPlugin);
     currPlugin = currPlugin->next;
   }
 
@@ -567,7 +580,13 @@ static int installServices(ZISContext *context, ZISPlugin *plugin,
   return RC_ZIS_OK;
 }
 
-static int relocatePluginToLPAIfNeeded(ZISPlugin **pluginAddr,
+static bool isLPADevMode(const ZISContext *context) {
+  int devFlags = CMS_SERVER_FLAG_DEV_MODE_LPA | CMS_SERVER_FLAG_DEV_MODE;
+  return (context->cmsFlags & devFlags) || ZIS_LPA_DEV_MODE;
+}
+
+static int relocatePluginToLPAIfNeeded(ZISContext *context,
+                                       ZISPlugin **pluginAddr,
                                        ZISPluginAnchor *anchor,
                                        EightCharString moduleName) {
 
@@ -577,6 +596,8 @@ static int relocatePluginToLPAIfNeeded(ZISPlugin **pluginAddr,
 
   if (lpaPresent) {
 
+    bool lpaDiscarded = false;
+
     if (anchor->pluginVersion != plugin->pluginVersion) {
 
       zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING,
@@ -585,10 +606,14 @@ static int relocatePluginToLPAIfNeeded(ZISPlugin **pluginAddr,
       zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING,
                (char *)&anchor->moduleInfo, sizeof(LPMEA));
 
-#ifdef ZIS_LPA_DEV_MODE
+      lpaDiscarded = true;
+    }
+
+    if (isLPADevMode(context)) {
 
       zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
-              " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE\n");
+              " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of "
+              "\'%8.8s\'\n", anchor->moduleInfo.inputInfo.name);
 
       int lpaRSN = 0;
       int lpaRC = lpaDelete(&anchor->moduleInfo, &lpaRSN);
@@ -597,12 +622,14 @@ static int relocatePluginToLPAIfNeeded(ZISPlugin **pluginAddr,
                 "DELETE", anchor->moduleInfo.inputInfo.name, lpaRC, lpaRSN);
         return RC_ZIS_ERROR;
       }
-#endif
+
+      lpaDiscarded = true;
+    }
+
+    if (lpaDiscarded) {
       memset(&anchor->moduleInfo, 0, sizeof(anchor->moduleInfo));
       anchor->flags &= ~ZIS_PLUGIN_ANCHOR_FLAG_LPA;
       lpaPresent = false;
-    }  else {
-      lpaPresent = true;
     }
 
   }
@@ -632,6 +659,37 @@ static int relocatePluginToLPAIfNeeded(ZISPlugin **pluginAddr,
         (ZISPluginDescriptorFunction *)((int)ep & 0xFFFFFFFE);
 
     *pluginAddr = getPluginDescriptor();
+
+  }
+
+  return RC_ZIS_OK;
+}
+
+static int removePluginFromLPAIfNeeded(ZISContext *context,
+                                       ZISPluginAnchor *anchor) {
+
+  bool lpaPresent = anchor->flags & ZIS_PLUGIN_ANCHOR_FLAG_LPA ? true : false;
+
+  if (lpaPresent) {
+
+    if (isLPADevMode(context)) {
+
+      zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
+              " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of "
+              "\'%8.8s\'\n", anchor->moduleInfo.inputInfo.name);
+
+      int lpaRSN = 0;
+      int lpaRC = lpaDelete(&anchor->moduleInfo, &lpaRSN);
+      if (lpaRC != 0) {
+        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, ZIS_LOG_LPA_FAILURE_MSG,
+                "DELETE", anchor->moduleInfo.inputInfo.name, lpaRC, lpaRSN);
+        return RC_ZIS_ERROR;
+      }
+
+      memset(&anchor->moduleInfo, 0, sizeof(anchor->moduleInfo));
+      anchor->flags &= ~ZIS_PLUGIN_ANCHOR_FLAG_LPA;
+      lpaPresent = false;
+    }
 
   }
 
@@ -696,7 +754,8 @@ static int installPlugin(ZISContext *context, ZISPlugin *plugin,
     context->zisAnchor->firstPlugin = anchor;
   }
 
-  int relocateRC = relocatePluginToLPAIfNeeded(&plugin, anchor, moduleName);
+  int relocateRC = relocatePluginToLPAIfNeeded(context, &plugin, anchor,
+                                               moduleName);
   if (relocateRC != RC_ZIS_OK) {
     return relocateRC;
   }
@@ -1107,6 +1166,7 @@ static int cleanupServer(CrossMemoryServerGlobalArea *ga, void *userData) {
   ZISContext *context = userData;
 
   terminatePlugins(context);
+  cleanPlugins(context);
 
 #ifdef ZIS_DEV_MODE
   destroyServiceTable(context);
@@ -1244,6 +1304,16 @@ static int getCMSConfigFlags(const ZISParmSet *zisParms) {
     flags |= CMS_SERVER_FLAG_CHECKAUTH;
   }
 
+  const char *devMode = zisGetParmValue(zisParms, ZIS_PARM_DEV_MODE);
+  if (devMode && !strcmp(devMode, ZIS_PARM_DEV_MODE_ON)) {
+    flags |= CMS_SERVER_FLAG_DEV_MODE;
+  }
+
+  const char *lpaDevMode = zisGetParmValue(zisParms, ZIS_PARM_DEV_MODE_LPA);
+  if (lpaDevMode && !strcmp(lpaDevMode, ZIS_PARM_DEV_MODE_ON)) {
+    flags |= CMS_SERVER_FLAG_DEV_MODE_LPA;
+  }
+
   return flags;
 }
 
@@ -1308,11 +1378,11 @@ static CrossMemoryServerName getCMServerName(const ZISParmSet *zisParms) {
 static int initCoreServer(ZISContext *context) {
 
   CrossMemoryServerName serverName = getCMServerName(context->parms);
-  unsigned int cmsFlags = getCMSConfigFlags(context->parms);
+  context->cmsFlags = getCMSConfigFlags(context->parms);
   int makeServerRSN = 0;
   CrossMemoryServer *cmServer = makeCrossMemoryServer2(context->stcBase,
                                                        &serverName,
-                                                       cmsFlags,
+                                                       context->cmsFlags,
                                                        initServer,
                                                        cleanupServer,
                                                        handleModifyCommands,

--- a/h/zis/server.h
+++ b/h/zis/server.h
@@ -30,6 +30,7 @@ typedef struct ZISContext_tag {
   CrossMemoryServerGlobalArea *cmsGA;
   struct ZISServerAnchor_tag *zisAnchor;
   struct ZISPlugin_tag *firstPlugin;
+  int cmsFlags;
 } ZISContext;
 
 typedef struct ZISServerAnchor_tag {

--- a/samplib/zis/ZWESIP00
+++ b/samplib/zis/ZWESIP00
@@ -45,6 +45,15 @@
 //*         WILL REFRESH THE PROFILES AFTER ANY PROFILE              */
 //*         OPERATION IN THE CLASS FROM ZWES.SECMGMT.CLASS.          */
 //*         THE DEFAULT VALUE IS NO.                                 */
+//*     DEV_MODE - DEVELOPMENT MODE. IF SET TO YES, ENABLES ALL THE  */
+//*         DEVELOPMENT MODES LISTED BELOW.                          */
+//*     DEV_MODE.LPA - LPA DEVELOPMENT MODE. IF SET TO YES, IT       */
+//*         FORCES THE SERVER TO REMOVE ALL THE MODULES FROM LPA     */
+//*         UPON TERMINATION AND REFRESH ALL THE MODULES IN LPA      */
+//*         AT START UP. THIS MODE MUST NEVER BE USED IN PRODUCTION  */
+//*         AS IT MAY AFFECT THE CALLERS OF THE CROSS-MEMORY SERVER. */
+//*         USE THIS MODE TO DECREASE THE MEMORY FOOTPRINT DURING    */
+//*         DEVELOPMENT.                                             */
 //*                                                                  */
 //********************************************************************/
 


### PR DESCRIPTION
**This pull-request depends on zowe/zowe-common-c#140**

**Overview**

This pull-request adds new config options to enable the dev mode and LPA dev mode. The dev mode only includes the LPA dev mode at the moment.
```
ZWES.DEV_MODE=YES
ZWES.DEV_MODE.LPA=YES
```

Additionally to the new way of handling ZWESIS01 from zowe/zowe-common-c#140, in the LPA dev mode, the plugin modules will be refreshed at start up and removed upon termination.
This should make the memory footprint smaller in a development environment.

If the new run-time mode is enabled, a warning message will be issued to
the SYSLOG and SYSPRINT logs.
