### PR TITLE
 Make ZSS build fail when RC != 0

### DIFF
--- a/build/build_zss.sh
+++ b/build/build_zss.sh
@@ -29,6 +29,8 @@ date_stamp=$(date +%Y%m%d)
 echo "Version: $major.$minor.$micro"
 echo "Date stamp: $date_stamp"
 
+export _C89_ACCEPTABLE_RC=0
+
 c89 \
   -c -O2 \
   -DPRODUCT_MAJOR_VERSION="$major" \
@@ -62,7 +64,7 @@ c89 \
   -DAPF_AUTHORIZED=0 \
   -Wc,dll,expo,langlvl\(extc99\),gonum,goff,hgpr,roconst,ASM,asmlib\('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN'\) \
   -Wc,agg,exp,list\(\),so\(\),off,xref \
-  -Wl,ac=1 \
+  -Wl,ac=1,dll \
   -I ${COMMON}/h \
   -I ${COMMON}/jwt/jwt \
   -I ${COMMON}/jwt/rscrypto \


### PR DESCRIPTION
**Overview**

Currently, if a warning message is produced by the compiler, the build process is considered successful. This is often dangerous as warnings may mean passing the wrong type or redefinition of a `#define`, which should be considered bugs. The pull-requests makes the build process stricter - any warning messages will now lead to a failing build.

**Changes**
* Make sure there are no warning messages in the current build
  * Update deps to remove the httpfileservice.c warning message, and pick up a minor type fix
  * Ensure side-deck file/SYSDEFSD DD by adding the dll option to the linker
* Adjust the compiler env variable controlling the severity
* Ensure no ZSS binary is created if RC != 0