### PR TITLE
Do not attempt to start ZSS if not on z/OS

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -21,5 +21,10 @@
 # - ZOWE_ZLUX_TELNET_PORT
 # - ZOWE_ZLUX_SECURITY_TYPE
 
-cd ${ROOT_DIR}/components/zss/bin
-./zssServer.sh
+OSNAME=$(uname -I)
+if [[ "${OSNAME}" == "z/OS" ]]; then
+  cd ${ROOT_DIR}/components/zss/bin
+  ./zssServer.sh
+else
+  echo "Zowe ZSS server is unsupported on ${OSNAME}. Supported systems: z/OS"
+fi

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -21,10 +21,10 @@
 # - ZOWE_ZLUX_TELNET_PORT
 # - ZOWE_ZLUX_SECURITY_TYPE
 
-OSNAME=$(uname -I)
-if [[ "${OSNAME}" == "z/OS" ]]; then
+OSNAME=$(uname)
+if [[ "${OSNAME}" == "OS/390" ]]; then
   cd ${ROOT_DIR}/components/zss/bin
   ./zssServer.sh
 else
-  echo "Zowe ZSS server is unsupported on ${OSNAME}. Supported systems: z/OS"
+  echo "Zowe ZSS server is unsupported on ${OSNAME}. Supported systems: OS/390"
 fi


### PR DESCRIPTION
This pull request implements the following feature:
- ZSS server will not attempt to start in unsupported environments