### PR TITLE
Agent API: Allow to see limited info without authentication

### DIFF
--- a/c/serverStatusService.c
+++ b/c/serverStatusService.c
@@ -57,6 +57,7 @@ EXSMFI *smfFunc;
 void installServerStatusService(HttpServer *server, JsonObject *serverSettings, char* productVer) {
   HttpService *httpService = makeGeneratedService("Server_Status_Service", "/server/agent/**");
   httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  httpService->authFlags |= SERVICE_AUTH_FLAG_OPTIONAL;
   httpService->serviceFunction = &serveStatus;
   httpService->runInSubtask = TRUE;
   httpService->doImpersonation = TRUE;
@@ -84,14 +85,14 @@ int respondWithServerConfig(HttpResponse *response, JsonObject* config) {
   return 0;
 }
 
-int respondWithServerRoutes(HttpResponse *response, bool rbacEnabled) {
+int respondWithServerRoutes(HttpResponse *response, bool allowFullAccess) {
   jsonPrinter *out = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
   setDefaultJSONRESTHeaders(response);
   writeHeader(response);
   jsonStart(out);
   jsonStartArray(out, "links");
-  if (rbacEnabled) {
+  if (allowFullAccess) {
     jsonStartObject(out, NULL);
     jsonAddString(out, "href", "/server/agent/config");
     jsonAddString(out, "rel", "config");
@@ -142,7 +143,7 @@ int respondWithLogLevels(HttpResponse *response, ServerAgentContext *context) {
 #ifndef HOST_NAME_MAX
 #define HOST_NAME_MAX 256
 #endif
-int respondWithServerEnvironment(HttpResponse *response, ServerAgentContext *context, bool rbacEnabled) {
+int respondWithServerEnvironment(HttpResponse *response, ServerAgentContext *context, bool allowFullAccess) {
   /*Information about parameters for smf_unc: https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.erbb700/smfp.htm#smfp*/
   extern char **environ;
   struct utsname unameRet;
@@ -194,7 +195,7 @@ int respondWithServerEnvironment(HttpResponse *response, ServerAgentContext *con
   setDefaultJSONRESTHeaders(response);
   writeHeader(response);
   jsonStart(out);
-  if (rbacEnabled) {
+  if (allowFullAccess) {
     if (ctime_r(&ltime, tstamp) != NULL) {
       if (tstamp[strlen(tstamp) - 1] != '\0') {
         tstamp[strlen(tstamp) - 1] = '\0';
@@ -213,7 +214,7 @@ int respondWithServerEnvironment(HttpResponse *response, ServerAgentContext *con
   jsonAddString(out, "osRelease", unameRet.release);
   jsonAddString(out, "osVersion", unameRet.version);
   jsonAddString(out, "hardwareIdentifier", unameRet.machine);
-  if (rbacEnabled) {
+  if (allowFullAccess) {
     jsonAddString(out, "hostname", hostnameBuffer);
     jsonAddString(out, "nodename", unameRet.nodename);
     jsonStartObject(out, "userEnvironment");
@@ -271,7 +272,7 @@ static int respondWithServices(HttpResponse *response, HttpServer *server) {
   return 0;
 }
 
-static bool statusEndPointRequireRBAC(const char *endpoint) {
+static bool statusEndPointRequireAuthAndRBAC(const char *endpoint) {
   return !strcmp(endpoint, "config") ||
          !strcmp(endpoint, "log") ||
          !strcmp(endpoint, "logLevels");
@@ -281,17 +282,25 @@ static int serveStatus(HttpService *service, HttpResponse *response) {
   HttpRequest *request = response->request;
   ServerAgentContext *context = service->userPointer;
   //This service is conditional on RBAC being enabled because it is a 
-  //sensitive URL that only RBAC authorized users should be able to access
+  //sensitive URL that only RBAC authorized users should be able to get full access
   JsonObject *dataserviceAuth = jsonObjectGetObject(context->serverConfig, "dataserviceAuthentication");
   int rbacParm = jsonObjectGetBoolean(dataserviceAuth, "rbac");
+  int isAuthenticated = response->request->authenticated;
+  bool allowFullAccess = isAuthenticated && rbacParm;
   if (!strcmp(request->method, methodGET)) {
     char *l1 = stringListPrint(request->parsedFile, 2, 1, "/", 0);
-    if (!rbacParm && statusEndPointRequireRBAC(l1)) {
-      respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Set dataserviceAuthentication.rbac to true in server configuration");
-      return -1;
+    if (!allowFullAccess && statusEndPointRequireAuthAndRBAC(l1)) {
+      if (!isAuthenticated) {
+        respondWithError(response, HTTP_STATUS_UNAUTHORIZED, "Not Authorized");
+        return -1;
+      }
+      if (!rbacParm) {
+        respondWithError(response, HTTP_STATUS_BAD_REQUEST, "Set dataserviceAuthentication.rbac to true in server configuration");
+        return -1;
+      }
     }
     if (!strcmp(l1, "")) {
-      return respondWithServerRoutes(response, rbacParm);
+      return respondWithServerRoutes(response, allowFullAccess);
     } else if (!strcmp(l1, "config")) {
       return respondWithServerConfig(response, context->serverConfig);
     } else if (!strcmp(l1, "log")) {
@@ -306,7 +315,7 @@ static int serveStatus(HttpService *service, HttpResponse *response) {
     } else if (!strcmp(l1, "logLevels")) {
       return respondWithLogLevels(response, context);
     } else if (!strcmp(l1, "environment")) {
-      return respondWithServerEnvironment(response, context, rbacParm);
+      return respondWithServerEnvironment(response, context, allowFullAccess);
     } else if (!strcmp(l1, "services")) {
       return respondWithServices(response, service->server);
     } else {


### PR DESCRIPTION
Agent API: Allow to see limited info without authentication:

- /server/agent/environment (limited info)
- /server/agent/services

This PR depends on https://github.com/zowe/zowe-common-c/pull/162