### PR TITLE
Get true Operating System info

### DIFF
--- a/c/serverStatusService.c
+++ b/c/serverStatusService.c
@@ -153,7 +153,10 @@ int respondWithServerEnvironment(HttpResponse *response, ServerAgentContext *con
   int subtype = 0x00000009; //SMF record subtype
   int bufferlen = 716800; // Yes the SMF buffer is actually 700Kb roughly
   int cpuUtil = 0, demandPaging = 0, options = 0, mvsSrm = 0, zaapUtil = 0, ziipUtil = 0;
-  uname(&unameRet);
+  if (__osname(&unameRet) < 0) {
+    respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Falied to retrieve operating system info");
+    return -1;
+  }
   gethostname(hostnameBuffer, sizeof(hostnameBuffer));
   buffer = (char *)safeMalloc(bufferlen, "buffer");
   if (buffer == NULL) {

--- a/c/serverStatusService.c
+++ b/c/serverStatusService.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <errno.h>
 #endif
 #include <sys/utsname.h>
 
@@ -154,6 +155,9 @@ int respondWithServerEnvironment(HttpResponse *response, ServerAgentContext *con
   int bufferlen = 716800; // Yes the SMF buffer is actually 700Kb roughly
   int cpuUtil = 0, demandPaging = 0, options = 0, mvsSrm = 0, zaapUtil = 0, ziipUtil = 0;
   if (__osname(&unameRet) < 0) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG,
+            "Falied to retrieve operating system info, errno=%d - %s",
+            errno, strerror(errno));
     respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Falied to retrieve operating system info");
     return -1;
   }


### PR DESCRIPTION
This PR replaces a call to [uname](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.1.0/com.ibm.zos.v2r1.bpxbd00/rtuna.htm) with [__osname](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.bpxbd00/osnm.htm). `__osname` returns true operation system information, which is easier to interpret. For example:

- `uname`:

```json
{
 "arch": "OS/390",
 "osRelease": "27.00",
 "osVersion": "04",
 "hardwareIdentifier": "8561"
}
```

- `__osname`:

```json
{
  "arch": "z/OS",
  "osRelease": "04.00",
  "osVersion": "02",
  "hardwareIdentifier": "8561"
}
```