### PR TITLE
Allow AUX to run as a non-reusable address space

### DIFF
--- a/zis-aux/include/aux-manager.h
+++ b/zis-aux/include/aux-manager.h
@@ -72,6 +72,9 @@ typedef struct ZISAUXParm_tag {
   char value[200];
 } ZISAUXParm;
 
+#define ZIS_AUX_FLAG_NONE         0x00000000
+#define ZIS_AUX_FLAG_REUSASID_NO  0x00000001
+
 ZOWE_PRAGMA_PACK_RESET
 
 #ifndef __LONGNAME__
@@ -80,6 +83,7 @@ ZOWE_PRAGMA_PACK_RESET
 #define zisauxMgrClean ZISAMCL
 #define zisauxMgrSetHostSTC ZISAMHS
 #define zisauxMgrStartGuest ZISAMST
+#define zisauxMgrStartGuest2 ZISAMST2
 #define zisauxMgrStopGuest ZISAMSP
 #define zisauxMgrInitCommand ZISAICMD
 #define zisauxMgrCleanCommand ZISACCMD
@@ -111,6 +115,14 @@ int zisauxMgrStartGuest(ZISAUXManager *mgr,
                         ZISAUXModule guestModuleName,
                         const ZISAUXParm *guestParm,
                         int *reasonCode, int traceLevel);
+
+int zisauxMgrStartGuest2(ZISAUXManager *mgr,
+                         ZISAUXNickname guestNickname,
+                         ZISAUXModule guestModuleName,
+                         const ZISAUXParm *guestParm,
+                         int flags,
+                         int *reasonCode,
+                         int traceLevel);
 
 int zisauxMgrStopGuest(ZISAUXManager *mgr,
                        ZISAUXNickname guestNickname,

--- a/zis-aux/src/aux-manager.c
+++ b/zis-aux/src/aux-manager.c
@@ -145,6 +145,29 @@ int zisauxMgrStartGuest(ZISAUXManager *mgr,
                         const ZISAUXParm *guestParm,
                         int *reasonCode, int traceLevel) {
 
+  return zisauxMgrStartGuest2(mgr, guestNickname, guestModuleName, guestParm,
+                              ZIS_AUX_FLAG_NONE, reasonCode, traceLevel);
+}
+
+static uint32_t makeASCREAttributes(int auxFlags) {
+
+  uint32_t attributes = AS_ATTR_NOSWAP;
+
+  if (!(auxFlags & ZIS_AUX_FLAG_REUSASID_NO)) {
+    attributes |= AS_ATTR_REUSASID;
+  }
+
+  return attributes;
+}
+
+int zisauxMgrStartGuest2(ZISAUXManager *mgr,
+                         ZISAUXNickname guestNickname,
+                         ZISAUXModule guestModuleName,
+                         const ZISAUXParm *guestParm,
+                         int flags,
+                         int *reasonCode,
+                         int traceLevel) {
+
   if (memcmp(mgr->eyecatcher, ZISAUX_MGR_EYECATCHER,
              sizeof(mgr->eyecatcher))) {
     return RC_ZISAUX_BAD_EYECATCHER;
@@ -179,7 +202,7 @@ int zisauxMgrStartGuest(ZISAUXManager *mgr,
 
  ASOutputData asCreateResult = {0};
  int startRC = 0, startRSN = 0;
- uint32_t ascreAttributes = AS_ATTR_NOSWAP | AS_ATTR_REUSASID;
+ uint32_t ascreAttributes = makeASCREAttributes(flags);
  startRC = addressSpaceCreateWithTerm(&startCmd, &hostParm, ascreAttributes,
                                       &asCreateResult, auxTermExit, commArea,
                                       &startRSN);


### PR DESCRIPTION
#### Overview
Some z/OS services like ones based on non-stacking PC-routines cannot be called from an address space running with `REUSASID=YES`. If the caller attempts doing that, an S0D3 ABEND is received. In order to allow such client code to run inside an AUX address space, the AUX address space needs to be started with `REUSASID=NO`. This pull-request adds a second version of the AUX start guest function which includes a flag argument and one of the flags forces AUX to be started with `REUSASID=NO`.

**WARNING:** running an AUX address space with `REUSASID=NO` **will** leak ASIDs since an AUX address space uses a system LX for its communication PC routine.