### PR TITLE
AUX communication PC disablement

### DIFF
--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -230,6 +230,10 @@
 #define ZISAUX_LOG_USERMOD_CMD_RESP_MSG_TEXT    "Response message - \'%.*s\'"
 #define ZISAUX_LOG_USERMOD_CMD_RESP_MSG         ZISAUX_LOG_USERMOD_CMD_RESP_MSG_ID" "ZISAUX_LOG_USERMOD_CMD_RESP_MSG_TEXT
 
+#define ZISAUX_LOG_TERM_SIGNAL_MSG_ID           ZIS_MSG_PRFX"0080I"
+#define ZISAUX_LOG_TERM_SIGNAL_MSG_TEXT         "Termination signal received (0x%08X)"
+#define ZISAUX_LOG_TERM_SIGNAL_MSG              ZISAUX_LOG_TERM_SIGNAL_MSG_ID" "ZISAUX_LOG_TERM_SIGNAL_MSG_TEXT
+
 #define ZISAUX_LOG_DUB_ERROR_MSG_ID             ZIS_MSG_PRFX"0081E"
 #define ZISAUX_LOG_DUB_ERROR_MSG_TEXT           "Bad dub status %d (%d,0x%04X), verify that the started task user has an OMVS segment"
 #define ZISAUX_LOG_DUB_ERROR_MSG                ZISAUX_LOG_DUB_ERROR_MSG_ID" "ZISAUX_LOG_DUB_ERROR_MSG_TEXT

--- a/zis-aux/include/aux-host.h
+++ b/zis-aux/include/aux-host.h
@@ -23,6 +23,9 @@
 #define ZISAUX_REVISION             ZIS_REVISION
 #define ZISAUX_VERSION_DATE_STAMP   ZIS_VERSION_DATE_STAMP
 
+#define ZISAUX_HOST_PARM_MOD_KEY  "MOD"
+#define ZISAUX_HOST_PARM_COMM_KEY "COMM"
+
 typedef struct ZISAUXContext_tag {
 
   char eyecatcher[8];

--- a/zis-aux/include/aux-manager.h
+++ b/zis-aux/include/aux-manager.h
@@ -47,7 +47,10 @@ typedef struct ZISAUXManager_tag {
 
 typedef struct ZISAUXCommArea_tag {
   char eyecatcher[8];
-#define ZISAUX_COMM_EYECATCHER    "ZISAUXC "
+#define ZISAUX_COMM_EYECATCHER    "ZISAUXCA"
+  uint8_t version;
+#define ZISAUX_COMM_VERSION 2
+  char reserved0[3];
   int32_t flag;
 #define ZISAUX_HOST_FLAG_READY          0x00000001
 #define ZISAUX_HOST_FLAG_TERMINATED     0x00000002
@@ -55,12 +58,11 @@ typedef struct ZISAUXCommArea_tag {
   uint32_t pcNumber;
   uint32_t sequenceNumber;
   int32_t termECB;
+  char reserved1[4];
   uint64_t stoken;
   ASCB * __ptr32 ascb;
   uint16_t parentASID;
-  uint8_t version;
-#define ZISAUX_COMM_VERSION 2
-  char reserved0[1];
+  char reserved2[2];
   int32_t commECB;
 #define ZISAUX_COMM_SIGNAL_TERM 1
 } ZISAUXCommArea;

--- a/zis-aux/include/aux-manager.h
+++ b/zis-aux/include/aux-manager.h
@@ -51,13 +51,18 @@ typedef struct ZISAUXCommArea_tag {
   int32_t flag;
 #define ZISAUX_HOST_FLAG_READY          0x00000001
 #define ZISAUX_HOST_FLAG_TERMINATED     0x00000002
+#define ZISAUX_HOST_FLAG_COMM_PC_ON     0x00000004
   uint32_t pcNumber;
   uint32_t sequenceNumber;
   int32_t termECB;
   uint64_t stoken;
   ASCB * __ptr32 ascb;
   uint16_t parentASID;
-  char reserved0[2];
+  uint8_t version;
+#define ZISAUX_COMM_VERSION 2
+  char reserved0[1];
+  int32_t commECB;
+#define ZISAUX_COMM_SIGNAL_TERM 1
 } ZISAUXCommArea;
 
 typedef struct ZISAUXNickname_tag {
@@ -74,6 +79,7 @@ typedef struct ZISAUXParm_tag {
 
 #define ZIS_AUX_FLAG_NONE         0x00000000
 #define ZIS_AUX_FLAG_REUSASID_NO  0x00000001
+#define ZIS_AUX_FLAG_COMM_PC_OFF  0x00000002
 
 ZOWE_PRAGMA_PACK_RESET
 
@@ -214,6 +220,8 @@ int zisauxMgrWaitForTerm(ZISAUXManager *mgr,
 #define RC_ZISAUX_SHR64_ERROR             40
 #define RC_ZISAUX_BUFFER_TOO_SMALL        41
 #define RC_ZISAUX_NOT_MANAGER_TCB         42
-#define RC_ZISAUX_CALLER_NOT_RECOGNIZED   43
+#define RC_ZISAUX_COMM_PC_DISABLED        43
+#define RC_ZISAUX_XMEM_POST_FAILED        44
+#define RC_ZISAUX_CALLER_NOT_RECOGNIZED   45
 
 #endif /* SRC_AUX_MANAGER_H_ */

--- a/zis-aux/src/aux-host.c
+++ b/zis-aux/src/aux-host.c
@@ -1638,6 +1638,11 @@ static int commTaskMain(RLETask *task) {
   auxutilWait(&commArea->commECB);
 
   // the only signal we handle is termination
+
+  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, ZISAUX_LOG_TERM_SIGNAL_MSG,
+          commArea->commECB);
+  commArea->commECB = 0;
+
   context->flags |= ZISAUX_CONTEXT_FLAG_TERM_COMMAND_RECEIVED;
   stcBaseShutdown(context->base);
 
@@ -1709,15 +1714,15 @@ static int run(STCBase *base, const ZISMainFunctionParms *mainParms) {
 
   do {
 
-    int commTaskRC = launchCommTask(context, base);
-    if (commTaskRC != RC_ZISAUX_OK) {
-      status = commTaskRC;
-      break;
-    }
-
     int configRC = loadConfig(context, mainParms);
     if (configRC != RC_ZISAUX_OK) {
       status = configRC;
+      break;
+    }
+
+    int commTaskRC = launchCommTask(context, base);
+    if (commTaskRC != RC_ZISAUX_OK) {
+      status = commTaskRC;
       break;
     }
 


### PR DESCRIPTION
#### Overview

With the introduction of the REUSASID=NO option for AUX, it became somewhat dangerous to run it with the communication PC as it would leak ASIDs. This commit adds the ability to disable the communication PC and introduces an alternative communication path for the termination signal.

##### Major changes:
* Disablement of the communication PC
* Termination signal via a cross-memory POST

##### Minor changes:
* Defines for AUX parameters
* Communication area versioning

Fixes: #250
