### PR TITLE
Check the OMVS segment in AUX.

### DIFF
--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -230,6 +230,10 @@
 #define ZISAUX_LOG_USERMOD_CMD_RESP_MSG_TEXT    "Response message - \'%.*s\'"
 #define ZISAUX_LOG_USERMOD_CMD_RESP_MSG         ZISAUX_LOG_USERMOD_CMD_RESP_MSG_ID" "ZISAUX_LOG_USERMOD_CMD_RESP_MSG_TEXT
 
+#define ZISAUX_LOG_DUB_ERROR_MSG_ID             ZIS_MSG_PRFX"0081E"
+#define ZISAUX_LOG_DUB_ERROR_MSG_TEXT           "Bad dub status %d (%d,0x%04X), verify that the started task user has an OMVS segment"
+#define ZISAUX_LOG_DUB_ERROR_MSG                ZISAUX_LOG_DUB_ERROR_MSG_ID" "ZISAUX_LOG_DUB_ERROR_MSG_TEXT
+
 #endif /* ZIS_MSG_H_ */
 
 


### PR DESCRIPTION
#### Overview
The STC base framework which AUX uses requires the STC user to have an OMVS segment. When it's missing, the STC will fail without providing any useful information. This pull-request adds code to check the segment and print an error message if it's missing. The same check has been already added to the ZIS STC code.