### PR TITLE
Fix a null pointer dereference

### DIFF
--- a/c/zis/parm.c
+++ b/c/zis/parm.c
@@ -439,7 +439,7 @@ int zisReadMainParms(ZISParmSet *parms, const ZISMainFunctionParms *mainParms) {
     }
 
     char *key = workBuffer;
-    char *value = NULL;
+    char *value = "";
 
     int parmLength = endIdx - startIdx;
     memcpy(key, &mainParms->text[startIdx], parmLength);


### PR DESCRIPTION
#### Overview
In case a bad parm is specified in ZIS config, the code may end up dereferencing a NULL pointer. This fix makes the default value an empty string.