### PR TITLE
Make sure the AUX API is backward and forward compatible with 1.19.

### DIFF
--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -238,6 +238,10 @@
 #define ZISAUX_LOG_DUB_ERROR_MSG_TEXT           "Bad dub status %d (%d,0x%04X), verify that the started task user has an OMVS segment"
 #define ZISAUX_LOG_DUB_ERROR_MSG                ZISAUX_LOG_DUB_ERROR_MSG_ID" "ZISAUX_LOG_DUB_ERROR_MSG_TEXT
 
+#define ZISAUX_LOG_LEGACY_API_MSG_ID            ZIS_MSG_PRFX"0082W"
+#define ZISAUX_LOG_LEGACY_API_MSG_TEXT          "Legacy API has been detected, some functionality may be limited"
+#define ZISAUX_LOG_LEGACY_API_MSG               ZISAUX_LOG_LEGACY_API_MSG_ID" "ZISAUX_LOG_LEGACY_API_MSG_TEXT
+
 #endif /* ZIS_MSG_H_ */
 
 

--- a/zis-aux/include/aux-host.h
+++ b/zis-aux/include/aux-host.h
@@ -38,6 +38,7 @@ typedef struct ZISAUXContext_tag {
   unsigned int flags;
 #define ZISAUX_CONTEXT_FLAG_TERM_COMMAND_RECEIVED     0x00000001
 #define ZISAUX_CONTEXT_FLAG_GUEST_INITIALIZED         0x00000002
+#define ZISAUX_CONTEXT_FLAG_LEGACY_API                0x00000004
   char reserved0[12];
 
   struct STCBase_tag *base;

--- a/zis-aux/include/aux-manager.h
+++ b/zis-aux/include/aux-manager.h
@@ -47,10 +47,7 @@ typedef struct ZISAUXManager_tag {
 
 typedef struct ZISAUXCommArea_tag {
   char eyecatcher[8];
-#define ZISAUX_COMM_EYECATCHER    "ZISAUXCA"
-  uint8_t version;
-#define ZISAUX_COMM_VERSION 2
-  char reserved0[3];
+#define ZISAUX_COMM_EYECATCHER    "ZISAUXC "
   int32_t flag;
 #define ZISAUX_HOST_FLAG_READY          0x00000001
 #define ZISAUX_HOST_FLAG_TERMINATED     0x00000002
@@ -58,13 +55,20 @@ typedef struct ZISAUXCommArea_tag {
   uint32_t pcNumber;
   uint32_t sequenceNumber;
   int32_t termECB;
-  char reserved1[4];
   uint64_t stoken;
   ASCB * __ptr32 ascb;
   uint16_t parentASID;
-  char reserved2[2];
+
+  uint8_t version;
+#define ZISAUX_COMM_VERSION 2
+
+  char reserved0[1];
+
   int32_t commECB;
 #define ZISAUX_COMM_SIGNAL_TERM 1
+
+  char reserved1[20];
+
 } ZISAUXCommArea;
 
 typedef struct ZISAUXNickname_tag {


### PR DESCRIPTION
#### Overview
Previous changes introducing new AUX flags made it incompatible with older AUX clients. The user of the AUX manager code would not be able to start the AUX STC because of differences in the communication area. This pull-request fixes this by changing the communication area to be compatible with the old code.

Both forward and backward compatibility should be present with one caveat - if the client code uses the new flags and tries to use the old AUX module, the new options will be ignored and some functionality may be affected (termination won't work, ASID may leak). Client must make sure to use the update AUX when using the new flags. 