### PR TITLE
Bugfix for missing xmem property reading

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -126,3 +126,12 @@ else
     export "${PREFIX}password=${KEYSTORE_PASSWORD}"
   fi
 fi
+
+# xmem name customization
+if [ -z "$ZWED_privilegedServerName" ]
+then
+  if [ -n "$ZOWE_ZSS_XMEM_SERVER_NAME" ]
+  then
+    export ZWED_privilegedServerName=$ZOWE_ZSS_XMEM_SERVER_NAME
+  fi 
+fi


### PR DESCRIPTION
app-server does this already and their environments used to be shared but we're moving away from that model so this is a bug waiting to happen. Fixing it before it becomes an issue.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>