### PR TITLE
Handle empty records during dataset reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
 
+## `1.22.0`
+
+### New features and enhancements
+
+- Bugfix: Dataset contents API doesn't skip empty records while reading a dataset 
+
 ## `1.21.0`
 
 - Set cookie path to root in order to avoid multiple cookies when browser tries to set path automatically

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -23,6 +23,7 @@
 
 OSNAME=$(uname)
 if [[ "${OSNAME}" == "OS/390" ]]; then
+  export _EDC_ZERO_RECLEN=Y # allow processing of zero-length records in datasets
   cd ${ROOT_DIR}/components/zss/bin
   ./zssServer.sh
 else


### PR DESCRIPTION
Currently we skip empty records in DS contents API. This PR fixes the bug.

Depends on: https://github.com/zowe/zowe-common-c/pull/211