### PR TITLE
Make relativeTo work when loading plugin dlls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Bugfix: Dataset contents API doesn't skip empty records while reading a dataset 
 - Enhancement: Plugins can push state out to the Caching Service for high availability storage via a storage API, available to dataservices as `remoteStorage`
 - Enhancement: Plugins can push state out to the In-Memory Storage via a storage API, available to dataservices as `localStorage`
+- Bugfix: ZSS now takes into account `relativeTo` attribute when loading plugin dlls
 
 ## `1.21.0`
 


### PR DESCRIPTION
This PR makes `relativeTo` attribute work when zss is loading plugin dlls. For example, for sample angular app 
```json
{
  "identifier": "org.zowe.zlux.sample.angular",
  "pluginLocation": "components/app-server/share/sample-angular-app",
  "relativeTo": "$ROOT_DIR"
}
```
zss must load plugins from `$ROOT_DIR/components/app-server/share/sample-angular-app/lib` folder