### PR TITLE
Bugfix for relative parsing that takes into account string length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
 
+## `1.23.0`
+
+- Bugfix: `relativeTo` parsing may have failed depending upon path length and contents, leading to skipped plugin loading.
+
 ## `1.22.0`
 
 ### New features and enhancements

--- a/c/zss.c
+++ b/c/zss.c
@@ -554,6 +554,7 @@ static char* resolvePluginLocation(ShortLivedHeap *slh, const char *pluginLocati
     if (varValue) {
       zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "relativeTo '%s' resolves to '%s'\n", relativeTo, varValue);
       relativeTo = varValue;
+      relativeToLen = strlen(relativeTo);
     } else {
       zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "unable to resolve relativeTo '%s', env var not set\n", relativeTo, varValue);
     }


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
This fixes failure to load plugins in a specific case where the value of "ROOT_DIR" s 9th character was '/'. This was due to not adjusting the variable's length check to the value we get when resolving from environment variable.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Make a ROOT_DIR path such as
/u/thing/zowe/test/123
Then try another, like
/u/another/zowe/test/123
In one case, the 9th character is slash, in another, it is not. In the old code, one of these two would fail, whereas in this fix they both should work.
