### PR TITLE
Disable impersonation for OMVS service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `1.23.0`
 
 - Bugfix: `relativeTo` parsing may have failed depending upon path length and contents, leading to skipped plugin loading.
+- Enhancement: Disable impersonation for OMVS Service.
 
 ## `1.22.0`
 

--- a/c/omvsService.c
+++ b/c/omvsService.c
@@ -55,8 +55,8 @@ int installOMVSService(HttpServer *server)
   HttpService *httpService = makeGeneratedService("OMVS_Service", "/omvs/**");
   httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
   httpService->serviceFunction = &serveOMVSSegment;
-  httpService->runInSubtask = TRUE;
-  httpService->doImpersonation = TRUE;
+  httpService->runInSubtask = FALSE;
+  httpService->doImpersonation = FALSE;
   registerHttpService(server, httpService);
 
   return 0;


### PR DESCRIPTION
## Proposed changes

So far OMVS Service required every end user to have `READ` to `IRR.RADMIN.LISTUSER`.  By disabling impersonation for the service this PR moves the requirement to the userid under which Zowe STC is running. 

PR for docs: https://github.com/zowe/docs-site/pull/1750

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below




