### PR TITLE
Cross-memory fixes for ZSS 64

### DIFF
--- a/c/zis/client.c
+++ b/c/zis/client.c
@@ -1179,7 +1179,6 @@ static int zisCallServiceInternal(const CrossMemoryServerName *serverName,
   CrossMemoryServerGlobalArea *cmsGA = NULL;
   int getGlobalAreaRC = cmsGetGlobalArea(serverName, &cmsGA);
   if (getGlobalAreaRC != RC_CMS_OK) {
-    printf("gonna die!\n");
     return RC_ZIS_SRVC_GLOBAL_AREA_NULL;
   }
 
@@ -1228,9 +1227,6 @@ static int zisCallServiceInternal(const CrossMemoryServerName *serverName,
   int cmsRC = cmsCallService3(cmsGA, routerServiceID, &routerParmList,
                               cmsFlags, &routerRC);
 
-  if (cmsRC || routerRC){
-    printf("ZIS.client fail: cmsRC %d routerRC %d\n",cmsRC,routerRC);
-  }
   if (cmsRC != RC_CMS_OK) {
     status->cmsRC = cmsRC;
     return RC_ZIS_SRVC_CMS_FAILED;

--- a/c/zis/parm.c
+++ b/c/zis/parm.c
@@ -315,9 +315,6 @@ static void freeReadBuffer(IEFPRMLBHeader *readBuffer) {
 
 int zisReadParmlib(ZISParmSet *parms, const char *ddname, const char *member,
                    ZISParmStatus *readStatus) {
-  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, "JOE: read the parms ddname=%s member=%s!\n",
-	  ddname,member);
-
 
   /* handle DD and member names */
   char ddnameSpacePadded[8];

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -124,12 +124,12 @@ static int zisRouteService(struct CrossMemoryServerGlobalArea_tag *globalArea,
   }
 
   if (serviceAnchor->flags & ZIS_SERVICE_ANCHOR_FLAG_SPECIFIC_AUTH){
-    bool authorized = cmsTestAuth(globalArea,serviceAnchor->safClassName,serviceAnchor->safEntityName);
+    bool authorized = cmsTestAuth(globalArea, serviceAnchor->safClassName,
+                                  serviceAnchor->safEntityName);
     if (!authorized){
       return RC_ZIS_SRVC_SPECIFIC_AUTH_FAILED;
     }
   }
-  authWTOPrintf("about to call service %32.32s\n",(char*)servicePath);
   return serviceAnchor->serve(globalArea,
                               serviceAnchor,
                               &serviceAnchor->serviceData,
@@ -384,9 +384,11 @@ static int callPluginInit(ZISContext *context, ZISPlugin *plugin,
     if (recoveryRC == RC_RCV_OK) {
 
       if (plugin->init != NULL) {
-	zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, "JOE: before init plugin\n");
+        zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_DEBUG,
+                "About to init plugin \'%.4s\'\n", plugin->nickname.text);
         int initRC = plugin->init(context, plugin, anchor);
-	zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, "JOE: plugin was init()-ed, rc=%d\n",initRC);
+        zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_DEBUG,
+                "Plugin init()-ed, rc=%d\n", initRC);
         if (initRC != RC_ZIS_OK) {
           zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING,
                   ZIS_LOG_PLUGIN_FAILURE_MSG_PREFIX" plug-in init RC = %d",
@@ -544,7 +546,9 @@ static int installServices(ZISContext *context, ZISPlugin *plugin,
 
   CrossMemoryMap *serviceTable = context->zisAnchor->serviceTable;
 
-  zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, "JOE plugin serviceCount=%d\n",plugin->serviceCount);
+  zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
+          "Plugin \'%.4s\' serviceCount=%d\n",
+          plugin->nickname.text, plugin->serviceCount);
   for (unsigned int i = 0; i < plugin->serviceCount; i++) {
 
     ZISService *service = &plugin->services[i];
@@ -976,8 +980,9 @@ static void visitPluginParm(const char *name, const char *value,
     return;
   }
   const char *pluginName = name + strlen("ZWES.PLUGIN.");
-  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO,"JOE: visitPluginParm %s value=%s\n",
-	  pluginName,value);
+  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_DEBUG,
+          "visitPluginParm %s value=%s\n",
+          pluginName, value);
   if (value == NULL) {
     zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_WARNING,
             ZIS_LOG_PLUGIN_FAILURE_MSG_PREFIX" module name not provided",
@@ -1132,7 +1137,7 @@ static void printStopMessage(int status) {
 }
 
 static void deployPlugins(ZISContext *context) {
-  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_INFO, "JOE: deploy the ZIS plugins !\n");
+  zowelog(NULL, LOG_COMP_STCBASE, ZOWE_LOG_DEBUG, "Deploy the ZIS plugins\n");
   zisIterateParms(context->parms, visitPluginParm, context);
 }
 

--- a/c/zis/service.c
+++ b/c/zis/service.c
@@ -55,21 +55,27 @@ ZISService zisCreateSpaceSwitchService(
 
 }
 
-int zisServiceUseSpecificAuth(ZISService *service, 
-			      char *className,
-			      char *entityName){
+/*
+ * Adds class and entity names to a service.
+ */
+int zisServiceUseSpecificAuth(ZISService *service,
+                              const char *className,
+                              const char *entityName) {
+
   int cLen = strlen(className);
   int eLen = strlen(entityName);
-  if (cLen > 8){
-    return 12;
+  if (cLen + 1 > sizeof(service->safClassName)) {
+    return -1;
   }
-  if (eLen > 255){
-    return 12;
+  if (eLen + 1 > sizeof(service->safEntityName)) {
+    return -1;
   }
-  memset(service->safClassName,' ',8);
-  memcpy(service->safClassName,className,cLen);
-  strcpy(service->safEntityName,entityName);
+
+  strcpy(service->safClassName, className);
+  strcpy(service->safEntityName, entityName);
   service->flags |= ZIS_SERVICE_FLAG_SPECIFIC_AUTH;
+
+  return 0;
 }
 
 ZISService zisCreateCurrentPrimaryService(
@@ -120,8 +126,10 @@ ZISServiceAnchor *zisCreateServiceAnchor(const struct ZISPlugin_tag *plugin,
   anchor->pluginAnchor = plugin->anchor;
   anchor->serve = service->serve;
   anchor->serviceVersion = service->serviceVersion;
-  memcpy(anchor->safClassName,service->safClassName,8);
-  memcpy(anchor->safEntityName,service->safEntityName,256);
+  memcpy(anchor->safClassName, service->safClassName,
+         sizeof(anchor->safClassName));
+  memcpy(anchor->safEntityName, service->safEntityName,
+         sizeof(anchor->safEntityName));
 
   return anchor;
 }
@@ -143,9 +151,10 @@ void zisUpdateServiceAnchor(ZISServiceAnchor *anchor,
   anchor->flags = service->flags;
   anchor->serve = service->serve;
   anchor->serviceVersion = service->serviceVersion;
-  memcpy(anchor->safClassName,service->safClassName,8);
-  memcpy(anchor->safEntityName,service->safEntityName,256);
-
+  memcpy(anchor->safClassName, service->safClassName,
+         sizeof(anchor->safClassName));
+  memcpy(anchor->safEntityName, service->safEntityName,
+         sizeof(anchor->safEntityName));
 
 }
 

--- a/h/zis/service.h
+++ b/h/zis/service.h
@@ -77,8 +77,9 @@ struct ZISServiceAnchor_tag {
   PAD_LONG(2, ZISServiceServeFunction *serve);
 
   ZISServiceData serviceData;
-  char safClassName[8];
+  char safClassName[9];
   char safEntityName[256];
+  char reserved1[7];
 
 };
 
@@ -104,9 +105,9 @@ struct ZISService_tag {
   unsigned int serviceVersion;
 #define ZIS_SERVICE_ANY_VERSION  0xFFFFFFFF
 
-  char safClassName[8];
-  char safEntityName[256];  /* room for 255 chars plus null term */
-  char reserved[176];
+  char safClassName[8 + 1];  /* room for 8 chars plus null term */
+  char safEntityName[255 + 1];  /* room for 255 chars plus null term */
+  char reserved[175];
 
 };
 
@@ -141,9 +142,17 @@ ZISService zisCreateCurrentPrimaryService(
     unsigned int version
 );
 
-int zisServiceUseSpecificAuth(ZISService *service, 
-			      char *className,
-			      char *entityName);
+/**
+ * Adds class and entity names to a service.
+ *
+ * @param service The service to be used with the class and entity.
+ * @param className The class name to be used.
+ * @param entityName The entity name to be used.
+ * @return 0 in case of success, -1 if the class or entity name is too long.
+ */
+int zisServiceUseSpecificAuth(ZISService *service,
+                              const char *className,
+                              const char *entityName);
 
 
 struct ZISPlugin_tag;


### PR DESCRIPTION
Changes:
* Remove naked log messages
* Remove use of magic numbers
* Adjust the field sizes

An important TODO:
* We need to figure out what to do with service anchors when a service gets upgraded to use SAF. The anchors are in common storage and are not removed. So we may be reading/writing beyond our storage boundaries. 