### PR TITLE
Limit entity check to default class only to prevent misuse by ZSS

### DIFF
--- a/c/zis/services/auth.c
+++ b/c/zis/services/auth.c
@@ -102,16 +102,19 @@ static int handleEntityCheck(AuthServiceParmList *parmList,
   int rcvRC = 0;
   int rc = RC_ZIS_AUTHSRV_OK;
 
-  AuthClass class = {0};
-  size_t classLength = strlen(parmList->classNullTerm);
-  if (classLength == 0) {
-    int getClassRC = getDefaultClassValue(globalArea, &class);
-    if (getClassRC != RC_ZIS_AUTHSRV_OK) {
-      return getClassRC;
-    }
-  } else {
-    memcpy(class.valueNullTerm, parmList->classNullTerm, classLength);
+  AuthClass defaultClass = {0};
+  int getClassRC = getDefaultClassValue(globalArea, &defaultClass);
+  if (getClassRC != RC_ZIS_AUTHSRV_OK) {
+    return getClassRC;
   }
+
+  size_t classLength = strlen(parmList->classNullTerm);
+  if (classLength != 0) {
+    if (strcmp(parmList->classNullTerm, defaultClass.valueNullTerm) != 0) {
+      return RC_ZIS_AUTHSRV_CUSTOM_CLASS_NOT_ALLOWED;
+    }
+  }
+  AuthClass class = defaultClass;
 
   CMS_DEBUG(globalArea, "handleEntityCheck(): user = %s, entity = %s, class = %s,"
       " access = %x\n", parmList->userIDNullTerm, parmList->entityNullTerm,
@@ -257,15 +260,13 @@ static int handleAccessRetrieval(AuthServiceParmList *parmList,
     return getClassRC;
   }
 
-  AuthClass class = {0};
   size_t classLength = strlen(parmList->classNullTerm);
   if (classLength != 0) {
-    if (strcmp(class.valueNullTerm, defaultClass.valueNullTerm) != 0) {
+    if (strcmp(parmList->classNullTerm, defaultClass.valueNullTerm) != 0) {
       return RC_ZIS_AUTHSRV_CUSTOM_CLASS_NOT_ALLOWED;
     }
-  } else {
-    class = defaultClass;
   }
+  AuthClass class = defaultClass;
 
   CMS_DEBUG2(globalArea, traceLevel,
              "handleAccessRetrieval(): user=\'%s\', entity=\'%s\', "


### PR DESCRIPTION
## Proposed changes

A recent PR showed that it's likely that a person who doesn't know the implications of exposing ZIS services may accidentally  create a security vulnerability. This PR closes the ability to pass a SAF class to the entity check service which will make it impossible to misuse it by any future ZSS changes. Additionally, a bug has been fixed where the access service would always return an error if a non empty class was provided.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.

## Testing
The standard tests against the security endpoints need to be performed.
