### PR TITLE
Respect ZOWE_ZSS_SERVER_TLS environment variable

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -1047,7 +1047,13 @@ static bool readAgentHttpsSettings(ShortLivedHeap *slh,
   if (!address) {
     address = "127.0.0.1";
   }
-  bool isHttpsConfigured = port && settings->keyring;
+
+  const char *useTlsParam = getenv("ZOWE_ZSS_SERVER_TLS");
+  zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "Environment variable ZOWE_ZSS_SERVER_TLS is %s\n",
+          useTlsParam ? useTlsParam : "not set");
+
+  bool forceHttp = useTlsParam && (0 == strcmp(useTlsParam, "false"));
+  bool isHttpsConfigured = !forceHttp && port && settings->keyring;
   if (settings->keyring) {
       zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, ZSS_LOG_TLS_SETTINGS_MSG,
               settings->keyring,


### PR DESCRIPTION
## Proposed changes

This PR makes zss always check `ZOWE_ZSS_SERVER_TLS` environment variable at startup, and choose `http` protocol when it's set to `false`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))

## Testing
Set `ZOWE_ZSS_SERVER_TLS` environment variable to `false` and ensure that zss runs without TLS.

