### PR TITLE
Add user-info service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `1.24.0`
 
 - Bugfix: Fix `zis-plugin-install.sh` script to properly exit on error with extended-install
+- Enhancement: Add an endpoint for user info
 
 ## `1.23.0`
 

--- a/build/build_zss.sh
+++ b/build/build_zss.sh
@@ -145,6 +145,7 @@ if c89 \
   ${ZSS}/c/zis/client.c \
   ${ZSS}/c/serverStatusService.c \
   ${ZSS}/c/rasService.c \
+  ${ZSS}/c/userInfoService.c \
   ${GSKLIB} ;
 then
   extattr +p ${ZSS}/bin/zssServer

--- a/c/userInfoService.c
+++ b/c/userInfoService.c
@@ -1,0 +1,106 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pwd.h>
+#include <errno.h>
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "utils.h"
+#include "charsets.h"
+#include "httpserver.h"
+#include "json.h"
+#include "zssLogging.h"
+#include "serviceUtils.h"
+#include "userInfoService.h"
+
+static int serveUserInfo(HttpService *service, HttpResponse *response);
+static void respondWithUserInfo(HttpResponse *response, struct passwd *pw);
+static void respondWithUserInfoError(HttpResponse *response, int code, const char *status, const char *message);
+
+int installUserInfoService(HttpServer *server) {
+  HttpService *httpService = makeGeneratedService("User info service", "/user-info");
+  httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  httpService->serviceFunction = serveUserInfo;
+  httpService->runInSubtask = TRUE;
+  httpService->doImpersonation = TRUE;
+  registerHttpService(server, httpService);
+
+  return 0;
+}
+
+static int serveUserInfo(HttpService *service, HttpResponse *response) {
+  HttpRequest *request = response->request;
+  const char *userId = request->username;
+
+  if (0 != strcmp(request->method, methodGET)) {
+    respondWithUserInfoError(response, HTTP_STATUS_METHOD_NOT_FOUND, "Method Not Allowed", "Only GET method allowed");
+    return 0;
+  }
+
+  struct passwd pw = {0};
+  struct passwd *pwPtr = NULL;
+  char buf[1024] = {0};
+  int rc = getpwnam_r(userId, &pw, buf, sizeof(buf), &pwPtr);
+  if (rc != 0) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "failed to get user info for %s - %s\n", userId, strerror(errno));
+    respondWithUserInfoError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Internal Server Error", "Failed to get user info");
+    return 0;
+  }
+
+  respondWithUserInfo(response, &pw);
+  return 0;
+}
+
+static void respondWithUserInfo(HttpResponse *response, struct passwd *pw) {
+  HttpRequest *request = response->request;
+  jsonPrinter *p = respondWithJsonPrinter(response);
+  setResponseStatus(response, 200, "OK");
+  setDefaultJSONRESTHeaders(response);
+  writeHeader(response);
+
+  jsonStart(p);
+  jsonAddString(p, "userId", pw->pw_name);
+  jsonAddUInt(p, "uid", pw->pw_uid);
+  jsonAddUInt(p, "gid", pw->pw_gid);
+  jsonAddString(p, "home", pw->pw_dir);
+  jsonAddString(p, "shell", pw->pw_shell);
+  jsonEnd(p);
+
+  finishResponse(response);
+}
+
+static void respondWithUserInfoError(HttpResponse *response, int code, const char *status, const char *message) {
+  HttpRequest *request = response->request;
+  jsonPrinter *p = respondWithJsonPrinter(response);
+
+  setResponseStatus(response, code, (char*)status);
+  setDefaultJSONRESTHeaders(response);
+  writeHeader(response);
+
+  jsonStart(p);
+  jsonAddString(p, "error", (char*)message);
+  jsonEnd(p);
+  finishResponse(response);
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/c/zss.c
+++ b/c/zss.c
@@ -74,6 +74,7 @@
 #include "rasService.h"
 #include "certificateService.h"
 #include "registerProduct.h"
+#include "userInfoService.h"
 #include "jwt.h"
 #ifdef USE_ZOWE_TLS
 #include "tls.h"
@@ -1619,6 +1620,7 @@ int main(int argc, char **argv){
       installServerStatusService(server, MVD_SETTINGS, productVersion);
       installZosPasswordService(server);
       installRASService(server);
+      installUserInfoService(server);
 #endif
       installLoginService(server);
       installLogoutService(server);

--- a/h/userInfoService.h
+++ b/h/userInfoService.h
@@ -1,0 +1,27 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifndef __USER_INFO_SERVICE_H__
+#define __USER_INFO_SERVICE_H__
+
+int installUserInfoService(HttpServer *server);
+
+#endif // __USER_INFO_SERVICE_H__
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/


### PR DESCRIPTION
## Proposed changes
This PR adds a new endpoint `/user-info` that returns information about current user. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
### Request
`GET /user-info`

### Response 
 `HTTP 200 OK`
#### Response body
```json
{
  "userId": "USERA",
  "uid": 1222,
  "gid": 100,
  "home": "/u/usera",
  "shell": "/bin/sh"
}
```
