### PR TITLE
Updated zowe-common-c pointer to unix file copy status fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## `1.25.0`
 
-- Bugfix: unixfile copy API now returns valid error status.
+- Bugfix: Unixfile copy API now returns valid error status.
 
 ## `1.24.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
 
+## `1.25.0`
+
+- Bugfix: unixfile copy API now returns valid error status.
+
 ## `1.24.0`
 
 - Bugfix: Fix `zis-plugin-install.sh` script to properly exit on error with extended-install


### PR DESCRIPTION
Signed-off-by: Aditya Ranshinge <aranshinge@rocketsoftware.com>

Updated pointer to zowe-common-c, bugfix to return valid status for POST /unixfile/copy