### PR TITLE
Use converted zss environment from zowe.yaml

### DIFF
--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -30,7 +30,7 @@ else
   ZSS_SCRIPT_DIR=$(cd `dirname $0` && pwd)
   . ${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-app-server/bin/convert-env.sh
   yamlConverter="${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-server-framework/utils/yamlConfig.js"
-  env_converted_from_yaml=$(node $yamlConverter zss 2>/dev/null)
+  env_converted_from_yaml=$(node $yamlConverter 2>/dev/null)
   if [ -n "$env_converted_from_yaml" ]; then
     eval "$env_converted_from_yaml"
   fi

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -30,7 +30,7 @@ else
   ZSS_SCRIPT_DIR=$(cd `dirname $0` && pwd)
   . ${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-app-server/bin/convert-env.sh
   yamlConverter="${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-server-framework/utils/yamlConfig.js"
-  env_converted_from_yaml=$(node $yamlConverter 2>/dev/null)
+  env_converted_from_yaml=$(node $yamlConverter --components 'zss app-server' 2>/dev/null)
   if [ -n "$env_converted_from_yaml" ]; then
     eval "$env_converted_from_yaml"
   fi

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -29,6 +29,11 @@ then
 else
   ZSS_SCRIPT_DIR=$(cd `dirname $0` && pwd)
   . ${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-app-server/bin/convert-env.sh
+  yamlConverter="${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-server-framework/utils/yamlConfig.js"
+  env_converted_from_yaml=$(node $yamlConverter zss 2>/dev/null)
+  if [ -n "$env_converted_from_yaml" ]; then
+    eval "$env_converted_from_yaml"
+  fi
 fi
 if [ -e "$ZSS_CONFIG_FILE" ]
 then


### PR DESCRIPTION
## Proposed changes
This PR reads app-server/zss config from `zowe.yaml` and sets corresponding environments variables using `export` statements.

This PR depends upon the following PRs: 
* https://github.com/zowe/zlux-server-framework/pull/333

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

```yaml
  app-server:
    enabled: true
    port: "59344"
    certificate:
      keystore:
        alias: app-server
      pem:
        key: /u/ts3105/keystore-ha/localhost/localhost.keystore.app-server.key
        certificate: /u/ts3105/keystore-ha/localhost/localhost.keystore.app-server.cer-ebcdic
    logLevels:
      "_zsf.utils": 4
    node:
        https: 
          enableTrace: true
  zss:
    enabled: true
    port: "59342"
    crossMemoryServerName: ZWESIS_STD
    tls: true
    certificate:
      keystore:
        alias: zss
    agent:
      mediationLayer:
        enabled: false
```

