### PR TITLE
Updated zowe-common-c pointer to unix file copy status fix and updated CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the ZSS package will be documented in this file.
 
 - Enhancement: Add an endpoint for PassTicket generation
 - Enhancement: Add an endpoint for user info
+- Bugfix: Unixfile API returns valid error status
 
 ## `1.24.0`
 


### PR DESCRIPTION
Signed-off-by: Aditya Ranshinge <aranshinge@rocketsoftware.com>

Updated pointer to zowe-common-c, bugfix to return valid status for POST /unixfile/copy
Updated CHANGELOG.md

