### PR TITLE
Updated zowe-common-c pointer to forceOverwrite directory fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: Add an endpoint for PassTicket generation
 - Enhancement: Add an endpoint for user info
 - Bugfix: Unixfile API returns valid error status
-- Bugfix: Unixfile copy and rename directory API supports forceOverwrite query
+- Bugfix: Unixfile Copy and Rename directory API doesn't support forceOverwrite query
 
 ## `1.24.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: Add an endpoint for PassTicket generation
 - Enhancement: Add an endpoint for user info
 - Bugfix: Unixfile API returns valid error status
+- Bugfix: Unixfile copy and rename directory API supports forceOverwrite query
 
 ## `1.24.0`
 


### PR DESCRIPTION


Signed-off-by: Aditya Ranshinge <aranshinge@rocketsoftware.com>

Updated pointer to zowe-common-c, bugfix to allow forceOverwrite query for Unixfile copy and rename directory API
Updated CHANGELOG.md