### PR TITLE
Fix sso env var setting

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -64,6 +64,31 @@ if [ ! -f "$currentJsonConfigPath" ]; then
 fi
 
 APP_WORKSPACE_DIR=${INSTANCE_DIR}/workspace/app-server
+
+#SSO
+if [ -z "$ZWED_agent_jwt_fallback" ]
+then
+  if [ -n $SSO_FALLBACK_TO_NATIVE_AUTH ]
+  then
+    export ZWED_agent_jwt_fallback=$SSO_FALLBACK_TO_NATIVE_AUTH
+  fi
+fi
+if [ -z "$ZWED_agent_jwt_token_name" ]
+then
+  if [ -n $PKCS11_TOKEN_NAME ]
+  then
+    export ZWED_agent_jwt_token_name=$PKCS11_TOKEN_NAME
+  fi
+fi
+if [ -z "$ZWED_agent_jwt_token_label" ]
+then
+  if [ -n $PKCS11_TOKEN_LABEL ]
+  then
+    export ZWED_agent_jwt_token_label=$PKCS11_TOKEN_LABEL
+  fi
+fi
+
+
 if [ "${ZOWE_ZSS_SERVER_TLS}" = "false" ]; then
   PROTOCOL="http"
 else


### PR DESCRIPTION
This is a short potential bugfix that uses the same sso env var setting as seen in app-server.
The ZWED vars are essential for zss to get the config values it needs, but don't appear to be read in zss setup, but instead in app-server setup. So, that could break when app-server is in a container instead