### PR TITLE
Add zlux-root-dir env var

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -12,6 +12,9 @@
 # - ROOT_DIR
 # - WORKSPACE_DIR
 
+# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
+export ZLUX_ROOT_DIR=$(cd ../../../app-server/share; pwd)
+
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/bin
 . ./convert-env.sh
 
@@ -103,6 +106,3 @@ then
     export ZWED_privilegedServerName=$ZOWE_ZSS_XMEM_SERVER_NAME
   fi 
 fi
-
-# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
-export ZLUX_ROOT_DIR=$(cd ../../app-server/share; pwd)

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -103,3 +103,6 @@ then
     export ZWED_privilegedServerName=$ZOWE_ZSS_XMEM_SERVER_NAME
   fi 
 fi
+
+# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
+export ZLUX_ROOT_DIR=$(cd ../../app-server/share; pwd)

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -12,9 +12,6 @@
 # - ROOT_DIR
 # - WORKSPACE_DIR
 
-# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
-export ZLUX_ROOT_DIR=$(cd ../../../app-server/share; pwd)
-
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/bin
 . ./convert-env.sh
 
@@ -106,3 +103,6 @@ then
     export ZWED_privilegedServerName=$ZOWE_ZSS_XMEM_SERVER_NAME
   fi 
 fi
+
+# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
+export ZLUX_ROOT_DIR=${ROOT_DIR}/components/app-server/share


### PR DESCRIPTION
This is a small fix to be able to resolve plugin definition relativeTo references that use the new value "ZLUX_ROOT_DIR" which is supposed to be the path to the zlux folders such as zlux-app-server. Here's an example of a plugin: https://github.com/zowe/zowe-install-packaging/blob/staging/files/zlux/config/plugins/org.zowe.configjs.json