### PR TITLE
Optimistic-locking dataset write with etag

### DIFF
--- a/c/datasetService.c
+++ b/c/datasetService.c
@@ -191,6 +191,7 @@ void installDatasetContentsService(HttpServer *server) {
   httpService->runInSubtask = TRUE;
   httpService->doImpersonation = TRUE;
   httpService->serviceFunction = serveDatasetContents;
+  httpService->paramSpecList = makeStringParamSpec("force",SERVICE_ARG_OPTIONAL, NULL);
   registerHttpService(server, httpService);
 }
 


### PR DESCRIPTION
This PR brings the API of the mock server to reality in the ZSS server.
It makes the /datasetContents api send an "etag" hash attribute in the json on reads, and expects an etag either in the header or json body on writes.
The hash is of the contents of the dataset or member.
On writes, the hash given is checked against the hash of the current contents on the system.
If they dont match, a write does not occur, unless the query parameter "force=true" was also used, in which case hash check is skipped.
Upon successful write, the new hash of the contents is returned.
Overall its expected that a client store the etag every time received, so that on next request it is given again. Upon receiving a etag-mismatch write fail, a client is expected to either give up or re-read the dataset and submit a new write request with whatever amendments desired after reviewing what the change was.
If for some reason the hashing code fails, its also expected that the read operation will still continue, but just not return a hash, making write impossible unless forced.
If when writing, a new hash likewise cannot be given, then it is also not returned despite the write succeeding.