### PR TITLE
Unix file chmod

### DIFF
--- a/mock/server.py
+++ b/mock/server.py
@@ -518,23 +518,45 @@ def unixfile_rename(subpath):
             dir = dir["contents"][newNames[i]]
         return {"msg": "File Successfully Renamed"}
 
-
-@app.route('/unixfile/copy/<path:subpath>', methods=['POST'])
-def unixfile_copy(subpath):
+@app.route('/unixfile/chmod/<path:dir>', methods=['POST'])
+def unixfile_chmod(dir):
     if request.method == 'POST':
-        newNames = request.get_json()['newName'].split('/')
-        paths = subpath.split('/')
-        directory = global_directory
-        for i in range(len(paths)-1):
-            directory = directory["contents"][paths[i]]
-        newDirectory  = directory['contents'][paths[len(paths)-1]].copy()
-        dir = global_directory
-        for i in range(len(newNames)):
-            if i == len(newNames)-1:
-                dir['contents'][newNames[i]] = newDirectory
-            dir = dir["contents"][newNames[i]]
-        return {"msg": "File Successfully Copied"}
+        try:
+            directory = global_directory["contents"]
+            dirPaths = dir.split("/")
+            mode = request.args.get('mode')
+            recursive = False
+            pattern = request.args.get('pattern')
+            if(request.args.get('recursive') is not None):
+                recursive = request.args.get('recursive').lower() == "true"
+            if(pattern == ""):
+                pattern = None
+            try:
+                int(mode, 8)
+                if(mode[:2] == "0o"):
+                    mode = int(mode, 8)
+                else:
+                    mode = int(mode)
+            except:
+                return {"msg": "Failed to change mode, mode not octal"}, 400
+            currPath = directory
+            for x in range(0, len(dirPaths) - 1):
+                if(dirPaths[x] not in currPath):
+                    return {"msg": "Directory/File not found."}, 404
+                currPath = currPath[dirPaths[x]]["contents"]
+            if (dirPaths[len(dirPaths) - 1] not in currPath):
+                return {"msg": "Directory/File not found."}, 404
+            if(pattern is None or pattern in dirPaths[len(dirPaths)-1]):
+                currPath[dirPaths[len(dirPaths) - 1]]["permissions"] = mode
+            if(currPath[dirPaths[len(dirPaths)-1]]["type"] == "folder" and len(currPath[dirPaths[len(dirPaths)-1]]["contents"]) > 0 and recursive):
+                for child, value in currPath[dirPaths[len(dirPaths)-1]]["contents"].items():
+                    if (value["type"] == "folder"):
+                        print(unixfile_chmod(dir + "/" + child))
+                    if (pattern is None or pattern in child):
+                        value["permissions"] = mode
+            return {"msg": "Successfully Modified Modes"}, 200
+        except:
+            return {"msg": "Failed to modify file modes"}, 500
 
 if __name__ == '__main__':
     app.run(debug=True)
-

--- a/mock/server.py
+++ b/mock/server.py
@@ -518,6 +518,7 @@ def unixfile_rename(subpath):
             dir = dir["contents"][newNames[i]]
         return {"msg": "File Successfully Renamed"}
 
+
 @app.route('/unixfile/copy/<path:subpath>', methods=['POST'])
 def unixfile_copy(subpath):
     if request.method == 'POST':

--- a/mock/server.py
+++ b/mock/server.py
@@ -518,6 +518,22 @@ def unixfile_rename(subpath):
             dir = dir["contents"][newNames[i]]
         return {"msg": "File Successfully Renamed"}
 
+@app.route('/unixfile/copy/<path:subpath>', methods=['POST'])
+def unixfile_copy(subpath):
+    if request.method == 'POST':
+        newNames = request.get_json()['newName'].split('/')
+        paths = subpath.split('/')
+        directory = global_directory
+        for i in range(len(paths)-1):
+            directory = directory["contents"][paths[i]]
+        newDirectory  = directory['contents'][paths[len(paths)-1]].copy()
+        dir = global_directory
+        for i in range(len(newNames)):
+            if i == len(newNames)-1:
+                dir['contents'][newNames[i]] = newDirectory
+            dir = dir["contents"][newNames[i]]
+        return {"msg": "File Successfully Copied"}
+
 @app.route('/unixfile/chmod/<path:dir>', methods=['POST'])
 def unixfile_chmod(dir):
     if request.method == 'POST':


### PR DESCRIPTION
## Proposed changes

This PR addresses Issue: The metadata command is missing from the mock server.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## PR Checklist

- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

To test this feature, please consider the following test conditions:

1. You attempt to change the mode without including the mode.
2. You attempt to change the mode with a non-octal mode.
3. You attempt to change the mode of a path/file that does not exist.
4. You attempt to change the mode of an existing file/folder without recursion.
5. You attempt to change the mode of a folder with recursion without a pattern.
6. You attempt to change the mode of a folder with recursion with a pattern.

## Further comments

This is not a relatively large change but will further enhance the mock server for learning purposes.
