### PR TITLE
Fix cookie set by logout service

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -273,8 +273,10 @@ int serveLogoutByRemovingSessionToken(HttpService *service, HttpResponse *respon
   addStringHeader(response, "Cache-control", "no-store");
   addStringHeader(response, "Pragma", "no-cache");
   
+  char cookie[512] = {0};
+  snprintf(cookie, sizeof(cookie), "%s=non-token; Path=/; HttpOnly", service->server->cookieName);
   /* Remove the session token when the user wants to log out */
-  addStringHeader(response,"Set-Cookie","jedHTTPSession=non-token; Path=/; HttpOnly");
+  addStringHeader(response,"Set-Cookie", cookie);
   response->sessionCookie = "non-token";
   writeHeader(response);
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR fixes cookieName set by `logout` service.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
