### PR TITLE
Add option that allows to run 64-bit ZSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `2.0.0`
 
 - Breaking change: Cookie name now has a suffix which includes the port or if in an HA instance, the HA ID.
+- Enhancement: New configuration option that allows to run 64-bit ZSS
 
 
 ## `1.27.0`

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -150,11 +150,22 @@ fi
 #Determined log file.  Run zssServer.
 export dir=`dirname "$0"`
 cd $ZSS_SCRIPT_DIR
+
+# determine amode for zssServer 
+ZSS_SERVER_31="./zssServer"
+ZSS_SERVER_64="./zssServer64"
+
+if [ "$ZWE_components_zss_agent_64bit" = "true" ] && [ -x "${ZSS_SERVER_64}" ]; then
+  ZSS_SERVER="${ZSS_SERVER_64}"
+else
+  ZSS_SERVER="${ZSS_SERVER_31}"
+fi
+
 if [ -f "$CONFIG_FILE" ]
 then
-  _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ./zssServer "${CONFIG_FILE}" 2>&1 | tee $ZWES_LOG_FILE
+  _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} "${CONFIG_FILE}" 2>&1 | tee $ZWES_LOG_FILE
 else
-  _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ./zssServer 2>&1 | tee $ZWES_LOG_FILE
+  _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} 2>&1 | tee $ZWES_LOG_FILE
 fi
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/h/zssLogging.h
+++ b/h/zssLogging.h
@@ -134,7 +134,11 @@ bool isLogLevelValid(int level);
 #ifndef ZSS_LOG_ZSS_START_VER_MSG_ID
 #define ZSS_LOG_ZSS_START_VER_MSG_ID         ZSS_LOG_MSG_PRFX"1013I"
 #endif
-#define ZSS_LOG_ZSS_START_VER_MSG_TEXT       "ZSS Server has started. Version '%s'\n"
+#ifdef __ZOWE_64
+#define ZSS_LOG_ZSS_START_VER_MSG_TEXT       "ZSS Server has started. Version '%s' 64-bit\n"
+#else
+#define ZSS_LOG_ZSS_START_VER_MSG_TEXT       "ZSS Server has started. Version '%s' 31-bit\n"
+#endif
 #define ZSS_LOG_ZSS_START_VER_MSG            ZSS_LOG_ZSS_START_VER_MSG_ID" "ZSS_LOG_ZSS_START_VER_MSG_TEXT
 
 #ifndef ZSS_LOG_ZIS_STATUS_MSG_ID


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR allows to run zss in 64-bit mode using an option in the config:
```yaml
components:
  zss:
    agent:
      64bit: true
```
This PR depends upon the following PRs:

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
