### PR TITLE
pc bit check and set

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -12,10 +12,26 @@
 # - ZWE_zowe_runtimeDirectory
 # - ZWE_zowe_workspaceDirectory
 
-cd ${ZWE_zowe_runtimeDirectory}/components/app-server/share/zlux-app-server/bin
-. ./convert-env.sh
+COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/zss
 
-cd ${ZWE_zowe_runtimeDirectory}/components/app-server/share/zlux-app-server/lib
+# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
+if [ -z "${ZLUX_ROOT_DIR}" ]; then
+  if [ -d "${COMPONENT_HOME}/../app-server/share" ]; then
+    export ZLUX_ROOT_DIR=$(cd `dirname ${COMPONENT_HOME}/../app-server/share/zlux-app-server` && pwd)
+  fi
+fi
+
+# Consume server infrastructure environment variables if possible
+if [ -n "$ZLUX_ROOT_DIR" ]; then
+  cd ${ZLUX_ROOT_DIR}/zlux-app-server/bin/init
+  . ../utils/convert-env.sh
+  NO_NODE=1
+  CHECK_PC_BIT=1
+  . ./plugins-init.sh $NO_NODE $CHECK_PC_BIT
+  cd $COMPONENT_HOME/bin
+elif [ -e ./convert-env.sh ]; then
+  . ./convert-env.sh
+fi
 
 # ZWED_instanceDir, ZWED_siteDir are set by convert-env.sh
 SITE_DIR="$ZWED_instanceDir/site"
@@ -71,6 +87,3 @@ then
     export ZWED_privilegedServerName=$ZWES_XMEM_SERVER_NAME
   fi 
 fi
-
-# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
-export ZLUX_ROOT_DIR=${ZWE_zowe_runtimeDirectory}/components/app-server/share

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -16,37 +16,40 @@ COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/zss
 
 # this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
 if [ -z "${ZLUX_ROOT_DIR}" ]; then
-  if [ -d "${COMPONENT_HOME}/../app-server/share" ]; then
-    export ZLUX_ROOT_DIR=$(cd `dirname ${COMPONENT_HOME}/../app-server/share/zlux-app-server` && pwd)
+  if [ -d "${ZWE_zowe_runtimeDirectory}/components/app-server/share" ]; then
+    export ZLUX_ROOT_DIR="${ZWE_zowe_runtimeDirectory}/components/app-server/share"
   fi
 fi
 
-# Consume server infrastructure environment variables if possible
-if [ -n "$ZLUX_ROOT_DIR" ]; then
-  cd ${ZLUX_ROOT_DIR}/zlux-app-server/bin/init
+# This location will have init and utils folders inside and is used to gather env vars and do plugin initialization
+helper_script_location="${ZLUX_ROOT_DIR}/zlux-app-server/bin"
+
+if [ -d "${helper_script_location}" ]; then
+  cd "${helper_script_location}/init"
   . ../utils/convert-env.sh
+
+  # Register/deregister plugins according to their enabled status, and check for PC bit
   NO_NODE=1
   CHECK_PC_BIT=1
   . ./plugins-init.sh $NO_NODE $CHECK_PC_BIT
-  cd $COMPONENT_HOME/bin
-elif [ -e ./convert-env.sh ]; then
-  . ./convert-env.sh
+
+  cd "${COMPONENT_HOME}/bin"
+  
+  # ZWED_instanceDir, ZWED_siteDir are set by convert-env.sh
+  SITE_DIR="$ZWED_instanceDir/site"
+  SITE_PLUGIN_STORAGE="$ZWED_siteDir/ZLUX/pluginStorage"
+  INSTANCE_PLUGIN_STORAGE="$ZWED_instanceDir/ZLUX/pluginStorage"
+  GROUPS_DIR="$ZWED_instanceDir/groups"
+  USERS_DIR="$ZWED_instanceDir/users"
+  PLUGINS_DIR="$ZWED_instanceDir/plugins"
+
+  mkdir -p "$SITE_DIR"
+  mkdir -p "$SITE_PLUGIN_STORAGE"
+  mkdir -p "$INSTANCE_PLUGIN_STORAGE"
+  mkdir -p "$GROUPS_DIR"
+  mkdir -p "$USERS_DIR"
+  mkdir -p "$PLUGINS_DIR"
 fi
-
-# ZWED_instanceDir, ZWED_siteDir are set by convert-env.sh
-SITE_DIR="$ZWED_instanceDir/site"
-SITE_PLUGIN_STORAGE="$ZWED_siteDir/ZLUX/pluginStorage"
-INSTANCE_PLUGIN_STORAGE="$ZWED_instanceDir/ZLUX/pluginStorage"
-GROUPS_DIR="$ZWED_instanceDir/groups"
-USERS_DIR="$ZWED_instanceDir/users"
-PLUGINS_DIR="$ZWED_instanceDir/plugins"
-
-mkdir -p "$SITE_DIR"
-mkdir -p "$SITE_PLUGIN_STORAGE"
-mkdir -p "$INSTANCE_PLUGIN_STORAGE"
-mkdir -p "$GROUPS_DIR"
-mkdir -p "$USERS_DIR"
-mkdir -p "$PLUGINS_DIR"
 
 if [ "${ZWES_SERVER_TLS}" = "false" ]; then
   PROTOCOL="http"

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -10,31 +10,34 @@
 
 export _BPXK_AUTOCVT=ON
 
-if [ -e "../bin/app-server.sh" ]
-then
-  in_app_server=true
-else
-  in_app_server=false
-fi
-if $in_app_server
-then
-  ZSS_FILE=../bin/zssServer
-  ZSS_COMPONENT=${ZWE_zowe_runtimeDirectory}/components/zss/bin
-  if test -f "$ZSS_FILE"; then
-    ZSS_SCRIPT_DIR=$(cd `dirname $0`/../bin && pwd)
-  elif [ -d "$ZSS_COMPONENT" ]; then
-    ZSS_SCRIPT_DIR=$ZSS_COMPONENT
-  fi
-  ../bin/convert-env.sh
-else
-  ZSS_SCRIPT_DIR=$(cd `dirname $0` && pwd)
-  . ${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-app-server/bin/convert-env.sh
-  yamlConverter="${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-server-framework/utils/yamlConfig.js"
-  env_converted_from_yaml=$(node $yamlConverter --components 'zss app-server' 2>/dev/null)
-  if [ -n "$env_converted_from_yaml" ]; then
-    eval "$env_converted_from_yaml"
+COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/zss
+ZSS_SCRIPT_DIR=$COMPONENT_HOME/bin
+
+# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
+if [ -z "${ZLUX_ROOT_DIR}" ]; then
+  if [ -d "${COMPONENT_HOME}/../app-server/share" ]; then
+    export ZLUX_ROOT_DIR=$(cd `dirname ${COMPONENT_HOME}/../app-server/share/zlux-app-server` && pwd)
   fi
 fi
+
+# Consume server infrastructure environment variables if possible
+if [ -n "$ZLUX_ROOT_DIR" ]; then
+  cd ${ZLUX_ROOT_DIR}/zlux-app-server/bin/init
+  . ../utils/convert-env.sh
+  cd $COMPONENT_HOME/bin
+elif [ -e ./convert-env.sh ]; then
+  . ./convert-env.sh
+fi
+
+
+# TODO this depends on nodejs but shouldn't. It should go away when config manager is available.
+# Read yaml file, convert it to env vars loading same way as env vars
+yamlConverter="${ZSS_SCRIPT_DIR}/../../app-server/share/zlux-server-framework/utils/yamlConfig.js"
+env_converted_from_yaml=$(node $yamlConverter --components 'zss app-server' 2>/dev/null)
+if [ -n "$env_converted_from_yaml" ]; then
+  eval "$env_converted_from_yaml"
+fi
+
  # It's still possible to provide a json config
 if [ -e "$ZSS_CONFIG_FILE" ]
 then


### PR DESCRIPTION
This PR depends upon https://github.com/zowe/zlux-app-server/pull/201 to call a plugin init script which will among other things check if zss plugins that exist have the PC bit set on services. If not, it will attempt to add it. This makes the config more bullet proof because if plugins are moved or were packaged without attributes, the pc bit attribute can be added at runtime.