### PR TITLE
merging jsonschema and config mgr work

### DIFF
--- a/h/zis/server.h
+++ b/h/zis/server.h
@@ -53,7 +53,7 @@ typedef struct ZISServerAnchor_tag {
 
 } ZISServerAnchor;
 
-typedef __packed struct ZISServiceRouterData_tag {
+typedef _Packed struct ZISServiceRouterData_tag {
   char eyecatcher[8];
 #define ZIS_SERVICE_ROUTER_EYECATCHER "ZISSREYE"
   unsigned int version;


### PR DESCRIPTION
Signed-off-by: Joe <joe.devlin@gmail.com>

## Proposed changes

I just made the pull request to merge feature/jsonschema into zowe-common-c v2x.staging.   It's really big but mostly is new code, with some significant changes to json.c   There are a bunch of platform compatibility changes and clang/xlclang toleration changes that came in, too.  But they are mostly trivial and the bulk are responses to clang's front-end being much better at complaining about casts and printf format-string compatibility with arguments. (edited) 
[Joe Devlin](https://app.slack.com/team/UKARG36FJ) (https://openmainframeproject.slack.com/archives/C036YJCU9HT/p1647310203964769)

Also the vast bulk of non-ZOS-specific code compiles on Windows (and probably Linux, too) with Clang-12 or later.    Also, this feature brings in subdirectories for /platform that begins to hold backend-OS specific code, and /tests which has many new tests, but should eventually get older tests factored in from various "main()'s" that are "#ifdef-ed" out of many of the c files.


This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [ ] Chore, repository cleanup, updates the dependencies.


## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.


## Testing

Testing by automated ZSS test. 


