### PR TITLE
Fix logging with tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
 
+## `1.28.0`
+
+- Bugfix: Logging via tee could sometimes stop working if too much logging occurred at once. Tail is now used instead.
+
+
 ## `1.27.0`
 
 - Enhancement: Get public key for JWT signature verification using APIML

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -168,7 +168,16 @@ fi
 #Determined log file.  Run zssServer.
 export dir=`dirname "$0"`
 cd $ZSS_SCRIPT_DIR
-_BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ./zssServer "${CONFIG_FILE}" 2>&1 | tee $ZSS_LOG_FILE
+
+
+
+# This was used to log to stdout and a file at the same time, but it seems tee crashes if too much is logged at once
+# _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ./zssServer "${CONFIG_FILE}" 2>&1 | tee $ZSS_LOG_FILE
+
+# This is now used to log to stdout and file instead. tail seems to be fine with massive logging.
+touch $ZSS_LOG_FILE
+tail -f $ZSS_LOG_FILE &
+_BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ./zssServer "${CONFIG_FILE}" 2>&1 > $ZSS_LOG_FILE
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Enable all logging from a PR such as https://github.com/zowe/zss/pull/440
You may notice that tee will crash, particularly with these commented out loggers:
```
  "logLevels": {
  "_zsf.*":5,

  "_zss.traceLevel": 5,
  //zowe-common-c


  "_zss.alloc": 5,
  "_zss.utils": 5,
  "_zss.collections": 5,
  "_zss.serialization": 5,

  "_zss.zlparser": 5,
  "_zss.zlcompiler": 5,
  "_zss.zlruntime": 5,
  "_zss.stcbase": 5,

//  "_zss.httpserver": 5,
  "_zss.discovery": 5,
  "_zss.cms": 5,

  "_zss.lpa": 5,
  "_zss.resetdataset": 5,
  "_zss.restfile": 5,
//  "_zss.zos": 5,

  "_zss.httpclient": 5,
  "_zss.jwt": 5,

  //zss
//  "_zss.mvdserver": 5,
  "_zss.ctds": 5,

  "_zss.security": 5,
  "_zss.unixfile": 5,
//  "_zss.dataservice": 5,
  "_zss.apimlstorage": 5,
  "_zss.jwk": 5
  }
```

Tee may generate an error like 
```
bufferSize tee: FSUM6260 write error on file "211##[standard output]": EDC5122I Input/output error. (errno2=0x02210160)
```

In order to retain the functionality of logging to a file and stdout at the same time, I just switched from tee to tail. This seems to give the same goal but without the crashing part. In this case, I can turn on all loggers no problem.