### PR TITLE
Do not use tee when no log is being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the ZSS package will be documented in this file.
 
 - Breaking change: Cookie name now has a suffix which includes the port or if in an HA instance, the HA ID.
 - Enhancement: New configuration option that allows to run 64-bit ZSS
-
+- Bugfix: Do not use "tee" when log destination is /dev/null
 
 ## `1.27.0`
 

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -162,11 +162,18 @@ else
   ZSS_SERVER="${ZSS_SERVER_31}"
 fi
 
-if [ -f "$CONFIG_FILE" ]
-then
-  _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} "${CONFIG_FILE}" 2>&1 | tee $ZWES_LOG_FILE
+if [ -f "$CONFIG_FILE" ]; then
+  if [ "$ZWES_LOG_FILE" = "/dev/null" ]; then
+    _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} "${CONFIG_FILE}" 2>&1
+  else
+    _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} "${CONFIG_FILE}" 2>&1 | tee $ZWES_LOG_FILE
+  fi
 else
-  _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} 2>&1 | tee $ZWES_LOG_FILE
+  if [ "$ZWES_LOG_FILE" = "/dev/null" ]; then
+    _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} 2>&1
+  else
+    _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ${ZSS_SERVER} 2>&1 | tee $ZWES_LOG_FILE
+  fi
 fi
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies


### PR DESCRIPTION
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
An issue was noted where tee can crash if logging is too big, and tail is no better.
Therefore, in the event that you need to turn on tracing logs, its best to also write to stdout (or job) rather than to a file. In this case, simply setting the log destination as /dev/null will disable use of tee.