### PR TITLE
Fix jobname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
 
+## v1.28.0
+
+- Bugfix: ZSS had a jobname prefix regression for several releases when it recieved an incorrect value for ZOWE_PREFIX when LAUNCH_COMPONENT_GROUPS included GATEWAY
+
+
 ## `1.27.0`
 
 - Enhancement: Get public key for JWT signature verification using APIML

--- a/bin/zssServer.sh
+++ b/bin/zssServer.sh
@@ -168,6 +168,16 @@ fi
 #Determined log file.  Run zssServer.
 export dir=`dirname "$0"`
 cd $ZSS_SCRIPT_DIR
+
+# Weird bug in recent releases has app-server not having the same jobname prefix as other services.
+# This only happens when LAUNCH_COMPONENT_GROUPS includes GATEWAY.
+# Possibly due to hacks elsewhere that we weren't notified of https://github.com/zowe/zowe-install-packaging/commit/0ccb77afca8f6dd8e2782c25490283739ab2791c
+if [ -n "${ZOWE_INSTANCE}" ]; then
+  if [[ "${ZOWE_PREFIX}" != *"${ZOWE_INSTANCE}" ]]; then
+    export ZOWE_PREFIX=${ZOWE_PREFIX}${ZOWE_INSTANCE}
+  fi
+fi
+
 _BPX_SHAREAS=NO _BPX_JOBNAME=${ZOWE_PREFIX}SZ1 ./zssServer "${CONFIG_FILE}" 2>&1 | tee $ZSS_LOG_FILE
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies


### PR DESCRIPTION
## Proposed changes

Some users have reported that the jobname of some servers have changed. This appears to effect zss when the gateway group is running, but regardless a solution could be to force the zowe prefix to include the zowe instance. While modifying a user-configured variable to include another user-configured variable this seems wrong, it's what the rest of the code has been doing for a very long time, so I'm repeating it to be in alignment.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

Start Zowe up via STC to see if the jobname of app-server is for example ZWE1DS1 versus ZWEDS1.