### PR TITLE
Allow faster zss startup via JS usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `2.3.0`
 
 - Enhancment: ZSS now utilizes the configuration parameters present in the zowe configuration file via the configmgr, simplifying the startup of ZSS and increasing the validation of its parameters. The file zss/defaults.yaml shows the default configuration parameters of zss, in combination with the schema of the parameters within zss/schemas, though some parameters are derived from zowe-wide parameters or from other components when they involve those other components.
+- Enhancement: Improved startup time due to using the configmgr to process plugin registration, and only when the app-server is not enabled, as the app-server does the same thing.
 
 ## `2.0.0`
 

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -21,24 +21,7 @@ if [ -n "${ZWE_components_zss_pluginsDir}" ]; then
   mkdir -p "${ZWE_components_zss_pluginsDir}"
 fi
 
-# this is to resolve (builtin) plugins that use ZLUX_ROOT_DIR as a relative path. if it doesnt exist, the plugins shouldn't either, so no problem
-if [ -z "${ZLUX_ROOT_DIR}" ]; then
-  if [ -d "${ZWE_zowe_runtimeDirectory}/components/app-server/share" ]; then
-    export ZLUX_ROOT_DIR="${ZWE_zowe_runtimeDirectory}/components/app-server/share"
-  fi
-fi
-
-# This location will have init and utils folders inside and is used to gather env vars and do plugin initialization
-helper_script_location="${ZLUX_ROOT_DIR}/zlux-app-server/bin"
-
-if [ -d "${helper_script_location}" ]; then
-  cd "${helper_script_location}/init"
-  . ../utils/convert-env.sh
-
-  # Register/deregister plugins according to their enabled status
-  NO_NODE=1
-  . ./plugins-init.sh $NO_NODE
-
-  cd "${COMPONENT_HOME}/bin"
+if [ "${ZWE_components_app_server_enabled}" != "true" ]; then
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/components/zss/bin/plugins-init.js"  
 fi
 

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -14,6 +14,9 @@
 
 COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/zss
 
+# Some builtin plugins reference themselves via this, so we need to know where app-server is even if not running
+export ZLUX_ROOT_DIR=${ZWE_zowe_runtimeDirectory}/components/app-server/share
+
 if [ -n "${ZWE_components_zss_instanceDir}" ]; then
   mkdir -p "${ZWE_components_zss_instanceDir}"
 fi

--- a/bin/plugins-init.js
+++ b/bin/plugins-init.js
@@ -1,0 +1,131 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+import * as os from 'os';
+import * as zos from 'zos';
+import * as std from 'std';
+import * as xplatform from 'xplatform';
+
+console.log(`Started plugins-init.js, platform=${os.platform}`);
+
+const runtimeDirectory=std.getenv('ZWE_zowe_runtimeDirectory');
+const extensionDirectory=std.getenv('ZWE_zowe_extensionDirectory');
+const workspaceDirectory=std.getenv('ZWE_zowe_workspaceDirectory');
+
+
+// This can be used to load useful js libraries present within zowe
+// But it's not recommended for extenders because this is internal, undocumented code
+// Which could have a change in behavior between versions of zowe
+// It is being used here because app-server is shipped within zowe, so behavior is kept in sync
+let fs, componentlib;
+async function importModule() {
+  try {
+    fs = await import(`${runtimeDirectory}/bin/libs/fs`);
+    componentlib = await import(`${runtimeDirectory}/bin/libs/component`);
+  } catch (error) {
+    console.error('import failed');
+    std.exit(1);
+  }
+}
+
+importModule().then(()=> {
+  const installedComponentsEnv=std.getenv('ZWE_INSTALLED_COMPONENTS');
+  const installedComponents = installedComponentsEnv ? installedComponentsEnv.split(',') : null;
+
+  const enabledComponentsEnv=std.getenv('ZWE_ENABLED_COMPONENTS');
+  const enabledComponents = enabledComponentsEnv ? enabledComponentsEnv.split(',') : null;
+
+  const pluginPointerDirectory = `${workspaceDirectory}/app-server/plugins`;
+
+  function deleteFile(path) {
+    return os.remove(path);
+  }
+
+  function registerPlugin(path, pluginDefinition) {
+    const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
+    if (fs.fileExists(filePath)) {
+      return true;
+    } else {
+      let location, relativeTo;
+      const index = path.indexOf(runtimeDirectory);
+      if (index != -1) {
+        relativeTo = "$ZWE_zowe_runtimeDirectory";
+        location = filePath.substring(index);
+
+
+        return xplatform.storeFileUTF8(filePath, xplatform.AUTO_DETECT, JSON.stringify({
+          "identifier": pluginDefinition.identifier,
+          "pluginLocation": location,
+          "relativeTo": relativeTo
+        }, null, 2));
+      } else {
+        return xplatform.storeFileUTF8(filePath, xplatform.AUTO_DETECT, JSON.stringify({
+          "identifier": pluginDefinition.identifier,
+          "pluginLocation": filePath
+        }, null, 2));
+      }
+    }
+  }
+
+  function deregisterPlugin(pluginDefinition) {
+    const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
+    if (fs.fileExists(filePath, true)) {
+      const rc = deleteFile(filePath);
+      if (rc !== 0) {
+        console.log(`Could not deregister plugin ${pluginDefinition.identifier}, delete ${filePath} failed, error=${rc}`);
+      }
+      return rc !== 0;
+    } else {
+      return true;
+    }
+  }
+
+  if (!fs.directoryExists(pluginPointerDirectory, true)) {
+    const rc = os.mkdir(pluginPointerDirectory, 0o770);
+    if (rc < 0) {
+      console.log(`Could not create pluginsDir=${pluginPointerDirectory}, err=${rc}`);
+      std.exit(2);
+    }
+  }
+
+  console.log("Start iteration");
+
+  //A port of https://github.com/zowe/zlux-app-server/blob/v2.x/staging/bin/init/plugins-init.sh
+
+  installedComponents.forEach(function(installedComponent) {
+    const componentDirectory = componentlib.findComponentDirectory(installedComponent);
+    if (componentDirectory) {
+      const enabled = enabledComponents.includes(installedComponent);
+      console.log(`Checking plugins for component=${installedComponent}, enabled=${enabled}`);
+
+      const manifest = componentlib.getManifest(componentDirectory);
+      if (manifest.appfwPlugins) {
+        manifest.appfwPlugins.forEach(function (manifestPluginRef) {
+          const path = manifestPluginRef.path;
+          const fullPath = `${componentDirectory}/${path}`
+          const pluginDefinition = componentlib.getPluginDefinition(fullPath);
+          if (pluginDefinition) {
+            if (enabled) {
+              console.log(`Registering plugin ${fullPath}`);
+              registerPlugin(fullPath, pluginDefinition);
+            } else {
+              console.log(`Deregistering plugin ${fullPath}`);
+              deregisterPlugin(pluginDefinition);
+            }
+          } else {
+            console.log(`Skipping plugin at ${fullPath} due to pluginDefinition missing or invalid`);
+          }
+        });
+      }
+    } else {
+      console.log(`Warning: Could not remove app framework plugins for extension ${installedComponent} because its directory could not be found within ${extensionDirectory}`);
+    }
+  });
+});

--- a/bin/plugins-init.js
+++ b/bin/plugins-init.js
@@ -12,6 +12,8 @@ import * as os from 'os';
 import * as zos from 'zos';
 import * as std from 'std';
 import * as xplatform from 'xplatform';
+import * as fs from '../../../bin/libs/fs';
+import * as componentlib from '../../../bin/libs/component';
 
 console.log(`Started plugins-init.js, platform=${os.platform}`);
 
@@ -19,113 +21,97 @@ const runtimeDirectory=std.getenv('ZWE_zowe_runtimeDirectory');
 const extensionDirectory=std.getenv('ZWE_zowe_extensionDirectory');
 const workspaceDirectory=std.getenv('ZWE_zowe_workspaceDirectory');
 
+const installedComponentsEnv=std.getenv('ZWE_INSTALLED_COMPONENTS');
+const installedComponents = installedComponentsEnv ? installedComponentsEnv.split(',') : null;
 
-// This can be used to load useful js libraries present within zowe
-// But it's not recommended for extenders because this is internal, undocumented code
-// Which could have a change in behavior between versions of zowe
-// It is being used here because app-server is shipped within zowe, so behavior is kept in sync
-let fs, componentlib;
-async function importModule() {
-  try {
-    fs = await import(`${runtimeDirectory}/bin/libs/fs`);
-    componentlib = await import(`${runtimeDirectory}/bin/libs/component`);
-  } catch (error) {
-    console.error('import failed');
-    std.exit(1);
+const enabledComponentsEnv=std.getenv('ZWE_ENABLED_COMPONENTS');
+const enabledComponents = enabledComponentsEnv ? enabledComponentsEnv.split(',') : null;
+
+const pluginPointerDirectory = `${workspaceDirectory}/app-server/plugins`;
+
+function deleteFile(path) {
+  return os.remove(path);
+}
+
+function registerPlugin(pluginPath, pluginDefinition) {
+  const pointerPath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
+  if (fs.fileExists(pointerPath)) {
+    return true;
+  } else {
+    let location, relativeTo;
+    if (pluginPath.startsWith(runtimeDirectory)) {
+      relativeTo = "$ZWE_zowe_runtimeDirectory";
+      location = pluginPath.substring(runtimeDirectory.length);
+      if (location.startsWith('/')) {
+        location = location.substring(1);
+      }
+
+      return xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
+        "identifier": pluginDefinition.identifier,
+        "pluginLocation": location,
+        "relativeTo": relativeTo
+      }, null, 2));
+    } else {
+      return xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
+        "identifier": pluginDefinition.identifier,
+        "pluginLocation": pluginPath
+      }, null, 2));
+    }
   }
 }
 
-importModule().then(()=> {
-  const installedComponentsEnv=std.getenv('ZWE_INSTALLED_COMPONENTS');
-  const installedComponents = installedComponentsEnv ? installedComponentsEnv.split(',') : null;
-
-  const enabledComponentsEnv=std.getenv('ZWE_ENABLED_COMPONENTS');
-  const enabledComponents = enabledComponentsEnv ? enabledComponentsEnv.split(',') : null;
-
-  const pluginPointerDirectory = `${workspaceDirectory}/app-server/plugins`;
-
-  function deleteFile(path) {
-    return os.remove(path);
-  }
-
-  function registerPlugin(path, pluginDefinition) {
-    const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
-    if (fs.fileExists(filePath)) {
-      return true;
-    } else {
-      let location, relativeTo;
-      const index = path.indexOf(runtimeDirectory);
-      if (index != -1) {
-        relativeTo = "$ZWE_zowe_runtimeDirectory";
-        location = filePath.substring(index);
-
-
-        return xplatform.storeFileUTF8(filePath, xplatform.AUTO_DETECT, JSON.stringify({
-          "identifier": pluginDefinition.identifier,
-          "pluginLocation": location,
-          "relativeTo": relativeTo
-        }, null, 2));
-      } else {
-        return xplatform.storeFileUTF8(filePath, xplatform.AUTO_DETECT, JSON.stringify({
-          "identifier": pluginDefinition.identifier,
-          "pluginLocation": filePath
-        }, null, 2));
-      }
+function deregisterPlugin(pluginDefinition) {
+  const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
+  if (fs.fileExists(filePath, true)) {
+    const rc = deleteFile(filePath);
+    if (rc !== 0) {
+      console.log(`Could not deregister plugin ${pluginDefinition.identifier}, delete ${filePath} failed, error=${rc}`);
     }
+    return rc !== 0;
+  } else {
+    return true;
   }
+}
 
-  function deregisterPlugin(pluginDefinition) {
-    const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
-    if (fs.fileExists(filePath, true)) {
-      const rc = deleteFile(filePath);
-      if (rc !== 0) {
-        console.log(`Could not deregister plugin ${pluginDefinition.identifier}, delete ${filePath} failed, error=${rc}`);
-      }
-      return rc !== 0;
-    } else {
-      return true;
-    }
+if (!fs.directoryExists(pluginPointerDirectory, true)) {
+  const rc = fs.mkdirp(pluginPointerDirectory);
+  if (rc < 0) {
+    console.log(`Could not create pluginsDir=${pluginPointerDirectory}, err=${rc}`);
+    std.exit(2);
   }
+}
 
-  if (!fs.directoryExists(pluginPointerDirectory, true)) {
-    const rc = os.mkdir(pluginPointerDirectory, 0o770);
-    if (rc < 0) {
-      console.log(`Could not create pluginsDir=${pluginPointerDirectory}, err=${rc}`);
-      std.exit(2);
-    }
-  }
+console.log("Start iteration");
 
-  console.log("Start iteration");
+//A port of https://github.com/zowe/zlux-app-server/blob/v2.x/staging/bin/init/plugins-init.sh
 
-  //A port of https://github.com/zowe/zlux-app-server/blob/v2.x/staging/bin/init/plugins-init.sh
+installedComponents.forEach(function(installedComponent) {
+  const componentDirectory = componentlib.findComponentDirectory(installedComponent);
+  if (componentDirectory) {
+    const enabled = enabledComponents.includes(installedComponent);
+    console.log(`Checking plugins for component=${installedComponent}, enabled=${enabled}`);
 
-  installedComponents.forEach(function(installedComponent) {
-    const componentDirectory = componentlib.findComponentDirectory(installedComponent);
-    if (componentDirectory) {
-      const enabled = enabledComponents.includes(installedComponent);
-      console.log(`Checking plugins for component=${installedComponent}, enabled=${enabled}`);
-
-      const manifest = componentlib.getManifest(componentDirectory);
-      if (manifest.appfwPlugins) {
-        manifest.appfwPlugins.forEach(function (manifestPluginRef) {
-          const path = manifestPluginRef.path;
-          const fullPath = `${componentDirectory}/${path}`
-          const pluginDefinition = componentlib.getPluginDefinition(fullPath);
-          if (pluginDefinition) {
-            if (enabled) {
-              console.log(`Registering plugin ${fullPath}`);
-              registerPlugin(fullPath, pluginDefinition);
-            } else {
-              console.log(`Deregistering plugin ${fullPath}`);
-              deregisterPlugin(pluginDefinition);
-            }
+    const manifest = componentlib.getManifest(componentDirectory);
+    if (manifest.appfwPlugins) {
+      manifest.appfwPlugins.forEach(function (manifestPluginRef) {
+        const path = manifestPluginRef.path;
+        const fullPath = `${componentDirectory}/${path}`
+        const pluginDefinition = componentlib.getPluginDefinition(fullPath);
+        if (pluginDefinition) {
+          if (enabled) {
+            console.log(`Registering plugin ${fullPath}`);
+            registerPlugin(fullPath, pluginDefinition);
           } else {
-            console.log(`Skipping plugin at ${fullPath} due to pluginDefinition missing or invalid`);
+            console.log(`Deregistering plugin ${fullPath}`);
+            deregisterPlugin(pluginDefinition);
           }
-        });
-      }
-    } else {
-      console.log(`Warning: Could not remove app framework plugins for extension ${installedComponent} because its directory could not be found within ${extensionDirectory}`);
+        } else {
+          console.log(`Skipping plugin at ${fullPath} due to pluginDefinition missing or invalid`);
+        }
+      });
     }
-  });
+  } else {
+    console.log(`Warning: Could not remove app framework plugins for extension ${installedComponent} because its directory could not be found within ${extensionDirectory}`);
+  }
 });
+

--- a/c/jwk.c
+++ b/c/jwk.c
@@ -85,7 +85,7 @@ static int jwkTaskMain(RLETask *task) {
   JwkContext *context = (JwkContext*)task->userPointer;
   JwkSettings *settings = context->settings;
   const int maxAttempts = 1000;
-  const int retryIntervalSeconds = 30;
+  const int retryIntervalSeconds = settings->retryIntervalSeconds;
   bool success = false;
 
   for (int i = 0; i < maxAttempts; i++) {

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -679,6 +679,8 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
   char *routeFileName = cleanURLParamValue(response->slh, encodedRouteFileName);
   unsigned int currUnixTime = (unsigned)time(NULL);
 
+  zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG, "Serve unix file contents method=%s, path=%s\n",request->method, routeFileName);
+
   if (!strcmp(request->method, methodPUT)) {
     UploadSessionTracker *tracker = service->userPointer;
 

--- a/c/zss.c
+++ b/c/zss.c
@@ -1508,6 +1508,18 @@ static void logLevelConfiguratorV2(ConfigManager *configmgr){
   readAndConfigureLogLevelFromConfig(logComponent, configmgr, LOGGING_COMPONENT_PREFIX);
   LogComponentsMap *zssLogComponent = (LogComponentsMap *)zssLogComponents;
   readAndConfigureLogLevelFromConfig(zssLogComponent, configmgr, LOGGING_COMPONENT_PREFIX);
+
+  /* special (old!) ones that arent real loggers, just trace conditionals */  
+  TraceDefinition *traceDef = traceDefs;
+  int logLevel;
+
+  while (traceDef->name != 0){
+    int cfgStatus = cfgGetIntC(configmgr,ZSS_CFGNAME,&logLevel,4,"components","zss","logLevels",(char*) traceDef->name);
+    if (!cfgStatus && isLogLevelValid(logLevel)) {
+      traceDef->function(logLevel);
+    }
+    ++traceDef;
+  }
 }
 
 #define NOT_INTEGER 8

--- a/c/zss.c
+++ b/c/zss.c
@@ -1040,6 +1040,7 @@ static JwkSettings *readJwkSettingsV2(ShortLivedHeap *slh, ConfigManager *config
   settings->host = host; 
   settings->port = port;
   settings->tlsEnv = tlsEnv;
+  settings->retryIntervalSeconds=getJwtRetryIntervalSeconds(configmgr);
   settings->timeoutSeconds = 10;
   settings->path = "/gateway/api/v1/auth/keys/public/current";
   settings->fallback = fallback;
@@ -1300,6 +1301,19 @@ static bool isJwtFallbackEnabledV2(ConfigManager *configmgr){
     return false;
   }
 }
+
+static int getJwtRetryIntervalSeconds(ConfigManager *configmgr) {
+  int retryVal = 0;
+  int retryDefault = 10;
+  int getStatus = cfgGetIntC(configmgr, ZSS_CFGNAME, &retryVal, 5, "components", "zss", "agent", "jwt", "retryIntervalSeconds");
+  if (getStatus != ZCFG_SUCCESS) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "Error loading components.zss.agent.jwt.retryIntervalSeconds, defaulting to %d\n", retryDefault);
+    return retryDefault;
+  } else{
+    return retryVal;
+  }
+}
+
 
 static bool isJwtFallbackEnabled(JsonObject *serverConfig, JsonObject *envSettings) {
   Json *fallbackJson = jsonObjectGetPropertyValue(envSettings, ENV_AGENT_JWT_KEY("fallback"));

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -12,6 +12,7 @@ components:
       64bit: true
       jwt:
         fallback: true
+        retryIntervalSeconds: 10
       https:
         keyring: ${{ ()=> { if (components.zss.tls) { if (zowe.certificate.keystore.type == "JCERACFKS") { return zowe.certificate.keystore.file.substring(15) } else { return zowe.certificate.keystore.file } } else { return null } }() }}
         password: ${{ ()=> { if (components.zss.tls) { return zowe.certificate.keystore.password } else { null } }() }}

--- a/h/jwk.h
+++ b/h/jwk.h
@@ -25,6 +25,7 @@ struct JwkSettings_tag {
   int timeoutSeconds;
   char *path;
   bool fallback;
+  int retryIntervalSeconds;
 };
 
 struct JwkContext_tag {

--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -155,7 +155,12 @@
             "fallback": {
               "type": "boolean",
               "description": "Whether the agent will issue and accept cookies from itself in the event a JWT cannot be provided"
-            }
+            },
+            "retryIntervalSeconds": {
+              "type": "integer",
+              "description": "The time in seconds to wait between attempts to reach the JWT provider in case they are inaccessible",
+              "minimum": 1,
+              "maximum": 60
           }
         }
       }


### PR DESCRIPTION
By using the same plugin registration logic that app-server uses, conditional to app-server not being present, the zss server can startup quicker in a standard zowe environment. This saves about 1 minute of startup time.
The only issue with this PR is that it is straight code duplication. I copied a file from zlux-app-server into here.
I do not expect this file to need many changes over time, so I figure the performance tradeoff is worthwhile.