### PR TITLE
Make schema multi-file 

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -15,7 +15,9 @@ keywords:
   - appfw
 license: EPL-2.0
 schemas:
-  configs: schemas/zowe-schema.json
+  configs: 
+  - schemas/zowe-schema.json
+  - schemas/zss-config.json
 repository:
   type: git
   url: https://github.com/zowe/zss.git

--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -4,7 +4,6 @@
   "title": "zss configuration",
   "description": "Configuration properties for zss, as specified within a configuration file such as zowe.yaml",
   "type": "object",
-  "required": [ "pluginsDir", "instanceDir", "productDir", "tls", "dataserviceAuthentication", "agent" ],
   "additionalProperties": true,
   "properties": {
     "tls": {


### PR DESCRIPTION
We have multiple schema files for app-server config and so we have to declare it as such in order to be compatible with component validation as seen in https://github.com/zowe/zowe-install-packaging/pull/3006