### PR TITLE
Dynamic version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the ZSS package will be documented in this file.
 ## `2.5.0`
 
 - Bugfix: In 2.3 and 2.4, 'safkeyring://' syntax stopped working, only allowing 'safkeyring:////'. Now, support for both is restored.
+- Support ZIS runtime version check 
+- Update the dynamic linkage stub vector to include new functions
 
 ## `2.4.0`
 

--- a/c/zis/server-api.c
+++ b/c/zis/server-api.c
@@ -32,9 +32,34 @@ _Bool zisIsLPADevModeOn(const ZISContext *context) {
 }
 
 void zisGetServerVersion(int *major, int *minor, int *revision) {
-  *major = ZIS_MAJOR_VERSION;
-  *minor = ZIS_MINOR_VERSION;
-  *revision = ZIS_REVISION;
+  *major = -1;
+  *minor = -1;
+  *revision = -1;
+  CAA *caa = (CAA *)getCAA();
+  if (caa == NULL) {
+    return;
+  }
+  RLETask *task = caa->rleTask;
+  if (task == NULL) {
+    return;
+  }
+  RLEAnchor *rleAnchor = task->anchor;
+  if (rleAnchor == NULL) {
+    return;
+  }
+  ZISContext *context = NULL;
+  if (getRLEApplicationAnchor(rleAnchor, (void **)&context)) {
+    return;
+  }
+  if (!(context->zisAnchor->flags & ZIS_SERVER_ANCHOR_VERSIONED_CONTEXT)) {
+    return;
+  }
+  if (context->version < ZIS_CONTEXT_VERSION_ZIS_VERSION_SUPPORT) {
+    return;
+  }
+  *major = context->zisVersion.major;
+  *minor = context->zisVersion.minor;
+  *revision = context->zisVersion.revision;
 }
 
 /*

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -1109,6 +1109,7 @@ ZISServerAnchor *createZISServerAnchor() {
   
   /* new feature bit for dynamic linking - Fall 2021 */
   anchor->flags |= ZIS_SERVER_ANCHOR_FLAG_DYNLINK;
+  anchor->flags |= ZIS_SERVER_ANCHOR_VERSIONED_CONTEXT;
 
   return anchor;
 }
@@ -1116,6 +1117,10 @@ ZISServerAnchor *createZISServerAnchor() {
 static void enableDynLink(ZISServerAnchor *anchor) {
   /* new feature bit for dynamic linking - Fall 2021 */
   anchor->flags |= ZIS_SERVER_ANCHOR_FLAG_DYNLINK;
+}
+
+static void enableVersionedContext(ZISServerAnchor *anchor) {
+  anchor->flags |= ZIS_SERVER_ANCHOR_VERSIONED_CONTEXT;
 }
 
 static void removeZISServerAnchor(ZISServerAnchor **anchor) {
@@ -1143,6 +1148,8 @@ static int initGlobalResources(ZISContext *context) {
   } else {
     // make sure any existing anchors supports dynamic linkage now
     enableDynLink(anchor);
+    // make sure it also supports a versioned ZIS context
+    enableVersionedContext(anchor);
   }
   context->zisAnchor = anchor;
 
@@ -1158,6 +1165,11 @@ static ZISContext makeContext(STCBase *base) {
 
   ZISContext cntx = {
       .eyecatcher = ZIS_CONTEXT_EYECATCHER,
+      .version = ZIS_CONTEXT_VERSION,
+      .size = sizeof(ZISContext),
+      .zisVersion.major = ZIS_MAJOR_VERSION,
+      .zisVersion.minor = ZIS_MINOR_VERSION,
+      .zisVersion.revision = ZIS_REVISION,
       .stcBase = base,
       .parms = NULL,
       .cmServer = NULL,
@@ -1369,6 +1381,8 @@ static int initContext(ZISContext *context) {
 
   memcpy(context->dynlinkModuleNameNullTerm, context->zisModuleName.text, 4);
   strcat(context->dynlinkModuleNameNullTerm, ZIS_DYN_LINKAGE_PLUGIN_MOD_SUFFIX);
+
+  setRLEApplicationAnchor(context->stcBase->rleAnchor, context);
 
   return RC_ZIS_OK;
 }

--- a/c/zis/stubinit.c
+++ b/c/zis/stubinit.c
@@ -273,6 +273,8 @@
     stubVector[ZIS_STUB_LETMRLEE] = (void*)termRLEEnvironment;
     stubVector[ZIS_STUB_LEMKFCAA] = (void*)makeFakeCAA;
     stubVector[ZIS_STUB_LEARTCAA] = (void*)abortIfUnsupportedCAA;
+    stubVector[ZIS_STUB_LESETANC] = (void*)setRLEApplicationAnchor;
+    stubVector[ZIS_STUB_LEGETANC] = (void*)getRLEApplicationAnchor;
     stubVector[ZIS_STUB_MKLOGCTX] = (void*)makeLoggingContext;
     stubVector[ZIS_STUB_MKLLGCTX] = (void*)makeLocalLoggingContext;
     stubVector[ZIS_STUB_RMLOGCTX] = (void*)removeLoggingContext;

--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -304,6 +304,10 @@
 #define ZISDYN_LOG_DEV_MODE_MSG_TEXT            "ZIS Dynamic base plugin development mode is enabled"
 #define ZISDYN_LOG_DEV_MODE_MSG                 ZISDYN_LOG_DEV_MODE_MSG_ID" "ZISDYN_LOG_DEV_MODE_MSG_TEXT
 
+#define ZISDYN_LOG_BAD_ZIS_VERSION_MSG_ID       ZIS_MSG_PRFX"0214E"
+#define ZISDYN_LOG_BAD_ZIS_VERSION_MSG_TEXT     "Bad cross-memory server version: expected [%d.%d.%d, %d.0.0), found %d.%d.%d"
+#define ZISDYN_LOG_BAD_ZIS_VERSION_MSG          ZISDYN_LOG_BAD_ZIS_VERSION_MSG_ID" "ZISDYN_LOG_BAD_ZIS_VERSION_MSG_TEXT
+
 #endif /* ZIS_MSG_H_ */
 
 

--- a/h/zis/server-api.h
+++ b/h/zis/server-api.h
@@ -20,7 +20,7 @@
 #pragma map(zisIsLPADevModeOn, "ZISLPADV")
 
 /**
- * Get the version of ZIS.
+ * Get the version of ZIS. In case of failure, all the results are set to -1.
  * @param[out] major The major ZIS version.
  * @param[out] minor The minor ZIS version.
  * @param[out] revision The revision of ZIS (aka the patch version).

--- a/h/zis/server.h
+++ b/h/zis/server.h
@@ -33,9 +33,23 @@ typedef struct ZISContext_tag {
   int cmsFlags;
   EightCharString zisModuleName;
   char dynlinkModuleNameNullTerm[9];
+  char reserved0[3];
+
+  int16_t version;
+#define ZIS_CONTEXT_VERSION 2
+#define ZIS_CONTEXT_VERSION_ZIS_VERSION_SUPPORT 2
+  uint16_t size;
+  uint32_t flags;
+  struct {
+    int32_t major;
+    int32_t minor;
+    int32_t revision;
+  } zisVersion;
+
 } ZISContext;
 
 #define ZIS_SERVER_ANCHOR_FLAG_DYNLINK 0x0001    /* supports dynamic linkage */
+#define ZIS_SERVER_ANCHOR_VERSIONED_CONTEXT 0x0002
 
 typedef struct ZISServerAnchor_tag {
   char eyecatcher[8];

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -20,7 +20,7 @@
    FULL BACKWARD COMPATIBILITY MUST BE MAINTAINED
    */
 
-#define ZIS_STUBS_VERSION 2
+#define ZIS_STUBS_VERSION 3
 
 /*
   How does a user check for compatibility?
@@ -362,6 +362,8 @@
 #define ZIS_STUB_LETMRLEE 457 /* termRLEEnvironment */
 #define ZIS_STUB_LEMKFCAA 458 /* makeFakeCAA */
 #define ZIS_STUB_LEARTCAA 459 /* abortIfUnsupportedCAA */
+#define ZIS_STUB_LESETANC 460 /* setRLEApplicationAnchor */
+#define ZIS_STUB_LEGETANC 461 /* getRLEApplicationAnchor */
 
 /* logging, 470-499 */
 #define ZIS_STUB_MKLOGCTX 470 /* makeLoggingContext */


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
This pull-request add the ability to check the ZIS version dynamically. It is useful to ensure the right ZIS version in a ZIS plugin. Additionally, the stub vector has been updated to include the new respective common functions.

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs:
- https://github.com/zowe/zowe-common-c/pull/343

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Manual testing is needed. QA can try running the dynamic linkage plugin with an incompatible version of ZIS (a different major version, smaller minor version or revision).

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
