### PR TITLE
Fix typo on schema of logger

### DIFF
--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -328,7 +328,7 @@
           "description": "Controls logging of lpa library functions",
           "$ref": "#/$defs/logLevel"
         },
-        "_zss.resetdataset": {
+        "_zss.restdataset": {
           "description": "Controls logging of resetdataset functions",
           "$ref": "#/$defs/logLevel"
         },

--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -329,7 +329,7 @@
           "$ref": "#/$defs/logLevel"
         },
         "_zss.restdataset": {
-          "description": "Controls logging of resetdataset functions",
+          "description": "Controls logging of restdataset functions",
           "$ref": "#/$defs/logLevel"
         },
         "_zss.restfile": {


### PR DESCRIPTION
"_zss.restdataset" could not be used because it was typod as _zss.resetdataset