### PR TITLE
Fixed unixfile/metadata api for spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `2.7.0`
 
 - Enhancement: A new ZIS plugin, "ZISDYNAMIC" is available within the LOADLIB as ZWESISDL. This plugin allows for ZIS plugins to access utility functions of the zowe-common-c libraries without needing to statically build them into the plugin itself.
+- Bugfix: Fixed /unixfile/metadata not working when URL encoded spaces were present in file names
 
 ## `2.5.0`
 

--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -934,7 +934,8 @@ static int serveUnixFileChangeMode(HttpService *service, HttpResponse *response)
 static int serveUnixFileMetadata(HttpService *service, HttpResponse *response) {
   HttpRequest *request = response->request;
   char *fileFrag = stringListPrint(request->parsedFile, 2, 1000, "/", 0);
-  char *fileName = stringConcatenate(response->slh, "/", fileFrag);
+  char *encodedFileName = stringConcatenate(response->slh, "/", fileFrag);
+  char *fileName = cleanURLParamValue(response->slh, encodedFileName);
 
   if (!strcmp(request->method, methodGET)) {
     respondWithUnixFileMetadata(response, fileName);


### PR DESCRIPTION
URLS with spaces such as in the `/unixfile/metadata` API such as  `/unixfile/metadata/u/me/ZLUX%20%20hahaha%20f/sample-iframe-app` would fail with a 4xx code due to lack of url encoding handling.
The other `unixfile` apis already did url encoding correctly, so I just copied the logic to fix the problem, and now the API returns data as expected.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below
