### PR TITLE
Remove some dead logging code that was rewritten in v2

### DIFF
--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -679,9 +679,10 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
   char *routeFileName = cleanURLParamValue(response->slh, encodedRouteFileName);
   unsigned int currUnixTime = (unsigned)time(NULL);
 
-  zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG, "Serve unix file contents method=%s, path=%s\n",request->method, routeFileName);
 
   if (!strcmp(request->method, methodPUT)) {
+    zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG, "Serve PUT unix file contents, path=%s\n", routeFileName);
+
     UploadSessionTracker *tracker = service->userPointer;
 
     removeSessionTimeOuts(tracker, &currUnixTime);
@@ -703,9 +704,13 @@ static int serveUnixFileContents(HttpService *service, HttpResponse *response) {
     }
   }
   else if (!strcmp(request->method, methodGET)) {
+    zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG, "Serve GET unix file contents, path=%s\n", routeFileName);
+
     respondWithUnixFileContentsWithAutocvtMode(NULL, response, routeFileName, TRUE, 0);
   }
   else if (!strcmp(request->method, methodDELETE)) {
+    zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG, "Serve DELETE unix file contents, path=%s\n", routeFileName);
+
     if (doesFileExist(routeFileName) == true) {
       if (isDir(routeFileName) == true) {
         deleteUnixDirectoryAndRespond(response, routeFileName);
@@ -743,6 +748,7 @@ static int serveUnixFileCopy(HttpService *service, HttpResponse *response) {
   char *encodedRouteFileName = stringConcatenate(response->slh, "/", routeFileFrag);
   char *routeFileName = cleanURLParamValue(response->slh, encodedRouteFileName);
   char *newName = getQueryParam(response->request, "newName");
+  zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG, "Serve copy unix file contents, source=%s, target=%s\n", routeFileName, newName);
   if (!newName) {
     respondWithJsonError(response, "newName query parameter is missing", 400, "Bad Request");
     return 0;

--- a/c/zss.c
+++ b/c/zss.c
@@ -125,7 +125,6 @@ static JsonObject *readPluginDefinition(ShortLivedHeap *slh,
                                         char *resolvedPluginLocation);
 static WebPluginListElt* readWebPluginDefinitions(HttpServer* server, ShortLivedHeap *slh, char *dirname,
                                                   ConfigManager *configmgr, ApimlStorageSettings *apimlStorageSettings);
-static void configureAndSetComponentLogLevel(LogComponentsMap *logComponent, JsonObject *logLevels, char *logCompPrefix);
 static JsonObject *readServerSettings(ShortLivedHeap *slh, const char *filename);
 static JsonObject *getDefaultServerSettings(ShortLivedHeap *slh);
 static hashtable *getServerTimeoutsHt(ShortLivedHeap *slh, Json *serverTimeouts, const char *key);
@@ -429,65 +428,6 @@ TraceDefinition traceDefs[] = {
 LOGGING_COMPONENTS_MAP(logComponents)
 
 ZSS_LOGGING_COMPONENTS_MAP(zssLogComponents)
-
-static void configureAndSetComponentLogLevel(LogComponentsMap *logComponent, JsonObject *logLevels, char *logCompPrefix) {
-  int logLevel = ZOWE_LOG_NA;
-  char *logCompName = NULL;
-  int logCompLen = 0;
-  while (logComponent->name != NULL) {
-    logCompLen = strlen(logComponent->name) + strlen (logCompPrefix) + 1;
-    logCompName = (char*) safeMalloc(logCompLen, "Log Component Name");
-    memset(logCompName, '\0', logCompLen);
-    strcpy(logCompName, logCompPrefix);
-    strcat(logCompName, logComponent->name);
-    logConfigureComponent(NULL, logComponent->compID, (char *)logComponent->name,
-                      LOG_DEST_PRINTF_STDOUT, ZOWE_LOG_INFO);
-    if (jsonObjectHasKey(logLevels, logCompName)) {
-      logLevel = jsonObjectGetNumber(logLevels, logCompName);
-      if (isLogLevelValid(logLevel)) {
-        logSetLevel(NULL, logComponent->compID, logLevel);  
-      }
-    }
-    safeFree(logCompName, logCompLen);
-    ++logComponent;
-  }
-}
-
-static JsonObject *readServerSettings(ShortLivedHeap *slh, const char *filename) {
-
-  char jsonErrorBuffer[512] = { 0 };
-  int jsonErrorBufferSize = sizeof(jsonErrorBuffer);
-  Json *mvdSettings = NULL; 
-  JsonObject *mvdSettingsJsonObject = NULL;
-  zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "reading server settings from %s\n", filename);
-  mvdSettings = jsonParseFile(slh, filename, jsonErrorBuffer, jsonErrorBufferSize);
-  if (mvdSettings) {
-    if (jsonIsObject(mvdSettings)) {
-      mvdSettingsJsonObject = jsonAsObject(mvdSettings);
-    } else {
-      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_SEVERE, ZSS_LOG_FILE_EXPECTED_TOP_MSG, filename);
-    }
-    JsonObject *logLevels = jsonObjectGetObject(mvdSettingsJsonObject, "logLevels");
-    if (logLevels) {
-      TraceDefinition *traceDef = traceDefs;
-      while (traceDef->name != 0) {
-        int traceLevel = jsonObjectGetNumber(logLevels, (char*) traceDef->name);
-        if (traceLevel > 0) {
-          traceDef->function(traceLevel);
-        }
-        ++traceDef;
-      }
-      LogComponentsMap *logComponent = (LogComponentsMap *)logComponents;
-      configureAndSetComponentLogLevel(logComponent, logLevels, LOGGING_COMPONENT_PREFIX);
-      LogComponentsMap *zssLogComponent = (LogComponentsMap *)zssLogComponents;
-      configureAndSetComponentLogLevel(zssLogComponent, logLevels, LOGGING_COMPONENT_PREFIX);
-    }
-    dumpJson(mvdSettings);
-  } else {
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_SEVERE, ZSS_LOG_PARS_ZSS_SETTING_MSG, filename, jsonErrorBuffer);
-  }
-  return mvdSettingsJsonObject;
-}
 
 #define DEFAULT_CONFIG "                                               \
                        {                                               \
@@ -1716,14 +1656,6 @@ int main(int argc, char **argv){
   logLevelConfiguratorV2(configmgr);
   JsonObject *mvdSettings = NULL;
   JsonObject *envSettings = NULL;
-  /*
-    JOE: More legacy stuff
-    if (serverConfigFile) {
-      mvdSettings = readServerSettings(slh, serverConfigFile);
-    } else {
-      mvdSettings = getDefaultServerSettings(slh);
-    }
-    */
 
   bool hasProductReg = false;
   if (configmgr) { /* mvdSettings */


### PR DESCRIPTION
I was trying to debug something and needed the loggers turned up, but got stuck looking at unused logging code that has since been replaced. So, let's remove this to prevent confusion, because it was already commented out.