### PR TITLE
space info metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
 
+## `2.8.0`
+
+- Enhancement: /datasetMetadata now returns primarySize, secondarySize, and spaceUnit fields
+
 ## `2.7.0`
 
 - Enhancement: A new ZIS plugin, "ZISDYNAMIC" is available within the LOADLIB as ZWESISDL. This plugin allows for ZIS plugins to access utility functions of the zowe-common-c libraries without needing to statically build them into the plugin itself.

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -478,7 +478,7 @@ static void addDetailsFromDSCB(char *dscb, jsonPrinter *jPrinter, int *isPDS) {
     uint32_t difftrk = hightrk-lowtrk +1;
     zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "diff cyl 0x%x - 0x%x, trk 0x%x - 0x%x is (%d cyl, %d trk)\n", highcyl, lowcyl, hightrk, lowtrk, diffcyl, difftrk);
 
-    uint64_t primarySizeBytes = (diffcyl * 849960) + (difftrk * 56664);
+    uint64_t primarySizeBytes = (diffcyl * bytesPerCylinder) + (difftrk * bytesPerTrack);
     /* debugging of interesting size types
     printf("primarySizeBytes is %lld\n", primarySizeBytes);
     if (sizeType==DATASET_ALLOC_TYPE_MB) {
@@ -501,9 +501,9 @@ static void addDetailsFromDSCB(char *dscb, jsonPrinter *jPrinter, int *isPDS) {
     }
     
     if (sizeType==DATASET_ALLOC_TYPE_CYL) { //cyl & track prime size seems to work reliably based on extent info
-      jsonAddInt(jPrinter, "prime", primarySizeBytes/849960);
+      jsonAddInt(jPrinter, "prime", primarySizeBytes/bytesPerCylinder);
     } else if (sizeType==DATASET_ALLOC_TYPE_TRK) {
-      jsonAddInt(jPrinter, "prime", primarySizeBytes/56664);
+      jsonAddInt(jPrinter, "prime", primarySizeBytes/bytesPerTrack);
     } else { //but other types, the extent info is way too large, so these numbers observed to be closer, often correct.
       if (scxtv){
         zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "scal3=%d, blocksize=%d, primarySizeDiv=%d, scxtv=%d\n", scal3, blockSize, primarySizeDiv, scxtv);
@@ -511,7 +511,7 @@ static void addDetailsFromDSCB(char *dscb, jsonPrinter *jPrinter, int *isPDS) {
           jsonAddInt(jPrinter, "prime", (scal3 * blockSize) / primarySizeDiv);
         } else {
           //this works well for block sizes like 32720 or 27990, but returns somewhat larger than expected values for small block sizes like 320
-          jsonAddInt(jPrinter, "prime", ((scal3 * blockSize) * (56664/blockSize)) / primarySizeDiv);
+          jsonAddInt(jPrinter, "prime", ((scal3 * blockSize) * (bytesPerTrack/blockSize)) / primarySizeDiv);
         }
       } else {
         jsonAddInt(jPrinter, "prime", scal3);


### PR DESCRIPTION
## Proposed changes
Updates the /datasetMetadata api for space, prime, and secnd fields for telling size information about each dataset.

Getting the space for "prime" correct has been challenging. DSCB extent info on how many tracks/cylinders are occupied can be way different from what something like ispf reports, depending on several factors such as unit  type.
So, this api currently sometimes uses the cyl/track info found, and sometimes instead relies upon a combination of other size-related fields found in the DSCB. This compromise passes most of my testing, with remaining areas of improvement when size type=block or blocksize is small.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
You can test this in the zowe editor, point it at any datasets you want.
I left some warnings in the code in case datasets i didn't find in my own environment were discovered, so that logic can be tuned to accomodate them.

Bug: datasets that are block-sized dont have proper reporting of primary/secondary unit, not sure how the math works here yet.