### PR TITLE
Fix byte allocation by using DALAVGR instead of DALTRK or DALCYL

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -2800,12 +2800,12 @@ static int setDatasetAttributesForCreation(JsonObject *object, int *configsCount
           // https://www.ibm.com/docs/en/zos/2.1.0?topic=statement-avgrec-parameter
             if (!avgrSet) {
               avgrSet=true;
-              rc = setTextUnit(TEXT_UNIT_CHAR, 0, NULL, DALDSORD_UREC, DALAVGR, configsCount, inputTextUnit);
+              rc = setTextUnit(TEXT_UNIT_CHAR, 0, NULL, DALDSORG_UREC, DALAVGR, configsCount, inputTextUnit);
             }
           } else if (!strcmp(spaceType, "KB")) {
             if (!avgrSet) {
               avgrSet=true;
-              rc = setTextUnit(TEXT_UNIT_CHAR, 0, NULL, DALDSORD_KREC, DALAVGR, configsCount, inputTextUnit);
+              rc = setTextUnit(TEXT_UNIT_CHAR, 0, NULL, DALDSORG_KREC, DALAVGR, configsCount, inputTextUnit);
             }
           } else if (!strcmp(spaceType, "MB")) {
             if (!avgrSet) {


### PR DESCRIPTION
In https://github.com/zowe/zss/pull/530 a mistake was made where the code assumed either DALTRK or DALCYL must be set. That's not true - if neither are set, allocation is going to be in bytes, which then requires DALAVGR but also block length to be specified.
In our API, avgr can be set directly, but because the "space" field also exists for specifying trk/cyl, "space" can contain byte types which would mean the same thing as avgr, so there's 2 ways to say you are working with bytes.
This PR checks to prevent setting DALAVGR twice, but gives the user the freedom to set it one way or the other.