### PR TITLE
Pass ZIS version to dynlink and use it for ZIS check

### DIFF
--- a/build/build_dynamic.sh
+++ b/build/build_dynamic.sh
@@ -42,6 +42,9 @@ echo "Version: $major.$minor.$micro"
 echo "Date stamp: $date_stamp"
 
 xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
+  -DZIS_MAJOR_VERSION="$major" \
+  -DZIS_MINOR_VERSION="$minor" \
+  -DZIS_REVISION="$micro" \
   -DZISDYN_MAJOR_VERSION="$major" \
   -DZISDYN_MINOR_VERSION="$minor" \
   -DZISDYN_REVISION="$micro" \

--- a/c/zis/zisdynamic.c
+++ b/c/zis/zisdynamic.c
@@ -399,13 +399,13 @@ static int verifyZISVersion(void) {
   zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
           "ZIS major=%d, minor=%d, rev=%d\n", zisMajor, zisMinor, zisRev);
 
-  if (zisMajor != ZISDYN_MAJOR_VERSION) {
+  if (zisMajor != ZIS_MIN_MAJOR_VERSION) {
     goto out_bad_version;
   }
-  if (zisMinor < ZISDYN_MINOR_VERSION) {
+  if (zisMinor < ZIS_MIN_MINOR_VERSION) {
     goto out_bad_version;
   }
-  if (zisMinor == ZISDYN_MINOR_VERSION && zisRev < ZISDYN_REVISION) {
+  if (zisMinor == ZIS_MIN_MINOR_VERSION && zisRev < ZIS_MIN_REVISION) {
     goto out_bad_version;
   }
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This pull-request changes the dynamic linkage base plugin build script to pass the ZIS version to the plugin. The plugin then uses that version to check whether the host ZIS is compatible with it. This also fixes, the `ZWES0214E` message since it's expected those ZIS version `#define`'s to be present (they weren't before this commit hence incorrect values in the message).

This PR addresses Issue: #586

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

Use the ZIS dynamic linkage plugin with a lower version of ZIS. There should be a `ZWES0214E` message printed with the correct required version range.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
