### PR TITLE
Fix incorrect RCs reported in zisReadParmlib

### DIFF
--- a/c/zis/parm.c
+++ b/c/zis/parm.c
@@ -433,8 +433,8 @@ int zisReadParmlib(ZISParmSet *parms, const char *ddname, const char *member,
       freeReadBuffer(readBuffer);
       readBuffer = NULL;
     } else {
-      readStatus->internalRC = allocRC;
-      readStatus->internalRSN = allocRSN;
+      readStatus->internalRC = readRC;
+      readStatus->internalRSN = readRSN;
       status = RC_ZISPARM_PARMLIB_READ_FAILED;
     }
 
@@ -467,8 +467,8 @@ int zisReadParmlib(ZISParmSet *parms, const char *ddname, const char *member,
       ddnameAllocated = false;
     } else {
       if (status != RC_ZISPARM_OK) {
-        readStatus->internalRC = allocRC;
-        readStatus->internalRSN = allocRSN;
+        readStatus->internalRC = freeRC;
+        readStatus->internalRSN = freeRSN;
         status = RC_ZISPARM_PARMLIB_FREE_FAILED;
       }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The `zisReadParmlib` function returns `allocRC` and `allocRSN` when unrelated calls fail. This PR changes it to return the correct return and reason codes.

This PR addresses Issue: N/A

This PR depends upon the following PRs: N/A

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
