### PR TITLE
Disable dynamic zis plugin by default

### DIFF
--- a/samplib/zis/ZWESIP00
+++ b/samplib/zis/ZWESIP00
@@ -57,10 +57,11 @@
 //*                                                                  */
 //********************************************************************/
 
-//* This plugin should be first. The order of plugins is important   */
+//* If enabled, this plugin should be first.                         */
+//*   The order of plugins is important                              */
 //*   because a plugin that is a dependency of another should be     */
 //*   higher in the list for access as early as needed               */
-ZWES.PLUGIN.ZISDYNAMIC=ZWESISDL
+* ZWES.PLUGIN.ZISDYNAMIC=ZWESISDL
 
 * ZWES.PLUGIN.ECHO=ECHOPL01
 * ZWES.PLUGIN.MAGICNUMBER=MNUMBER


### PR DESCRIPTION
The dynamic zis plugin is likely to be used by extensions of zowe, but isnt needed by zowe's base.
To be efficient to system resources, it's better to leave this disabled and have products enable it when needed.