### PR TITLE
tls tracing config

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -173,7 +173,12 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
   else
     ZSS_SERVER="${ZSS_SERVER_31}"
   fi
-  
+
+  if [ "$ZWE_components_zss_https_trace" = "true" ] && [ "$ZWES_LOG_FILE" != "/dev/null" ]; then
+    export GSK_TRACE_FILE="${ZWES_LOG_FILE}.tlstrace"
+    export GSK_TRACE=0xFF
+  fi
+
   if [ "$ZWES_LOG_FILE" = "/dev/null" ]; then
     _BPX_SHAREAS=NO _BPX_JOBNAME=${ZWE_zowe_job_prefix}SZ ${ZSS_SERVER} --schemas "${ZWES_SCHEMA_PATHS}" --configs "${ZWES_CONFIG}" 2>&1
   else

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -174,7 +174,7 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
     ZSS_SERVER="${ZSS_SERVER_31}"
   fi
 
-  if [ "$ZWE_components_zss_https_trace" = "true" ] && [ "$ZWES_LOG_FILE" != "/dev/null" ]; then
+  if [ "$ZWE_components_zss_agent_https_trace" = "true" ] && [ "$ZWES_LOG_FILE" != "/dev/null" ]; then
     export GSK_TRACE_FILE="${ZWES_LOG_FILE}.tlstrace"
     export GSK_TRACE=0xFF
   fi

--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -106,6 +106,11 @@
               "$ref": "#/$defs/ipsAndHostnames",
               "default": [ "0.0.0.0" ]
             },
+            "trace": {
+              "type": "boolean",
+              "description": "Enables TLS tracing to diagnose connection issues. Output will be within the zowe log directory.",
+              "default": false
+            },
             "label": {
               "type": [ "string", "null" ],
               "description": "The label (aka alias), identifying the server's certificate in the key store"


### PR DESCRIPTION
Instead of having to make edits in the startup script or make temporary tracing branches as done before, I just added the gsk tracing ability as an option into the zss config.

CHANGELOG: Enhancement: GSK tracing is now easy to enable via "components.zss.agent.https.trace: true"
VERSION: 2.12.0