### PR TITLE
Changed IP address 140.82.114.4 to github.com in build configuration …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the ZSS package will be documented in this file.
 
 ## Recent Changes
+- Bugfix:  Corrected build environment file's use of IP address to github.com (#660)
 
 ## `2.10.0`
 - This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#636)

--- a/build/zss.proj.env
+++ b/build/zss.proj.env
@@ -3,9 +3,9 @@ VERSION=2.12.0
 DEPS="QUICKJS LIBYAML"
 
 QUICKJS="quickjs"
-QUICKJS_SOURCE="git@140.82.114.4:joenemo/quickjs-portable.git"
+QUICKJS_SOURCE="git@github.com:joenemo/quickjs-portable.git"
 QUICKJS_BRANCH="main"
 
 LIBYAML="libyaml"
-LIBYAML_SOURCE="git@140.82.114.4:yaml/libyaml.git"
+LIBYAML_SOURCE="git@github.com:yaml/libyaml.git"
 LIBYAML_BRANCH="0.2.5"


### PR DESCRIPTION

## Proposed changes
Updated the zss.proj.env file to switch from IP addresses to github.com
This PR addresses Issue: [Issue 660](https://github.com/zowe/zss/issues/660)

This PR depends upon the following PRs:

none

Please delete options that are not relevant.
- [X ] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
CHANGELOG: Updated build environment files to use github.com for supporting repository clones.

## Testing
Download the repo and setup persintructions.  No additional changes should be necessary.
