### PR TITLE
Fix typos in "plugin".

### DIFF
--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -250,34 +250,34 @@
 #define ZISAUX_LOG_LEGACY_API_MSG_TEXT          "Legacy API has been detected, some functionality may be limited"
 #define ZISAUX_LOG_LEGACY_API_MSG               ZISAUX_LOG_LEGACY_API_MSG_ID" "ZISAUX_LOG_LEGACY_API_MSG_TEXT
 
-/* ZIS dynamic linkage plugin messages */
+/* ZIS dynamic linkage plug-in messages */
 
 #define ZISDYN_LOG_STARTUP_MSG_ID               ZIS_MSG_PRFX"0700I"
-#define ZISDYN_LOG_STARTUP_MSG_TEXT             "ZIS Dynamic Base plugin starting, version %d.%d.%d+%d, stub version %d"
+#define ZISDYN_LOG_STARTUP_MSG_TEXT             "ZIS Dynamic Base plug-in starting, version %d.%d.%d+%d, stub version %d"
 #define ZISDYN_LOG_STARTUP_MSG                  ZISDYN_LOG_STARTUP_MSG_ID" "ZISDYN_LOG_STARTUP_MSG_TEXT
 
 #define ZISDYN_LOG_STARTED_MSG_ID               ZIS_MSG_PRFX"0701I"
-#define ZISDYN_LOG_STARTED_MSG_TEXT             "ZIS Dynamic Base plugin successfully started"
+#define ZISDYN_LOG_STARTED_MSG_TEXT             "ZIS Dynamic Base plug-in successfully started"
 #define ZISDYN_LOG_STARTED_MSG                  ZISDYN_LOG_STARTED_MSG_ID" "ZISDYN_LOG_STARTED_MSG_TEXT
 
 #define ZISDYN_LOG_STARTUP_FAILED_MSG_ID        ZIS_MSG_PRFX"0702E"
-#define ZISDYN_LOG_STARTUP_FAILED_MSG_TEXT      "ZIS Dynamic Base plugin startup failed, status = %d"
+#define ZISDYN_LOG_STARTUP_FAILED_MSG_TEXT      "ZIS Dynamic Base plug-in startup failed, status = %d"
 #define ZISDYN_LOG_STARTUP_FAILED_MSG           ZISDYN_LOG_STARTUP_FAILED_MSG_ID" "ZISDYN_LOG_STARTUP_FAILED_MSG_TEXT
 
 #define ZISDYN_LOG_INIT_ERROR_MSG_ID            ZIS_MSG_PRFX"0703E"
-#define ZISDYN_LOG_INIT_ERROR_MSG_TEXT          "ZIS Dynamic Base plugin init error -"
+#define ZISDYN_LOG_INIT_ERROR_MSG_TEXT          "ZIS Dynamic Base plug-in init error -"
 #define ZISDYN_LOG_INIT_ERROR_MSG               ZISDYN_LOG_INIT_ERROR_MSG_ID" "ZISDYN_LOG_INIT_ERROR_MSG_TEXT
 
 #define ZISDYN_LOG_TERM_MSG_ID                  ZIS_MSG_PRFX"0704I"
-#define ZISDYN_LOG_TERM_MSG_TEXT                "ZIS Dynamic Base plugin terminating"
+#define ZISDYN_LOG_TERM_MSG_TEXT                "ZIS Dynamic Base plug-in terminating"
 #define ZISDYN_LOG_TERM_MSG                     ZISDYN_LOG_TERM_MSG_ID" "ZISDYN_LOG_TERM_MSG_TEXT
 
 #define ZISDYN_LOG_TERMED_MSG_ID                ZIS_MSG_PRFX"0705I"
-#define ZISDYN_LOG_TERMED_MSG_TEXT              "ZIS Dynamic Base plugin successfully terminated"
+#define ZISDYN_LOG_TERMED_MSG_TEXT              "ZIS Dynamic Base plug-in successfully terminated"
 #define ZISDYN_LOG_TERMED_MSG                   ZISDYN_LOG_TERMED_MSG_ID" "ZISDYN_LOG_TERMED_MSG_TEXT
 
 #define ZISDYN_LOG_TERM_FAILED_MSG_ID           ZIS_MSG_PRFX"0706E"
-#define ZISDYN_LOG_TERM_FAILED_MSG_TEXT         "ZIS Dynamic Base plugin terminated with error"
+#define ZISDYN_LOG_TERM_FAILED_MSG_TEXT         "ZIS Dynamic Base plug-in terminated with error"
 #define ZISDYN_LOG_TERM_FAILED_MSG              ZISDYN_LOG_TERM_FAILED_MSG_ID" "ZISDYN_LOG_TERM_FAILED_MSG_TEXT
 
 #define ZISDYN_LOG_CMD_RESP_MSG_ID              ZIS_MSG_PRFX"0707I"
@@ -301,7 +301,7 @@
 #define ZISDYN_LOG_STUB_DISCARDED_MSG           ZISDYN_LOG_STUB_DISCARDED_MSG_ID" "ZISDYN_LOG_STUB_DISCARDED_MSG_TEXT
 
 #define ZISDYN_LOG_DEV_MODE_MSG_ID              ZIS_MSG_PRFX"0713W"
-#define ZISDYN_LOG_DEV_MODE_MSG_TEXT            "ZIS Dynamic base plugin development mode is enabled"
+#define ZISDYN_LOG_DEV_MODE_MSG_TEXT            "ZIS Dynamic base plug-in development mode is enabled"
 #define ZISDYN_LOG_DEV_MODE_MSG                 ZISDYN_LOG_DEV_MODE_MSG_ID" "ZISDYN_LOG_DEV_MODE_MSG_TEXT
 
 #define ZISDYN_LOG_BAD_ZIS_VERSION_MSG_ID       ZIS_MSG_PRFX"0714E"


### PR DESCRIPTION
According to the Zowe doc guidelines, "plugin" must be "plug-in".

There is a related doc PR: https://github.com/zowe/docs-site/pull/3268.

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Fix the typos in the messages containing the word "plugin".

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change in a documentation

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


## Testing
Ensure that the ZIS messages with the word "plugin", are now printed with "plug-in". 

