### PR TITLE
Extend slh max size to avoid 0C4 ABENDs

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1575,7 +1575,7 @@ void updateDataset(HttpResponse* response, char* absolutePath, int jsonMode) {
 
   if(returnCode == 0) {  
     int blockSize = 0x10000;
-    int maxBlockCount = (translationLength*2)/blockSize;
+    int maxBlockCount = (translationLength*4)/blockSize;
     if (!maxBlockCount){
       maxBlockCount = 0x10;
     }


### PR DESCRIPTION
## Proposed changes
For some "content" the allocated SLH size (technically the number of blocks) is not enough, so ZSS thread is ABENDed with 0C4-4 like below:
```text
SLH at 0x3FF90A50 cannot allocate above block size 16 > 0 mxbl 2 bkct 2 bksz 65535
httpserver: ABEND 0C4-04 averted when handling datasetContents
```

Technically we increased the number of max blocks, so we do not request a 2 times bigger buffer.
But it's enough for some cases.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
- [X] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [X] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))

## Testing
The bug was found by the "OMEGAMON for Storage" team and we verified that the issue solved with these changes.
