### PR TITLE
Take into account leap seconds in AUX messages' timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `2.16.0`
+- Bugfix: AUX should take leap seconds into account in their log messages' timestamp (#690, #691)
+
 ## `2.14.0`
 - Bugfix: ZSS would not use zowe.cookieIdentifier when an HA config was used.
 

--- a/zis-aux/src/aux-utils.c
+++ b/zis-aux/src/aux-utils.c
@@ -199,11 +199,18 @@ static void getSTCK(uint64 *stckValue) {
   __asm(" STCK 0(%0)" : : "r"(stckValue));
 }
 
-static int64 getLocalTimeOffset() {
+static int64 getLocalTimeOffset(void) {
   CVT * __ptr32 cvt = *(void * __ptr32 * __ptr32)0x10;
   void * __ptr32 cvtext2 = cvt->cvtext2;
   int64 *cvtldto = (int64 * __ptr32)(cvtext2 + 0x38);
   return *cvtldto;
+}
+
+static int64 getLeapSecondsOffset(void) {
+  CVT * __ptr32 cvt = *(void * __ptr32 * __ptr32)0x10;
+  void * __ptr32 cvtext2 = cvt->cvtext2;
+  int64 *cvtlso = (int64 * __ptr32)(cvtext2 + 0x50);
+  return *cvtlso;
 }
 
 static void getCurrentLogTimestamp(LogTimestamp *timestamp) {
@@ -212,6 +219,7 @@ static void getCurrentLogTimestamp(LogTimestamp *timestamp) {
   getSTCK(&stck);
 
   stck += getLocalTimeOffset();
+  stck -= getLeapSecondsOffset();
 
   stckToLogTimestamp(stck, timestamp);
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The PR adds code to get the current amount of leap seconds and subtract that from the STCK value which goes into the timestamps.

### Additional changes:
* Pick up the cross-memory changes in zowe-common-c
* Update the changelog with these changes


This PR addresses Issue: #690 


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

* Start ZIS with AUX;
* Compare the timestamps from the beginning of the JES and SYSPRINT logs; the timestamps should match.