### PR TITLE
configure SLH size for ZSS to handle file size greater than 6mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `2.17.0`
+- Code to configure the SLH block size of the http server through 'httpRequestHeapMaxBlocks' in the yaml.(#701)
+
 ## `2.16.0`
 - Bugfix: AUX should take leap seconds into account in their log messages' timestamp (#690, #691)
 

--- a/c/zss.c
+++ b/c/zss.c
@@ -355,6 +355,27 @@ static void setPrivilegedServerName(HttpServer *server, JsonObject *mvdSettings,
 }
 #endif /* __ZOWE_OS_ZOS */
 
+static void setHttpRequestHeapMaxBlocks(HttpServer *server, ConfigManager *configmgr){
+
+  int maxBlocks = 0;
+  int getStatus = cfgGetIntC(configmgr,ZSS_CFGNAME,&maxBlocks,3,"components","zss","httpHeapMaxBlocks");
+
+  if (getStatus == ZCFG_SUCCESS){
+    if (maxBlocks > HTTP_REQUEST_HEAP_MAX_BLOCKS){
+      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "httpHeapMaxBlocks out of range, max value is %d\n",HTTP_REQUEST_HEAP_MAX_BLOCKS); 
+      maxBlocks = HTTP_REQUEST_HEAP_MAX_BLOCKS;
+     } else if (maxBlocks < HTTP_REQUEST_HEAP_MIN_BLOCKS){
+      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "httpHeapMaxBlocks out of range, min value is %d\n",HTTP_REQUEST_HEAP_MIN_BLOCKS); 
+      maxBlocks = HTTP_REQUEST_HEAP_MIN_BLOCKS;
+     }
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "httpHeapMaxBlocks should be between %d and %d\n",HTTP_REQUEST_HEAP_MIN_BLOCKS,HTTP_REQUEST_HEAP_MAX_BLOCKS);
+  } else{
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "fallback to default server settings\n");
+    maxBlocks = HTTP_REQUEST_HEAP_DEFAULT_BLOCKS;
+  }
+  server->config->httpRequestHeapMaxBlocks = (unsigned int)maxBlocks;
+}
+
 static void loadWebServerConfigV2(HttpServer *server, 
                                   ConfigManager *configmgr,
                                   hashtable *htUsers,
@@ -370,6 +391,7 @@ static void loadWebServerConfigV2(HttpServer *server,
   server->config->userTimeouts = htUsers;
   server->config->groupTimeouts = htGroups;
   server->config->defaultTimeout = defaultSessionTimeout;
+  setHttpRequestHeapMaxBlocks(server, configmgr);
   registerHttpServiceOfLastResort(server,NULL);
 #ifdef __ZOWE_OS_ZOS
   setPrivilegedServerNameV2(server, configmgr);


### PR DESCRIPTION

## Proposed changes
The heap available to the http server is currently capped to around 6MB, because of this there is a limit in the size of the dataset that can be uploaded using ZSS API's.
To solve this, we are providing an option in configuration under 'components ->zss ->httpHeapMaxBlocks'. By default it would be 1024 meaning, 64KB * 1024, and as of now we have capped the max value of this option to be 4096 meaning, 64kb * 4096.

This PR addresses Issue: https://github.com/zowe/zss/issues/698

This PR depends upon the following PRs:
https://github.com/zowe/zowe-common-c/pull/447

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [x] Chore, repository cleanup, updates the dependencies.


## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
You can try with uploading a dataset with size greater than 6mb using a python script.

## Further comments
zowe-common-c is pointing to the latest changes.
