### PR TITLE
Set native tls off if attls is on

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -2,7 +2,7 @@ components:
   zss:
     port: 7557
     crossMemoryServerName: ${{ ()=> { if (zowe.environments?.ZWED_privilegedServerName) { return zowe.environments.ZWED_privilegedServerName } else { if (zowe.environments?.ZWES_XMEM_SERVER_NAME) { return zowe.environments.ZWES_XMEM_SERVER_NAME } else { return "ZWESIS_STD" } } }() }}
-    tls: true
+    tls: "${{ ()=> { if (components.zss.zowe?.network?.server?.tls?.attls) { return false } else if (zowe.network?.server?.tls?.attls) { return false } else { return true } }() }}"
     productDir: ${{ zowe.runtimeDirectory }}/components/zss/defaults
     pluginsDir: ${{ zowe.workspaceDirectory }}/app-server/plugins
     instanceDir: ${{ zowe.workspaceDirectory }}/zss


### PR DESCRIPTION
`tls: true` in our config controls whether this server uses http or https on the listening port.
While it has been defaulting to true unconditionally for a long time, it is better to default it to the newly introduced parameter of whether or not attls is enabled.
This way, it is easier to enable attls for zss.