### PR TITLE
Add support for longer cross-memory server parms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `2.18.1`
+- Bugfix: Support cross-memory server parameters longer than 128 characters (#684)
+- Enhancement: Expose new cross-memory server's functions in dynlink (#684)
+
 ## `2.18.0`
 - Change log level for setting default value of 'httpRequestHeapMaxBlocks' to DEBUG instead of INFO.(#719)
 

--- a/c/zis/stubinit.c
+++ b/c/zis/stubinit.c
@@ -229,6 +229,8 @@
     stubVector[ZIS_STUB_CMGETLOG] = (void*)cmsGetPCLogLevel;
     stubVector[ZIS_STUB_CMGETSTS] = (void*)cmsGetStatus;
     stubVector[ZIS_STUB_CMMKSNAM] = (void*)cmsMakeServerName;
+    stubVector[ZIS_STUB_CMGETPRX] = (void*)cmsGetConfigParmExt;
+    stubVector[ZIS_STUB_CMGETPUX] = (void*)cmsGetConfigParmExtUnchecked;
     stubVector[ZIS_STUB_DYNASTXU] = (void*)createSimpleTextUnit;
     stubVector[ZIS_STUB_DYNASTX2] = (void*)createSimpleTextUnit2;
     stubVector[ZIS_STUB_DYNACTXU] = (void*)createCharTextUnit;

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -20,7 +20,7 @@
    FULL BACKWARD COMPATIBILITY MUST BE MAINTAINED
    */
 
-#define ZIS_STUBS_VERSION 3
+#define ZIS_STUBS_VERSION 4
 
 /*
   How does a user check for compatibility?
@@ -310,6 +310,8 @@
 /* #define ZIS_STUB_CMECSAFR 382 cmsFreeECSAStorage - not in CMS_CLIENT */
 /* #define ZIS_STUB_CMECSAA2 383 cmsAllocateECSAStorage2 - not in CMS_CLIENT */
 /* #define ZIS_STUB_CMECSAF2 384 cmsFreeECSAStorage2 - not in CMS_CLIENT */
+#define ZIS_STUB_CMGETPRX 385 /* cmsGetConfigParmExt */
+#define ZIS_STUB_CMGETPUX 386 /* cmsGetConfigParmExtUnchecked */
 
 /* dynalloc, 400-429 */
 #define ZIS_STUB_DYNASTXU 400 /* createSimpleTextUnit mapped */


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR picks up the zowe-common-c changes which add support for ZIS parameters longer than 128 characters. Additionally, new related zowe-common-c functions are now exposed in the dynamic linkage plug-in.

This PR addresses Issue: #684 

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/457

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

See https://github.com/zowe/zowe-common-c/pull/457.

