### PR TITLE
Adding more arguments to httpClientSessionInit to allow passing back rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `2.18.1`
 - Bugfix: Support cross-memory server parameters longer than 128 characters (#684)
 - Enhancement: Expose new cross-memory server's functions in dynlink (#684)
+- Enhancement: Adding more arguments to httpClientSessionInit to allow passing back rc (#727)
 
 ## `2.18.0`
 - Change log level for setting default value of 'httpRequestHeapMaxBlocks' to DEBUG instead of INFO.(#719)

--- a/c/jwk.c
+++ b/c/jwk.c
@@ -159,7 +159,7 @@ static Json *doRequest(ShortLivedHeap *slh, HttpClientSettings *clientSettings, 
       *rc = JWK_STATUS_HTTP_CONTEXT_ERROR;
       break;
     }
-    *rsn = httpClientSessionInit(httpClientContext, &session);
+    *rsn = httpClientSessionInit2(httpClientContext, &session, rc);
     if (*rsn) {
       *rc = JWK_STATUS_HTTP_REQ_INIT_ERROR;
       break;

--- a/c/storageApiml.c
+++ b/c/storageApiml.c
@@ -258,6 +258,7 @@ static int transformHttpStatus(int httpStatus) {
 static ApimlResponse *apimlDoRequest(ApimlStorage *storage, ApimlRequest *request, int *statusOut) {
   int status = 0;
   int statusCode = 0;
+  int rc = 0;
   TlsEnvironment *tlsEnv = storage->tlsEnv;
   HttpClientSettings *clientSettings = storage->clientSettings;
   HttpClientContext *httpClientContext = NULL;
@@ -277,7 +278,7 @@ static ApimlResponse *apimlDoRequest(ApimlStorage *storage, ApimlRequest *reques
       *statusOut = STORAGE_STATUS_HTTP_ERROR;
       break;
     }
-    status = httpClientSessionInit(httpClientContext, &session);
+    status = httpClientSessionInit2(httpClientContext, &session, &rc);
     if (status) {
       zowelog(NULL, LOG_COMP_ID_APIML_STORAGE, ZOWE_LOG_DEBUG, "error initing session: %d\n", status);
       *statusOut = STORAGE_STATUS_HTTP_ERROR;


### PR DESCRIPTION


## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue:  https://github.com/zowe/zowe-common-c/issues/468

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/477

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

