### PR TITLE
Utilize the module registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.1.0`
+- Enhancement: module registry (#732)
+
 ## `3.0.0`
 - Enhancement: if no `zowe.logDirectory` is defined in config, logging is disabled. (#726)
 - Bugfix: Support cross-memory server parameters longer than 128 characters (#684)

--- a/build/build_dynamic.sh
+++ b/build/build_dynamic.sh
@@ -50,12 +50,15 @@ xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
   -DZISDYN_REVISION="$micro" \
   -DZISDYN_VERSION_DATE_STAMP="$date_stamp" \
   -DZISDYN_PLUGIN_VERSION=${DYNLINK_PLUGIN_VERSION} \
+  -DLPA_LOG_DEBUG_MSG_ID=\"ZWES0100I\" \
+  -DMODREG_LOG_DEBUG_MSG_ID=\"ZWES0100I\" \
   -qreserved_reg=r12 \
   -DRCVR_CPOOL_STATES \
   -DHAVE_METALIO=1 \
   -Wc,langlvl\(extc99\),arch\(8\),agg,exp,list\(\),so\(\),off,xref,roconst,longname,lp64 \
   -I ${COMMON}/h -I ${ZSS}/h \
   -I ${ZSS}/zis-aux/include -I ${ZSS}/zis-aux/src \
+  -I /usr/include/zos \
   ${ZSS}/c/zis/zisdynamic.c \
   ${ZSS}/c/zis/server-api.c \
   ${ZSS}/c/zis/client.c \
@@ -81,6 +84,7 @@ xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
   ${COMMON}/c/logging.c \
   ${COMMON}/c/lpa.c \
   ${COMMON}/c/metalio.c \
+  ${COMMON}/c/modreg.c \
   ${COMMON}/c/nametoken.c \
   ${COMMON}/c/pause-element.c \
   ${COMMON}/c/pc.c \
@@ -125,6 +129,7 @@ for file in \
     logging \
     lpa \
     metalio \
+    modreg \
     nametoken \
     pause-element \
     pc \
@@ -173,6 +178,7 @@ le.o \
 logging.o \
 lpa.o \
 metalio.o \
+modreg.o \
 nametoken.o \
 pause-element.o \
 pc.o \

--- a/build/build_zis.sh
+++ b/build/build_zis.sh
@@ -56,9 +56,12 @@ xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
   -DZIS_VERSION_DATE_STAMP="$date_stamp" \
   -DRADMIN_XMEM_MODE \
   -DRCVR_CPOOL_STATES \
+  -DLPA_LOG_DEBUG_MSG_ID=\"ZWES0100I\" \
+  -DMODREG_LOG_DEBUG_MSG_ID=\"ZWES0100I\" \
   -qreserved_reg=r12 \
   -Wc,arch\(8\),agg,exp,list\(\),so\(\),off,xref,roconst,longname,lp64 \
   -I ${COMMON}/h -I ${ZSS}/h -I ${ZSS}/zis-aux/include -I ${ZSS}/zis-aux/src \
+  -I /usr/include/zos \
    ${COMMON}/c/alloc.c \
    ${COMMON}/c/as.c \
    ${COMMON}/c/cellpool.c \
@@ -70,6 +73,7 @@ xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
    ${COMMON}/c/logging.c \
    ${COMMON}/c/lpa.c \
    ${COMMON}/c/metalio.c \
+   ${COMMON}/c/modreg.c \
    ${COMMON}/c/mtlskt.c \
    ${COMMON}/c/nametoken.c \
    ${COMMON}/c/pause-element.c \
@@ -102,7 +106,7 @@ xlc -S -M -qmetal -q64 -DSUBPOOL=132 -DMETTLE=1 -DMSGPREFIX=\"ZWE\" \
    ${ZSS}/zis-aux/src/aux-host.c
 
 for file in \
-    alloc as cellpool cmutils collections crossmemory isgenq le logging lpa metalio mtlskt nametoken \
+    alloc as cellpool cmutils collections crossmemory isgenq le logging lpa metalio modreg mtlskt nametoken \
     pause-element pc qsam radmin recovery resmgr scheduling shrmem64 stcbase timeutls utils xlate \
     zos zvt \
     parm plugin server server-api service \
@@ -125,6 +129,7 @@ ld -V -b ac=1 -b rent -b case=mixed -b map -b xref -b reus \
   logging.o \
   lpa.o \
   metalio.o \
+  modreg.o \
   mtlskt.o \
   nametoken.o \
   qsam.o \
@@ -165,6 +170,7 @@ ld -V -b ac=1 -b rent -b case=mixed -b map -b xref -b reus \
   logging.o \
   lpa.o \
   metalio.o \
+  modreg.o \
   mtlskt.o \
   nametoken.o \
   pause-element.o \

--- a/c/zis/server-api.c
+++ b/c/zis/server-api.c
@@ -31,6 +31,10 @@ _Bool zisIsLPADevModeOn(const ZISContext *context) {
   return (context->cmsFlags & devFlags) || ZIS_LPA_DEV_MODE;
 }
 
+_Bool zisIsModregOn(const ZISContext *context) {
+  return context->cmsFlags & CMS_SERVER_FLAG_USE_MODREG;
+}
+
 void zisGetServerVersion(int *major, int *minor, int *revision) {
   *major = -1;
   *minor = -1;

--- a/c/zis/stubinit.c
+++ b/c/zis/stubinit.c
@@ -12,6 +12,7 @@
     stubVector[ZIS_STUB_ZISDYNPV] = (void*)zisdynGetPluginVersion;
     stubVector[ZIS_STUB_ZISGVRSN] = (void*)zisGetServerVersion;
     stubVector[ZIS_STUB_ZISLPADV] = (void*)zisIsLPADevModeOn;
+    stubVector[ZIS_STUB_ZISMDREG] = (void*)zisIsModregOn;
     stubVector[ZIS_STUB_ZISCSRVC] = (void*)zisCallService;
     stubVector[ZIS_STUB_ZISCUSVC] = (void*)zisCallServiceUnchecked;
     stubVector[ZIS_STUB_ZISCVSVC] = (void*)zisCallVersionedService;
@@ -558,6 +559,7 @@
     stubVector[ZIS_STUB_ZVTFENTR] = (void*)zvtFreeEntry;
     stubVector[ZIS_STUB_ZVTGXMLR] = (void*)zvtGetCMSLookupRoutineAnchor;
     stubVector[ZIS_STUB_ZVTSXMLR] = (void*)zvtSetCMSLookupRoutineAnchor;
+    stubVector[ZIS_STUB_MODRRGST] = (void*)modregRegister;
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/c/zis/zisdynamic.c
+++ b/c/zis/zisdynamic.c
@@ -31,6 +31,7 @@
 #include "logging.h"
 #include "lpa.h"
 #include "metalio.h"
+#include "modreg.h"
 #include "nametoken.h"
 #include "pause-element.h"
 #include "pc.h"
@@ -422,6 +423,8 @@ static int verifyZISVersion(void) {
 }
 
 ZISPlugin *getPluginDescriptor(void) {
+
+  MODREG_MARK_MODULE();
 
   if (verifyZISVersion() != 0) {
     return NULL;

--- a/h/zis/message.h
+++ b/h/zis/message.h
@@ -116,6 +116,18 @@
 #define ZIS_LOG_CXMS_MOD_NAME_FAILED_MSG_TEXT   "ZSS Cross-Memory server module member name not determined, RC = %d"
 #define ZIS_LOG_CXMS_MOD_NAME_FAILED_MSG        ZIS_LOG_CXMS_MOD_NAME_FAILED_MSG_ID" "ZIS_LOG_CXMS_MOD_NAME_FAILED_MSG_TEXT
 
+#define ZIS_LOG_MODULE_STATUS_MSG_ID            ZIS_MSG_PRFX"0022I"
+#define ZIS_LOG_MODULE_STATUS_MSG_TEXT          "Module %-8.8s status: %s"
+#define ZIS_LOG_MODULE_STATUS_MSG               ZIS_LOG_MODULE_STATUS_MSG_ID" "ZIS_LOG_MODULE_STATUS_MSG_TEXT
+
+#define ZIS_LOG_MODREG_NO_MARK_MSG_ID           ZIS_MSG_PRFX"0023I"
+#define ZIS_LOG_MODREG_NO_MARK_MSG_TEXT         "Module %-8.8s not eligible for registry, proceeding with LPA ADD"
+#define ZIS_LOG_MODREG_NO_MARK_MSG              ZIS_LOG_MODREG_NO_MARK_MSG_ID" "ZIS_LOG_MODREG_NO_MARK_MSG_TEXT
+
+#define ZIS_LOG_MODREG_FAILURE_MSG_ID           ZIS_MSG_PRFX"0024E"
+#define ZIS_LOG_MODREG_FAILURE_MSG_TEXT         "Module %-8.8s not registered, RC = %d, RSN = 0x%016llX"
+#define ZIS_LOG_MODREG_FAILURE_MSG              ZIS_LOG_MODREG_FAILURE_MSG_ID" "ZIS_LOG_MODREG_FAILURE_MSG_TEXT
+
 /* ZIS AUX messages */
 
 #define ZISAUX_LOG_STARTUP_MSG_ID               ZIS_MSG_PRFX"0050I"

--- a/h/zis/server-api.h
+++ b/h/zis/server-api.h
@@ -18,6 +18,7 @@
 
 #pragma map(zisGetServerVersion, "ZISGVRSN")
 #pragma map(zisIsLPADevModeOn, "ZISLPADV")
+#pragma map(zisIsModregOn, "ZISMDREG")
 
 /**
  * Get the version of ZIS. In case of failure, all the results are set to -1.
@@ -35,6 +36,13 @@ struct ZISContext_tag;
  * @return @c true if on, otherwise @c false.
  */
 _Bool zisIsLPADevModeOn(const struct ZISContext_tag *context);
+
+/**
+ * Check if the module registry is enabled for ZIS.
+ * @param[in] context The server context.
+ * @return @c true if on, otherwise @c false.
+ */
+_Bool zisIsModregOn(const struct ZISContext_tag *context);
 
 #endif /* ZIS_SERVER_API_H_ */
 

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -20,7 +20,7 @@
    FULL BACKWARD COMPATIBILITY MUST BE MAINTAINED
    */
 
-#define ZIS_STUBS_VERSION 4
+#define ZIS_STUBS_VERSION 5
 
 /*
   How does a user check for compatibility?
@@ -48,6 +48,7 @@
 #define ZIS_STUB_ZISDYNPV 2 /* zisdynGetPluginVersion mapped */
 #define ZIS_STUB_ZISGVRSN 3 /* zisGetServerVersion mapped */
 #define ZIS_STUB_ZISLPADV 4 /* zisIsLPADevModeOn mapped */
+#define ZIS_STUB_ZISMDREG 5 /* zisIsModregOn mapped */
 
 /* zis/client, 50-79 */
 #define ZIS_STUB_ZISCSRVC 50 /* zisCallService */
@@ -692,6 +693,9 @@
 #define ZIS_STUB_ZVTFENTR 903 /* zvtFreeEntry mapped */
 #define ZIS_STUB_ZVTGXMLR 904 /* zvtGetCMSLookupRoutineAnchor mapped */
 #define ZIS_STUB_ZVTSXMLR 905 /* zvtSetCMSLookupRoutineAnchor mapped */
+
+/* modreg, 915-920 */
+#define ZIS_STUB_MODRRGST 915 /* modregRegister mapped */
 
 #endif /* ZIS_ZISSTUBS_H_ */
 

--- a/samplib/zis/ZWESIP00
+++ b/samplib/zis/ZWESIP00
@@ -53,7 +53,13 @@
 //*         AT START UP. THIS MODE MUST NEVER BE USED IN PRODUCTION  */
 //*         AS IT MAY AFFECT THE CALLERS OF THE CROSS-MEMORY SERVER. */
 //*         USE THIS MODE TO DECREASE THE MEMORY FOOTPRINT DURING    */
-//*         DEVELOPMENT.                                             */
+//*         DEVELOPMENT. ADDITIONALLY, THIS MODE WILL DISABLE THE    */
+//*         MODULE REGISTRY FEATURE BECAUSE ZIS CANNOT REMOVE SHARED */
+//*         MODULE FROM LPA.                                         */
+//*     MODULE_REGISTRY - MODULE REGISTRY MODE. DEFAULT IS YES. IF   */
+//*         SET TO NO, DISABLES THE MODULE REGISTRY FEATURE, SO THAT */
+//*         ZIS WILL ALWAYS USE ITS OWN INSTANCES OF LOAD MODULES IN */
+//*         LPA.                                                     */
 //*                                                                  */
 //********************************************************************/
 


### PR DESCRIPTION
## Proposed changes

To decrease the ZIS LPA footprint, ZIS will use the module registry for its plug-in modules. When not in dev mode, ZIS will use the module registry API for adding plug-in modules to the LPA, and if a module is already registered, ZIS will reuse the existing LPA info. In dev mode, ZIS will load its own copy of plug-in modules to the LPA, just as it does now.

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/492

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

### Adding a module to the registry

* Upgrade your ZIS;
* Start the ZIS instance with dynamic linkage on;
* Check that SYSPRINT has the following messages:
  * `ZWES0258I Module status: new instance added to registry (10D80000)` (the address in the brackets will likely be different, and the same true for the other messages in this testing strategy text);
  * `ZWES0022I Module KAYSISDL status: new instance added to registry (110B1000)`;
* Restart the ZIS instance;
* Check that SYSPRINT has the following messages:
  * `ZWES0258I Module status: previously added/loaded instance reused (10D80000)`;
  * `ZWES0022I Module KAYSISDL status: previously added/loaded instance reused (110B1000)`.

### Module sharing

For the next test, you'll need another ZIS instance upgraded to the same level as the original instance.

* Start another ZIS instance;
* Check that SYSPRINT has the following messages:
  * `ZWES0258I Module status: instance reused from registry (10D80000)`;
  * `ZWES0022I Module KAYSISDL status: instance reused from registry (110B1000)`;
* Restart the ZIS instance;
* Check that SYSPRINT has the following messages:
  * `ZWES0258I Module status: previously added/loaded instance reused (10D80000)`;
  * `ZWES0022I Module KAYSISDL status: previously added/loaded instance reused (110B1000)`.

### Non-eligible module

For this test, you will need a plug-in module which does not use the new feature; i.e., the plug-in does not use the `MODREG_MARK_MODULE` macro.

* Start a ZIS instance with your legacy plug-in, and with the COLD option (`S zisstc,,,COLD,REUSASID=YES`);
* Check that SYSPRINT has the following messages:
  * `ZWES0023I Module <name of your plug-in module> not eligible for registry, proceeding with LPA ADD`;
  * `ZWES0022I Module <name of your plug-in module> status: own instance loaded to LPA (10BD1000)`.


### Non-LPA module

For this test, you will need a plug-in module which does not use the LPA.

* Start a ZIS instance with your non-LPA plug-in;
* Check that SYSPRINT has the following messages:
  * `ZWES0022I Module <name of your plug-in module> status: private storage instance used`.

### Registry disablement via the new parameter

* Add `ZWES.MODULE_REGISTRY=NO` to the PARMLIB member of your ZIS;
* Start your ZIS with the COLD option (`S zisstc,,,COLD,REUSASID=YES`);
* Check that SYSPRINT has the following messages:
  * `ZWES0258I Module status: own instance loaded to LPA (10BD1000)`;
  * `ZWES0022I Module KAYSISDL status: own instance loaded to LPA (10B49000)`.

### Registry disablement via the dev option

* Remove `ZWES.MODULE_REGISTRY=NO` and add `ZWES.DEV_MODE.LPA=YES` to the PARMLIB member of your ZIS;
* Start your ZIS with the COLD option (`S zisstc,,,COLD,REUSASID=YES`);
* Check that SYSPRINT has the following messages:
  * `ZWES0258I Module status: own instance loaded to LPA (10BD1000)`;
  * `ZWES0022I Module KAYSISDL status: own instance loaded to LPA (10B49000)`.