### PR TITLE
Update the dynamic linkage code to expose new cmutils functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.2.0`
+- Enhancement: expose new cmutils functions (#740)
+
 ## `3.1.0`
 - Enhancement: module registry (#732)
 

--- a/c/zis/stubinit.c
+++ b/c/zis/stubinit.c
@@ -169,6 +169,10 @@
     stubVector[ZIS_STUB_CMUMAPGH] = (void*)crossMemoryMapGetHandle;
     stubVector[ZIS_STUB_CMUMAPGT] = (void*)crossMemoryMapGet;
     stubVector[ZIS_STUB_CMUMAPIT] = (void*)crossMemoryMapIterate;
+    stubVector[ZIS_STUB_CMALLCX ] = (void*)cmAllocExec;
+    stubVector[ZIS_STUB_CMFREEX ] = (void*)cmFreeExec;
+    stubVector[ZIS_STUB_CMALLC2X] = (void*)cmAlloc2Exec;
+    stubVector[ZIS_STUB_CMFREE2X] = (void*)cmFree2Exec;
     stubVector[ZIS_STUB_FBMGRCRT] = (void*)fbMgrCreate;
     stubVector[ZIS_STUB_FBMGRALC] = (void*)fbMgrAlloc;
     stubVector[ZIS_STUB_FBMGRFRE] = (void*)fbMgrFree;

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -20,7 +20,7 @@
    FULL BACKWARD COMPATIBILITY MUST BE MAINTAINED
    */
 
-#define ZIS_STUBS_VERSION 5
+#define ZIS_STUBS_VERSION 6
 
 /*
   How does a user check for compatibility?
@@ -232,6 +232,10 @@
 #define ZIS_STUB_CMUMAPGH 278 /* crossMemoryMapGetHandle */
 #define ZIS_STUB_CMUMAPGT 279 /* crossMemoryMapGet */
 #define ZIS_STUB_CMUMAPIT 280 /* crossMemoryMapIterate */
+#define ZIS_STUB_CMALLCX  281 /* cmAllocExec */
+#define ZIS_STUB_CMFREEX  282 /* cmFreeExec */
+#define ZIS_STUB_CMALLC2X 283 /* cmAlloc2Exec */
+#define ZIS_STUB_CMFREE2X 284 /* cmFree2Exec */
 
 /* collections, 290-349 */
 #define ZIS_STUB_FBMGRCRT 290 /* fbMgrCreate */


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR updates the corresponding dynamic linkage code to pick up the new `zowe-common-c/c/cmutils.c` functions along with the changes addressing `EXECUTABLE=YES` storage.

This PR depends upon the following PRs:
* https://github.com/zowe/zowe-common-c/pull/507

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
Regression testing of ZIS is needed.

