### PR TITLE
Update the dynlink stub generator to include the stub version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.2.0`
+- Enhancement: include the stub version in the generated HLASM stub (#743)
+
 ## `3.1.0`
 - Enhancement: module registry (#732)
 

--- a/tools/dynzis/org/zowe/zis/ZISStubGenerator.java
+++ b/tools/dynzis/org/zowe/zis/ZISStubGenerator.java
@@ -90,8 +90,11 @@ public class ZISStubGenerator {
         Set<String> symbols = new HashSet<>();
         Set<String> functions = new HashSet<>();
         int maxStubNum = 0;
+        int stubVersion = 0;
+        boolean stubVersionFound = false;
         Pattern stubPattern = Pattern.compile("^#define\\s+ZIS_STUB_(\\S+)\\s+([0-9]{1,8})\\s*/\\*\\s*(\\S+)(\\s+mapped)?\\s*\\*/\\s*");
         Pattern maxStubCountPattern = Pattern.compile("^#define\\s+MAX_ZIS_STUBS\\s+([0-9]+)\\s*");
+        Pattern versionPattern = Pattern.compile("^#define\\s+ZIS_STUBS_VERSION\\s+([0-9]+)$");
 
         String line;
         while ((line = reader.readLine()) != null) {
@@ -155,9 +158,20 @@ public class ZISStubGenerator {
             if (maxStubCountMatcher.matches()) {
                 maxStubNum = Integer.parseInt(maxStubCountMatcher.group(1));
             }
+            if (!stubVersionFound) {
+                Matcher stubVersionMatcher = versionPattern.matcher(line);
+                if (stubVersionMatcher.matches()) {
+                    stubVersion = Integer.parseInt(stubVersionMatcher.group(1));
+                    stubVersionFound = true;
+                }
+            }
 
         }
+        if (!stubVersionFound) {
+            throw new RuntimeException("Error: stub version not found");
+        }
         if (generateASM) {
+            out.printf("ZISSTUBV EQU  %d\n", stubVersion);
             writeLines(out, hlasmEpilog);
         } else {
             writeLines(out, initCopyright);


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR changes the generator tool to include the stub version as an EQU. This can be useful for build time verification if a user wants to ensure that the stub version matches the code in `zss`/`zowe-common-c`.


## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

Use the stub generator tool with `h/zis/zisstubs.h` to generate the HLASM stub and verify that it contains `ZISSTUBV` which is equal to `ZIS_STUBS_VERSION` in `h/zis/zisstubs.h`.

