### PR TITLE
Fix for attls registration with gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `2.18.1`
 - Bugfix: Support cross-memory server parameters longer than 128 characters (#684)
 - Enhancement: Expose new cross-memory server's functions in dynlink (#684)
+- Bugfix: ZSS was not accessible from the Gateway when using AT-TLS (#748)
 
 ## `2.18.0`
 - Change log level for setting default value of 'httpRequestHeapMaxBlocks' to DEBUG instead of INFO.(#719)

--- a/apiml-static-reg.yaml.template
+++ b/apiml-static-reg.yaml.template
@@ -4,7 +4,7 @@ services:
     description: 'Zowe System Services is an HTTPS and Websocket server that makes it easy to have secure, powerful web APIs backed by low-level z/OS constructs. It contains services for essential z/OS abilities such as working with files, datasets, and ESMs, but is also extensible by REST and Websocket "Dataservices" which are optionally present in App Framework "Plugins".'
     catalogUiTileId: zss
     instanceBaseUrls:
-      - https://${ZWE_haInstance_hostname}:${ZWE_components_zss_port}/
+      - ${ZWE_zowe_network_proxyType:-https}://${ZWE_haInstance_hostname}:${ZWE_components_zss_port}/
     homePageRelativeUrl:
     routedServices:
       - gatewayUrl: api/v1
@@ -12,7 +12,7 @@ services:
     apiInfo:
       - apiId: zowe.zss
         gatewayUrl: api/v1
-        swaggerUrl: https://${ZWE_haInstance_hostname}:${ZWE_components_app_server_port}/api-docs/agent
+        swaggerUrl: ${ZWE_zowe_network_proxyType:-https}://${ZWE_haInstance_hostname}:${ZWE_components_app_server_port}/api-docs/agent
         # documentationUrl: TODO
     authentication:
         scheme: zoweJwt


### PR DESCRIPTION
I have noticed zss isnt accessible on gateway when using attls.
This was discussed here https://github.com/zowe/zss/issues/689 and still seems correct, but the reality is this solution does not work at this time.
Until that changes it is important to get attls working from an end user perspective, and the cleanest way I see to do this is to combine this PR with https://github.com/zowe/zowe-install-packaging/pull/4215 which allows the zowe startup to make decisions on what to report to apiml to result in a successful attls environment.