### PR TITLE
Temporary fix for AT-TLS Gateway SSO negotiation

### DIFF
--- a/c/jwk.c
+++ b/c/jwk.c
@@ -38,6 +38,7 @@
 #include "zssLogging.h"
 #include "jwt.h"
 #include "jwk.h"
+#include <unistd.h>
 
 static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientContext, HttpClientSession *session, int *statusOut);
 static Json *doRequest(ShortLivedHeap *slh, HttpClientSettings *clientSettings, TlsEnvironment *tlsEnv, char *path, int *rc, int *rsn);
@@ -154,10 +155,18 @@ static Json *doRequest(ShortLivedHeap *slh, HttpClientSettings *clientSettings, 
   do {
     zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_DEBUG, "JWK request to https://%s:%d%s\n",
             clientSettings->host, clientSettings->port, path);
-    *rsn = httpClientContextInitSecure(clientSettings, loggingContext, tlsEnv, &httpClientContext);
-    if (*rsn) {
-      *rc = JWK_STATUS_HTTP_CONTEXT_ERROR;
-      break;
+    if (tlsEnv){ // This is used when Zowe is using builtin TLS.
+      *rsn = httpClientContextInitSecure(clientSettings, loggingContext, tlsEnv, &httpClientContext);
+      if (*rsn) {
+        *rc = JWK_STATUS_HTTP_CONTEXT_ERROR;
+        break;
+      }
+    } else { // This is used when Zowe is configured for AT-TLS.
+      *rsn = httpClientContextInit(clientSettings, loggingContext, &httpClientContext);
+      if (*rsn) {
+        *rc = JWK_STATUS_HTTP_CONTEXT_ERROR;
+        break;
+      }
     }
     *rsn = httpClientSessionInit(httpClientContext, &session);
     if (*rsn) {
@@ -198,9 +207,19 @@ static Json *doRequest(ShortLivedHeap *slh, HttpClientSettings *clientSettings, 
 static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientContext, HttpClientSession *session, int *statusOut) {
   bool done = false;
   Json *jsonBody = NULL;
+  int loopLimit = 9;
+  int currentLoop = 0;
   while (!done) {
-    int status = httpClientSessionReceiveNative(httpClientContext, session, 1024);
-    if (status != 0) {
+    int status = httpClientSessionReceiveNativeLoop(httpClientContext, session);
+    if (status == 15){
+      currentLoop++;
+      usleep(1000);
+    }
+    if (currentLoop > loopLimit){
+      zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "JWT timeout reached\n");
+      break;
+    }
+    if (status != 0 && status != 15) {
       zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "error receiving response: %d\n", status);
       break;
     }

--- a/c/jwk.c
+++ b/c/jwk.c
@@ -211,7 +211,7 @@ static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientC
   int currentLoop = 0;
   while (!done) {
     int status = httpClientSessionReceiveNativeLoop(httpClientContext, session);
-    if (status == 15){
+    if (status == HTTP_CLIENT_EWOULDBLOCK){
       currentLoop++;
       usleep(1000);
     }

--- a/c/zss.c
+++ b/c/zss.c
@@ -996,10 +996,6 @@ static JwkSettings *readJwkSettingsV2(ShortLivedHeap *slh, ConfigManager *config
       zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "Gateway settings not found\n");
       break;
     }
-    if (!tlsEnv) {
-      zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "TLS settings not found\n");
-      break;
-    }
     fallback = isJwtFallbackEnabledV2(configmgr);
     configured = true;
   } while(0);
@@ -1178,11 +1174,6 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
                                      int *outPort,
                                      TlsEnvironment **outTlsEnv){  
   Json *httpsConfig = NULL;
-  int httpsGetStatus = cfgGetAnyC(configmgr,ZSS_CFGNAME,&httpsConfig,4,"components","zss","agent","https");
-  if (httpsGetStatus){
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "https is NOT configured for this ZSS\n");
-    return false;
-  }
   JsonObject *httpsConfigObject = jsonAsObject(httpsConfig);
   TlsSettings *settings = (TlsSettings*)SLHAlloc(slh, sizeof(*settings));
   settings->maxTls = jsonObjectGetString(httpsConfigObject, "maxTls");
@@ -1269,6 +1260,12 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
     } else {
       *outTlsEnv = tlsEnv;
     }
+  }
+
+  int httpsGetStatus = cfgGetAnyC(configmgr,ZSS_CFGNAME,&httpsConfig,4,"components","zss","agent","https");
+  if (httpsGetStatus){
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "https is NOT configured for this ZSS\n");
+    return false;
   }
   return isHttpsConfigured;
 }
@@ -1853,16 +1850,18 @@ int main(int argc, char **argv){
       if (isHttpsConfigured) {
         server = makeSecureHttpServer2(base, inetAddress, port, tlsEnv, requiredTLSFlag,
                                        cookieName, &returnCode, &reasonCode);
+        zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "made https server at 0x%p\n",server);
       } else {
         server = makeHttpServer3(base, inetAddress, port, requiredTLSFlag,
                                  cookieName, &returnCode, &reasonCode);
+        zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "made http server at 0x%p\n",server);
       }
     }
     if (hasProductReg){ 
       registerProduct(productReg, productPID, productVer, productOwner, productName);
     }
     
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "made http(s) server at 0x%p\n",server);
+
     if (server){
       httpServerConfigManager(server) = configmgr;
       ApimlStorageSettings *apimlStorageSettings = readApimlStorageSettingsV2(slh, configmgr, tlsEnv);


### PR DESCRIPTION
For SSO to work with ZSS, It needs to contact the gateway URL /gateway/api/v1/auth/keys/public/current
Currently, it does this only when ZSS is set up as an HTTPS server, because it sends an HTTPS request to the gateway and reuses the TLS settings.

This means when AT-TLS is enabled, currently, ZSS does not contact gateway at all. No SSO.

In this PR, I change that by
* Removing the requirement that the server must be setup for HTTPS in order to contact the gateway
* Making the gateway request conditionally HTTP / HTTPS depending upon the AT-TLS configuration

Switching to HTTP requests causes a little problem which I'm temporarily working around - the HTTP client code has different socket library behavior than the HTTPS client code (GSK).
In our HTTP client code, it seems that it's not blocking when it should, leading to us reading before the response is ready.
To work around this temporarily, I detect the error (EWOULDBLOCK) and do a sleep for 1 second before retrying, up to 9 seconds.
The SSO logic retries every 10 seconds until successful so, basically it may have an action every 1 second.

I will make another PR if I find a proper fix to the blocking behavior to avoid the 1 second polling.                                                                                           