### PR TITLE
Fix: revert httpsGetStatus check movement from end to beginning of readAgentHttpsSettingsV2

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -1174,6 +1174,12 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
                                      int *outPort,
                                      TlsEnvironment **outTlsEnv){  
   Json *httpsConfig = NULL;
+  int httpsGetStatus = cfgGetAnyC(configmgr,ZSS_CFGNAME,&httpsConfig,4,"components","zss","agent","https");
+  if (httpsGetStatus){
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "https is NOT configured for this ZSS\n");
+    return false;
+  }
+
   JsonObject *httpsConfigObject = jsonAsObject(httpsConfig);
   TlsSettings *settings = (TlsSettings*)SLHAlloc(slh, sizeof(*settings));
   settings->maxTls = jsonObjectGetString(httpsConfigObject, "maxTls");
@@ -1262,11 +1268,6 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
     }
   }
 
-  int httpsGetStatus = cfgGetAnyC(configmgr,ZSS_CFGNAME,&httpsConfig,4,"components","zss","agent","https");
-  if (httpsGetStatus){
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "https is NOT configured for this ZSS\n");
-    return false;
-  }
   return isHttpsConfigured;
 }
 


### PR DESCRIPTION
In https://github.com/zowe/zss/pull/750 the logic for httpsGetStatus was moved to the end of the function of readAgentHttpsSettingsV2 during testing. This turned out not to be needed but also caused trouble for loading non-ATTLS. Reverting this retains ATTLS fixes while restoring working HTTPS.