### PR TITLE
Ensure that modreg-based modules are never deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `3.2.0`
 - Enhancement: include the stub version in the generated HLASM stub (#743)
 - Enhancement: expose new cmutils functions (#740)
+- Bugfix: make sure modreg-based modules are never deleted (#752, zowe/zss#749)
 
 ## `3.1.0`
 - Enhancement: module registry (#732)

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -653,25 +653,31 @@ static int relocatePluginToLPAIfNeeded(ZISContext *context,
     }
 
     if (zisIsLPADevModeOn(context)) {
+      if (anchor->flags & ZIS_PLUGIN_ANCHOR_FLAG_PRIVATE_MODULE) {
+        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
+                " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of "
+                "\'%8.8s\'\n", anchor->moduleInfo.inputInfo.name);
 
-      zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
-              " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of "
-              "\'%8.8s\'\n", anchor->moduleInfo.inputInfo.name);
-
-      int lpaRSN = 0;
-      int lpaRC = lpaDelete(&anchor->moduleInfo, &lpaRSN);
-      if (lpaRC != 0) {
-        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, ZIS_LOG_LPA_FAILURE_MSG,
-                "DELETE", anchor->moduleInfo.inputInfo.name, lpaRC, lpaRSN);
-        return RC_ZIS_ERROR;
+        int lpaRSN = 0;
+        int lpaRC = lpaDelete(&anchor->moduleInfo, &lpaRSN);
+        if (lpaRC != 0) {
+          zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, ZIS_LOG_LPA_FAILURE_MSG,
+                  "DELETE", anchor->moduleInfo.inputInfo.name, lpaRC, lpaRSN);
+          return RC_ZIS_ERROR;
+        }
+      } else {
+        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
+                " Plugin LPA dev mode enabled, skipping CSVDYLPA DELETE of "
+                "\'%8.8s\' because it is not private\n",
+                anchor->moduleInfo.inputInfo.name);
       }
-
       lpaDiscarded = true;
     }
 
     if (lpaDiscarded) {
       memset(&anchor->moduleInfo, 0, sizeof(anchor->moduleInfo));
       anchor->flags &= ~ZIS_PLUGIN_ANCHOR_FLAG_LPA;
+      anchor->flags &= ~ZIS_PLUGIN_ANCHOR_FLAG_PRIVATE_MODULE;
       lpaPresent = false;
     }
 
@@ -718,6 +724,7 @@ static int relocatePluginToLPAIfNeeded(ZISContext *context,
                   "ADD", moduleName.text, lpaRC, lpaRSN);
           return RC_ZIS_ERROR;
         }
+        anchor->flags |= ZIS_PLUGIN_ANCHOR_FLAG_PRIVATE_MODULE;
       }
 
       anchor->flags |= ZIS_PLUGIN_ANCHOR_FLAG_LPA;
@@ -757,21 +764,27 @@ static int removePluginFromLPAIfNeeded(ZISContext *context,
   if (lpaPresent) {
 
     if (zisIsLPADevModeOn(context)) {
+      if (anchor->flags & ZIS_PLUGIN_ANCHOR_FLAG_PRIVATE_MODULE) {
+        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
+                " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of "
+                "\'%8.8s\'\n", anchor->moduleInfo.inputInfo.name);
 
-      zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
-              " Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of "
-              "\'%8.8s\'\n", anchor->moduleInfo.inputInfo.name);
-
-      int lpaRSN = 0;
-      int lpaRC = lpaDelete(&anchor->moduleInfo, &lpaRSN);
-      if (lpaRC != 0) {
-        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, ZIS_LOG_LPA_FAILURE_MSG,
-                "DELETE", anchor->moduleInfo.inputInfo.name, lpaRC, lpaRSN);
-        return RC_ZIS_ERROR;
+        int lpaRSN = 0;
+        int lpaRC = lpaDelete(&anchor->moduleInfo, &lpaRSN);
+        if (lpaRC != 0) {
+          zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, ZIS_LOG_LPA_FAILURE_MSG,
+                  "DELETE", anchor->moduleInfo.inputInfo.name, lpaRC, lpaRSN);
+          return RC_ZIS_ERROR;
+        }
+      } else {
+        zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, ZIS_LOG_DEBUG_MSG_ID
+                " Plugin LPA dev mode enabled, skipping CSVDYLPA DELETE of "
+                "\'%8.8s\' because it is not private\n",
+                anchor->moduleInfo.inputInfo.name);
       }
-
       memset(&anchor->moduleInfo, 0, sizeof(anchor->moduleInfo));
       anchor->flags &= ~ZIS_PLUGIN_ANCHOR_FLAG_LPA;
+      anchor->flags &= ~ZIS_PLUGIN_ANCHOR_FLAG_PRIVATE_MODULE;
       lpaPresent = false;
     }
 

--- a/h/zis/plugin.h
+++ b/h/zis/plugin.h
@@ -61,6 +61,7 @@ struct ZISPluginAnchor_tag {
   unsigned short size;
   int flags;
 #define ZIS_PLUGIN_ANCHOR_FLAG_LPA 0x00000001
+#define ZIS_PLUGIN_ANCHOR_FLAG_PRIVATE_MODULE 0x00000002
   int state;
 
   ZISPluginName name;


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This pull-request introduces a new flag which shows if a plug-in module is private and is safe to be deleted when the dev options are used.

The corresponding modreg changes in zowe-common-c, which are picked up in this commit, will ensure that the `LPMEA` area from `modregRegister` never contains a valid delete token, which means it can't be used to delete the corresponding module.

This PR addresses Issue: https://github.com/zowe/zss/issues/749

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/517

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

**WARNING:** testing of this fix should be done on a dedicated LPAR so as not to interfere with any other ZIS instances.

### Notes:
* The instructions have messages with absolute values (e.g. virtual storage addresses); these value will likely be different on your system.
* Always check for unexpected errors and ABENDs during the start-up and termination of ZIS.
* By "current ZIS", the version containing this fix is assumed.
* Unless explicitly stated, a ZIS is assumed to be run **without** any dev options.
* To reset the module registry, start and stop a separate current ZIS with an empty PARMLIB member (e.g., `ZWESIP99`): `S ZWESIS01,REUSASID=YES,NAME=SRV4RESET,MEM=99,OPT='RESET(MODREG),ZWES.MODULE_REGISTRY=NO'`.
* To switch versions, you can use a variable in your ZIS JCL:
```
@@ -1,4 +1,4 @@
-//ZWESIS01  PROC NAME='ZWESIS_STD',MEM=00,RGN=0M,OPT=''
+//ZWESIS01  PROC NAME='ZWESIS_STD',MEM=00,RGN=0M,OPT='',V=00
 //********************************************************************/
 //* This program and the accompanying materials are                  */
 //* made available under the terms of the                            */
@@ -52,6 +52,6 @@
 //********************************************************************/
 //ZWESIS01 EXEC PGM=ZWESIS01,REGION=&RGN,
 //         PARM='NAME=&NAME,MEM=&MEM,&OPT'
-//STEPLIB  DD   DSNAME=ZWES.SISLOAD,DISP=SHR
+//STEPLIB  DD   DSNAME=ZWES.SISLOAD.V&V.,DISP=SHR
 //PARMLIB  DD   DSNAME=ZWES.SISSAMP,DISP=SHR
 //SYSPRINT DD   SYSOUT=*

```
And the start your ZIS using the command `S ZWESIS01,REUSASID=YES,V=32` if you want to use the load library `ZWES.SISLOAD.V32`.

### Prerequisites

* For almost all the following test cases, you'll need version 3.1.0 of the ZWESISDL plug-in.
Add the following line to the PARMLIB member to enable the plug-in:
```
ZWES.PLUGIN.ZISDYNAMIC=ZWESISDL
```
* Make sure to use the updated JCL from https://github.com/zowe/zss/pull/755; this will allow passing parameters in the START command instead of modifying the PARMLIB member.

### Test cases

#### Prod-to-dev-to-prod switch

This case should versify the actual fix: when we turn on the dev mode, no shared module must be removed.

* Reset the registry.
* Start and then stop current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE1`.
* Make sure the log contain the following messages (use the cold start is necessary):
  * `ZWES0258I Module status: new instance added to registry (1060F000)`
  * `ZWES0022I Module ZWESISDL status: new instance added to registry (10587000)`
* Start ZIS in dev mode using the command `S ZWESIS01,REUSASID=YES,NAME=CASE1,OPT='ZWES.DEV_MODE.LPA=YES'`.
* Make sure that:
  * it's started successfully (no bad RCs, no ABENDs);
  * the log has the following messages upon start-up:
    * `ZWES0100I LPA dev mode enabled, skipping CSVDYLPA DELETE because module is not private`
    * `ZWES0258I Module status: own instance loaded to LPA (10BD1000)`
    * `ZWES0098I Plugin LPA dev mode enabled, skipping CSVDYLPA DELETE of 'ZWESISDL' because it is not private`
    * `ZWES0022I Module ZWESISDL status: own instance loaded to LPA (10EBF000)` 
* Stop ZIS; make sure:
  * it's stopped successfully (no bad RCs, no ABENDs);
  * the log has the following messages upon termination:
    * `ZWES0098I Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of 'ZWESISDL'`
    * `ZWES0100I LPA dev mode enabled, issuing CSVDYLPA DELETE`
* Start ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE1` and make sure the log contain the following messages:
  * `ZWES0258I Module status: instance reused from registry (1060F000)`
  * `ZWES0022I Module ZWESISDL status: existing instance reused from registry (10587000)`
* Verify that this last "ZWES0258I" and "ZWES0022I" messages have the same addresses as the first "ZWES0258I"  and "ZWES0022I" messages.
* Stop ZIS; make sure it's stopped successfully (no bad RCs, no ABENDs).

#### Upgrade/downgrade from/to v2.x.x

Here, we're trying to test whether a migration from v2 to this new v3 version goes well. For this test, use `ZWESISDL` from the respective version as oppose to what is said in the prerequisites.

* Reset the registry.
* Start a v2.x.x ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE2`.
* Stop ZIS.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE2`.
* The log should contain the following messages:
  * `ZWES0240W Discarding outdated LPA module at 10E3B000 ... `
  * `ZWES0258I Module status: new instance added to registry (10407000)`
  * `ZWES0018W Plug-in 'ZISDYNAMIC      ' version 70 doesn't match anchor version 11, LPA module discarded`
  * `ZWES0022I Module ZWESISDL status: new instance added to registry (1037F000)`
* Stop ZIS.
* Start the v2.x.x ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE2`.
* The log should contain the following messages:
  * `ZWES0240W Discarding outdated LPA module at 10D27000 ...`
  * `ZWES0018W Plug-in 'ZISDYNAMIC      ' version 11 doesn't match anchor version 70, LPA module discarded`
* Stop ZIS.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE2`.
* The log should contain the following messages:
  * `ZWES0240W Discarding outdated LPA module at 10BAC000 ... `
  * `ZWES0258I Module status: instance reused from registry (10D27000)`
  * `ZWES0018W Plug-in 'ZISDYNAMIC      ' version 70 doesn't match anchor version 11, LPA module discarded`
  * `ZWES0022I Module ZWESISDL status: existing instance reused from registry (10C9D000)`
* Stop ZIS.

#### Upgrade from v3.1.0

Here, we're trying to test whether a migration from v3.1.0 (the version with the bug) to this new v3 version goes well.

* Reset the registry.
* Start a v3.1.0 ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE3`.
* Stop ZIS.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE3`
* The log should contain the following messages:
  * `ZWES0240W Discarding outdated LPA module at 10982000 ...`
  * `ZWES0258I Module status: new instance added to registry (1086B000)`
  * `ZWES0022I Module ZWESISDL status: previously added/loaded instance reused (FBE6000)`
 * Stop ZIS.

#### Upgrade from affected v3.1.0

This case should verify whether the new version can recover a v3.1.0 instance.

* Reset the registry.
* Start a v3.1.0 ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE4`.
* Stop ZIS.
* Start the v3.1.0 ZIS in dev mode using the command `S ZWESIS01,REUSASID=YES,NAME=CASE4,OPT='ZWES.DEV_MODE.LPA=YES'`.
* Stop ZIS.
* Start the v3.1.0 ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE4`.
* It should terminated with a bad RC and the following error messages:
```
ZWES0115E Core server stopped with an error, status = 39
ZWES0011E ZSS Cross-Memory server not started, RC = 39
ZWES0013E ZSS Cross-Memory Server terminated due to an error, status = 8
```
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE4`.
* The log should contain the following messages:
  * `ZWES0240W Discarding outdated LPA module at 106EA000 ...`
  * `ZWES0258I Module status: new instance added to registry (FACC000)`
* It then should terminated with a bad RC and the following error messages:
```
ZWES0115E Core server stopped with an error, status = 39
ZWES0011E ZSS Cross-Memory server not started, RC = 39
ZWES0013E ZSS Cross-Memory Server terminated due to an error, status = 8
```
* Cold start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE4,OPT='COLD'`.
* Check the log, it should contain the following messages:
  * `ZWES0258I Module status: instance reused from registry (FACC000)`
  * `ZWES0022I Module ZWESISDL status: new instance added to registry (F9BB000)`
* Stop ZIS.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE4`.
* The log should contain the following messages:
  * `ZWES0258I Module status: previously added/loaded instance reused (FACC000)`
  * `ZWES0022I Module ZWESISDL status: previously added/loaded instance reused (F9BB000)`
* Verify that these last "ZWES0258I" and "ZWES0022I" messages have the same addresses as in the same messages in the previous run.
* Stop ZIS.

#### Upgrade from v3.1.0 to dev v3.2.0

This case should verify that a v3.2.0 instance with dev options won't try to delete LPA modules from v3.1.0.

* Reset the registry.
* Start a v3.1.0 ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE5`.
* Stop ZIS.
* Start the current ZIS in dev mode using the command `S ZWESIS01,REUSASID=YES,NAME=CASE5,OPT='ZWES.DEV_MODE.LPA=YES'`.
* There must be the following messages:
  * `ZWES0240W Discarding outdated LPA module at 1054A000 ...`
  * `ZWES0100I LPA dev mode enabled, skipping CSVDYLPA DELETE because module is not private`
  * `ZWES0258I Module status: own instance loaded to LPA (10435000)`
  * `ZWES0098I Plugin LPA dev mode enabled, skipping CSVDYLPA DELETE of 'ZWESISDL' because it is not private`
  * `ZWES0022I Module ZWESISDL status: own instance loaded to LPA (103AB000)`
* Cancel ZIS.
* Start the current ZIS in dev mode using the command `S ZWESIS01,REUSASID=YES,NAME=CASE5,OPT='ZWES.DEV_MODE.LPA=YES'`.
* There must be the following messages:
  * `ZWES0100I LPA dev mode enabled, issuing CSVDYLPA DELETE`
  * `ZWES0098I Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of 'ZWESISDL'`
* Stop ZIS; there must be the following additional messages:
  * `ZWES0098I Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of 'ZWESISDL'`
  * `ZWES0100I LPA dev mode enabled, issuing CSVDYLPA DELETE`

#### Downgrade to v3.1.0

This case should verify that v3.1.0 will not pick up a registry entry made by the current ZIS.

* Reset the registry.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE6`.
* Stop ZIS.
* The log should contain the following messages:
  * `ZWES0258I Module status: new instance added to registry (10D80000)`
  * `ZWES0022I Module ZWESISDL status: new instance added to registry (110B1000)`
* Start a v3.1.0 ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE61`.
* Stop ZIS.
* The log should contain the following messages:
  * `ZWES0258I Module status: new instance added to registry (10E80000)`
  * `ZWES0022I Module ZWESISDL status: new instance added to registry (110F1000)`
* Verify that these last "ZWES0258I" and "ZWES0022I" messages have different addresses than in the first log of this test case.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE6`.
* The log should contain the following messages:
  * `ZWES0258I Module status: previously added/loaded instance reused (10D80000)`
  * `ZWES0022I Module ZWESISDL status: previously added/loaded instance reused (110B1000)`
* Verify that these "ZWES0258I" and "ZWES0022I" messages have the same addresses as in the first log of this test case.
* Stop ZIS.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE6,OPT='COLD'`.
* The log should contain the following messages:
  * `ZWES0258I Module status: instance reused from registry (10D80000)`
  * `ZWES0022I Module ZWESISDL status: instance reused from registry (110B1000)`
* Verify that these "ZWES0258I" and "ZWES0022I" messages have the same addresses as in the first log of this test case.
* Stop ZIS.

#### Downgrade to v3.1.0 with the same server name

This case should verify that v3.1.0 will not be able to delete a module loaded by v3.2.0.

* Reset the registry.
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE7`.
* Stop ZIS.
* The log should contain the following messages:
  * `ZWES0258I Module status: new instance added to registry (F706000)`
  * `ZWES0022I Module ZWESISDL status: new instance added to registry (F67E000)`
* Start a v3.1.0 ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE7`.
* Stop ZIS.
* The log should contain the following messages:
  * `ZWES0240W Discarding outdated LPA module at F706000 ...` 
  * `ZWES0258I Module status: new instance added to registry (F5F2000)`
  * `ZWES0022I Module ZWESISDL status: previously added/loaded instance reused (F67E000)`
* Verify that these last "ZWES0258I" messages have different addresses than in the first log of this test case.
* Verify that these last ""ZWES0022I" messages have the same addresses than in the first log of this test case.
* Start the v3.1.0 ZIS in dev mode using the command `S ZWESIS01,REUSASID=YES,NAME=CASE7,OPT='ZWES.DEV_MODE.LPA=YES'`
* There should be the following messages:
  * `ZWES0100I LPA dev mode enabled, issuing CSVDYLPA DELETE`
  * `ZWES0258I Module status: own instance loaded to LPA (F5F2000)`
  * `ZWES0098I Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of 'ZWESISDL'`
  * `ZWES0015E LPA DELETE failed for module ZWESISDL, RC = 4, RSN = 1025`
* Stop ZIS and check that there are the following messages:
  * `ZWES0098I Plugin LPA dev mode enabled, issuing CSVDYLPA DELETE of 'ZWESISDL'`
  * `ZWES0015E LPA DELETE failed for module ZWESISDL, RC = 4, RSN = 1025`
  * `ZWES0100I LPA dev mode enabled, issuing CSVDYLPA DELETE`
* Start the current ZIS using the command `S ZWESIS01,REUSASID=YES,NAME=CASE7`.
* The log should contain the following messages:
  * `ZWES0258I Module status: instance reused from registry (F706000)`
  * `ZWES0022I Module ZWESISDL status: previously added/loaded instance reused (F67E000)`
* Verify that these last "ZWES0258I" and "ZWES0022I" messages have the same addresses as in the first log of this test case.
* Stop ZIS.
 