### PR TITLE
Add an ability to display and reset the module registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: add a parameter for resetting the module registry at ZIS
   start-up (#754)
 - Enhancement: expose the modregReset function via dynlink (#754)
+- Bugfix: correct the modregRegister entry in the dynlink stub (#754)
 
 ## `3.1.0`
 - Enhancement: module registry (#732)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to the ZSS package will be documented in this file.
 - Bugfix: make sure modreg-based modules are never deleted (#752, zowe/zss#749)
 - Bugfix: Update schema entry for JWT tracing from incorrect name "_zss.jwt" to correct name "_zss.jwtTrace", to help people identify which log level can enable JWT tracing (#757)
 - Enhancement: add support for passing multiple parameters to ZIS via the START command (#753, #755)
-
+- Enhancement: add a parameter for resetting the module registry at ZIS
+  start-up (#754)
 
 ## `3.1.0`
 - Enhancement: module registry (#732)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the ZSS package will be documented in this file.
   start-up (#754)
 - Enhancement: expose the modregReset function via dynlink (#754)
 - Bugfix: correct the modregRegister entry in the dynlink stub (#754)
+- Bugfix: fix the incorrect check of the look-up anchor reset parameter (#754)
 
 ## `3.1.0`
 - Enhancement: module registry (#732)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: add support for passing multiple parameters to ZIS via the START command (#753, #755)
 - Enhancement: add a parameter for resetting the module registry at ZIS
   start-up (#754)
+- Enhancement: expose the modregReset function via dynlink (#754)
 
 ## `3.1.0`
 - Enhancement: module registry (#732)

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -70,6 +70,7 @@ See details in the ZSS Cross Memory Server installation guide
 #define ZIS_PARM_COLD_START                   "COLD"
 #define ZIS_PARM_DEBUG_MODE                   "DEBUG"
 #define ZIS_PARM_RESET_LOOKUP                 "RESET(LOOKUP)"
+#define ZIS_PARM_RESET_MODREG                 "RESET(MODREG)"
 
 #define ZIS_PARM_PCSS_STACK_POOL_SIZE         CMS_PROD_ID".PCSS_STACK_POOL_SIZE"
 #define ZIS_PCSS_STACK_POOL_DEFAULT_SIZSE     1024
@@ -1536,6 +1537,11 @@ static int getCMSConfigFlags(const ZISParmSet *zisParms) {
   const char *modregMode = zisGetParmValue(zisParms, ZIS_PARM_MODREG);
   if (modregMode && !strcmp(modregMode, ZIS_PARM_MODREG_OFF)) {
     flags &= ~CMS_SERVER_FLAG_USE_MODREG;
+  }
+
+  const char *resetModreg = zisGetParmValue(zisParms, ZIS_PARM_RESET_MODREG);
+  if (resetModreg && strlen(resetModreg) == 0) {
+    flags |= CMS_SERVER_FLAG_RESET_MODREG;
   }
 
   return flags;

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -1530,7 +1530,7 @@ static int getCMSConfigFlags(const ZISParmSet *zisParms) {
   }
 
   const char *resetLookup = zisGetParmValue(zisParms, ZIS_PARM_RESET_LOOKUP);
-  if (resetLookup && strlen(coldStartValue) == 0) {
+  if (resetLookup && strlen(resetLookup) == 0) {
     flags |= CMS_SERVER_FLAG_RESET_LOOKUP;
   }
 

--- a/c/zis/stubinit.c
+++ b/c/zis/stubinit.c
@@ -564,6 +564,7 @@
     stubVector[ZIS_STUB_ZVTGXMLR] = (void*)zvtGetCMSLookupRoutineAnchor;
     stubVector[ZIS_STUB_ZVTSXMLR] = (void*)zvtSetCMSLookupRoutineAnchor;
     stubVector[ZIS_STUB_MODRRGST] = (void*)modregRegister;
+    stubVector[ZIS_STUB_MODRRSET] = (void*)modregReset;
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -699,7 +699,7 @@
 #define ZIS_STUB_ZVTSXMLR 905 /* zvtSetCMSLookupRoutineAnchor mapped */
 
 /* modreg, 915-920 */
-#define ZIS_STUB_MODRRGST 915 /* modregRegister mapped */
+#define ZIS_STUB_MODRRGST 915 /* modregRegister */
 #define ZIS_STUB_MODRRSET 916 /* modregReset */
 
 #endif /* ZIS_ZISSTUBS_H_ */

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -20,7 +20,7 @@
    FULL BACKWARD COMPATIBILITY MUST BE MAINTAINED
    */
 
-#define ZIS_STUBS_VERSION 6
+#define ZIS_STUBS_VERSION 7
 
 /*
   How does a user check for compatibility?
@@ -700,6 +700,7 @@
 
 /* modreg, 915-920 */
 #define ZIS_STUB_MODRRGST 915 /* modregRegister mapped */
+#define ZIS_STUB_MODRRSET 916 /* modregReset */
 
 #endif /* ZIS_ZISSTUBS_H_ */
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR introduces a new parameter for resetting the module registry in case something has broken the registry.

Add the following parameter to your `PARM=` field in the ZIS JCL or the ZIS PARMLIB member: `RESET(MODREG)`.

**WARNING:** using this feature will leak the LPA and common storage used by the registry; this will also affect all the ZIS instance who rely on the registry (the next time they get restarted, the modules will be re-added to the LPA).

Related minor changes:
* Expose the new module registry function `modregReset`
* Correct the type of the modregRegister dynlink stub entry
* Fix the incorrect check of the look-up anchor reset parameter
* Update the zowe-common-c dependencies to pick up the following:
  * Add a modify command for display the content of the module registry
  * Add a new flag for resetting the module registry

All these changes are split into individual PRs; use those commits for a easier review process.

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/519

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

### Prerequisites
* Make sure your ZIS JCL contains the changes from #755.
* Make sure to include the ZWESISDL plug-in in your PARMLIB member: `ZWES.PLUGIN.ZISDYNAMIC=ZWESISDL`.
* Make sure no dev mode is enabled in the ZIS PARMLIB member.

### Test cases

#### The "reset module registry" parameter
* Start ZIS using the command `S zisstc,REUSASID=YES,NAME=TESTSERVER1,OPT='RESET(MODREG)'`
* You should get the following message:
```
ZWES0260I Module registry has been reset
```
* Stop ZIS
* Use the command `S zisstc,REUSASID=YES,NAME=TESTSERVER2,OPT='COLD'` to start a clean ZIS with a different name
* Check that there are the following messages:
```
ZWES0258I Module status: new instance added to registry (11022000)
ZWES0022I Module ZWESISDL status: new instance added to registry (10F98000)
```
* Start a clean ZIS with the original name `S zisstc,REUSASID=YES,NAME=TESTSERVER1,OPT='COLD'`
* You should get the following message:
```
ZWES0258I Module status: instance reused from registry (11022000)
ZWES0022I Module ZWESISDL status: existing instance reused from registry (10F98000)
```
* Stop all ZIS instances

#### The "reset module registry" parameter on a system after an IPL
* IPL the system
* Start ZIS using the command `S zisstc,REUSASID=YES,NAME=TESTSERVER1,OPT='RESET(MODREG)'`
* You should get the following messages:
```
ZWES0261W Module registry reset RC = 3
ZWES0258I Module status: new instance added to registry (1113E000)
ZWES0022I Module ZWESISDL status: new instance added to registry (110B3000)
```
* Stop ZIS
* Start ZIS using the command `S zisstc,REUSASID=YES,NAME=TESTSERVER1`
* Verify that there are the following messages:
```
ZWES0258I Module status: previously added/loaded instance reused (1113E000)
ZWES0022I Module ZWESISDL status: previously added/loaded instance reused (110B3000)
```

#### New modify command

* Start ZIS using the following command: `S zisstc,REUSASID=YES,NAME=TESTSERVER1`
* Issue `F zisstc,D MODREG`
* The JESMSGLG log has the following messages:
```
ZWES0220I Modify D command received
ZWES0222I Module registry address is 0x1EF8641F300 at 0x111D6030
```
* The SYSPRINT log has the following messages:
```
ZWES0220I Modify D command received
ZWES0222I Module registry address is 0x1EF8641F300 at 0x111D6030
ZWES0222I Module registry entry #0 at 0x1EF8641F300:
ZWES0101I 00000000  E9E6C5D4 D6C4D9C5 02000000 00900000 |ZWEMODRE........|
ZWES0101I 00000010  E0ADA19F 0F4C2001 E9E6C5E2 C9E2F0F2 |\[~..<..ZWESIS02|
ZWES0101I 00000020  001A0000 00000000 000001EF 8641F200 |............f.2.|
ZWES0101I 00000030  E9E6C5E2 C9E2C4D3 E9E6C5C3 D4D6C47A |ZWESISDLZWECMOD:|
ZWES0101I 00000040  00010030 00000000 F2F0F2F5 60F0F460 |........2025-04-|
ZWES0101I 00000050  F0F240F0 F97AF5F7 7AF5F44B F9F4F5F1 |02 09:57:54.9451|
ZWES0101I 00000060  F4F70000 00000000 E9E6C5E2 C9E2C4D3 |47......ZWESISDL|
ZWES0101I 00000070  80008000 000008AC 0000020B 10F98039 |.............9..|
ZWES0101I 00000080  10F98000 00089408 00000000 00000000 |.9....m.........|
ZWES0222I Module registry entry #1 at 0x1EF8641F200:
ZWES0101I 00000000  E9E6C5D4 D6C4D9C5 02000000 00900000 |ZWEMODRE........|
ZWES0101I 00000010  E0ADA19F 06814B41 E9E6C5E2 C9E2F0F2 |\[~..a..ZWESIS02|
ZWES0101I 00000020  001A0000 00000000 00000000 00000000 |................|
ZWES0101I 00000030  E9E6C5E2 C9E2F0F1 E9E6C5C3 D4D6C47A |ZWESIS01ZWECMOD:|
ZWES0101I 00000040  00010030 00000000 F2F0F2F5 60F0F460 |........2025-04-|
ZWES0101I 00000050  F0F240F0 F97AF5F7 7AF2F74B F9F4F2F6 |02 09:57:27.9426|
ZWES0101I 00000060  F4F40000 00000000 E9E6C5E2 C9E2F0F1 |44......ZWESIS01|
ZWES0101I 00000070  80008000 000008AB 00000252 11087B69 |..............#.|
ZWES0101I 00000080  11022000 0008CDC0 00000000 00000000 |.......{........|
```
* Stop ZIS

#### New modify command with an empty register

* Start ZIS using the following command: `S zisstc,REUSASID=YES,NAME=TESTSERVER1,OPT='ZWES.MODULE_REGISTRY=NO,RESET(MODREG)'`
* Issue `F zisstc,D MODREG`
* You should get the following response in SYSPRINT:
```
ZWES0220I Modify D command received
ZWES0222I Module registry is empty at 0x111D6030
```
* Stop ZIS

#### `RESET(LOOKUP)` parameter fix

You will need a ZIS v3.0.0 instance for this test.

* Edit your PARMLIB member for ZIS and add the following lines:
```
COLD=FOO
RESET(LOOKUP)
```
* Start ZIS v3.0.0 using the command `S zisstc,REUSASID=YES,NAME=TESTSERVER1`
* Check the SYSPRINT log; there must **not** be the messages:
```
ZWES0107I Cold start initiated
ZWES0256I Look-up routine anchor at 12A4B088 has been explicitly discarded
```
* Stop ZIS
* Edit your PARMLIB member and remove `COLD=FOO`
* Start ZIS v3.0.0 using the command `S zisstc,REUSASID=YES,NAME=TESTSERVER1`
* Check the SYSPRINT log; there must be the following message:
```
ZWES0256I Look-up routine anchor at 12A4B088 has been explicitly discarded
```
* Stop ZIS and revert the changes in the PARMLIB member
* Edit your PARMLIB member for ZIS and add the following lines:
```
COLD=FOO
RESET(LOOKUP)
```
* Start a ZIS instance with the new libraries using the following command: `S zisstc,REUSASID=YES,NAME=TESTSERVER1`
* Check the SYSPRINT log; the message following message must **not** be in the log:
```
ZWES0107I Cold start initiated
```
* The following message must be present:
```
ZWES0256I Look-up routine anchor at 12A4B088 has been explicitly discarded
```
* Stop ZIS and revert the changes made in the PARMLIB member