### PR TITLE
Update proper trace name for JWT tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: include the stub version in the generated HLASM stub (#743)
 - Enhancement: expose new cmutils functions (#740)
 - Bugfix: make sure modreg-based modules are never deleted (#752, zowe/zss#749)
+- Bugfix: Update schema entry for JWT tracing from incorrect name "_zss.jwt" to correct name "_zss.jwtTrace", to help people identify which log level can enable JWT tracing (#757)
 
 ## `3.1.0`
 - Enhancement: module registry (#732)

--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -380,7 +380,7 @@
           "description": "Controls logging of http client calls.",
           "$ref": "#/$defs/logLevel"
         },
-        "_zss.jwt": {
+        "_zss.jwtTrace": {
           "description": "Controls logging of JWT library functions.",
           "$ref": "#/$defs/logLevel"
         },


### PR DESCRIPTION
I needed to trace the JWT code of zowe-common-c and found the schema did not match the behavior
ZSS calls the set function for JWT tracing when it sees the logLevel "_zss.jwtTrace", not "_zss.jwt": https://github.com/zowe/zss/blob/06c9143b3421ed3b9d5c55d8e63979e75f3160a6/c/zss.c#L452