### PR TITLE
Update incorrect CHANGELOG.md number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## `2.18.1`
 - Bugfix: Support cross-memory server parameters longer than 128 characters (#684)
-- Enhancement: Expose new cross-memory server's functions in dynlink (#684)
+- Enhancement: Expose new cross-memory server's functions in dynlink ([#714](https://github.com/zowe/zss/pull/714))
 
 ## `2.18.0`
 - Change log level for setting default value of 'httpRequestHeapMaxBlocks' to DEBUG instead of INFO.(#719)


### PR DESCRIPTION
v2.18.1 changelog has an item which points to a ticket number that is unrelated.
I have identified the PR that this changelog message came from, and have set it to reference that PR number instead.