### PR TITLE
Fix potential loop on HTTP/ATTLS Client JWK behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.3.0`
+- Bugfix: JWK logic for single-sign-on to the APIML Gateway had the potential for a high-cpu loop when AT-TLS was enabled and the destination had read errors ([#772](https://github.com/zowe/zss/pull/772))
+
 ## `3.2.0`
 - Enhancement: include the stub version in the generated HLASM stub (#743)
 - Enhancement: expose new cmutils functions (#740)

--- a/c/jwk.c
+++ b/c/jwk.c
@@ -211,15 +211,16 @@ static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientC
   int currentLoop = 0;
   while (!done) {
     int status = httpClientSessionReceiveNativeLoop(httpClientContext, session);
-    if (status == HTTP_CLIENT_EWOULDBLOCK){
-      currentLoop++;
-      usleep(1000);
-    }
     if (currentLoop > loopLimit){
       zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "JWT timeout reached\n");
       break;
     }
-    if (status != 0 && status != 15) {
+    if (status == HTTP_CLIENT_SOCKET_TIMEOUT) {
+      zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "socket timeout reached\n");
+      break;
+    } else if (status != 0 &&
+               status != HTTP_CLIENT_READ_ERROR &&
+               status != HTTP_CLIENT_UNBLOCKED_TRY_AGAIN) {
       zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "error receiving response: %d\n", status);
       break;
     }
@@ -227,6 +228,8 @@ static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientC
       done = true;
       break;
     }
+    currentLoop++;
+    sleep(1);
   }
   if (done) {
     int contentLength = session->response->contentLength;

--- a/c/jwk.c
+++ b/c/jwk.c
@@ -214,15 +214,14 @@ static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientC
     if (currentLoop > loopLimit){
       zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "JWT timeout reached\n");
       break;
-    }
-    if (status == HTTP_CLIENT_SOCKET_TIMEOUT) {
-      zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "socket timeout reached\n");
-      break;
-    } else if (status != 0 &&
-               status != HTTP_CLIENT_READ_ERROR &&
-               status != HTTP_CLIENT_UNBLOCKED_TRY_AGAIN) {
-      zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "error receiving response: %d\n", status);
-      break;
+    } else if (status != 0) {
+      if (status != HTTP_CLIENT_SOCKET_TIMEOUT ||
+          status != HTTP_CLIENT_UNBLOCKED_TRY_AGAIN) {
+        zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_DEBUG, "status=%d, trying again. loop count=%d\n", status, currentLoop);
+      } else{
+        zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "error receiving response: %d\n", status);
+        break;
+      }
     }
     if (session->response) {
       done = true;

--- a/c/jwk.c
+++ b/c/jwk.c
@@ -215,8 +215,8 @@ static Json *receiveResponse(ShortLivedHeap *slh, HttpClientContext *httpClientC
       zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "JWT timeout reached\n");
       break;
     } else if (status != 0) {
-      if (status != HTTP_CLIENT_SOCKET_TIMEOUT ||
-          status != HTTP_CLIENT_UNBLOCKED_TRY_AGAIN) {
+      if (status == HTTP_CLIENT_SOCKET_TIMEOUT ||
+          status == HTTP_CLIENT_UNBLOCKED_TRY_AGAIN) {
         zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_DEBUG, "status=%d, trying again. loop count=%d\n", status, currentLoop);
       } else{
         zowelog(NULL, LOG_COMP_ID_JWK, ZOWE_LOG_WARNING, "error receiving response: %d\n", status);


### PR DESCRIPTION
When HTTP/ATTLS is used in ZSS, when it tries to contact Gateway for SSO, the non-blocking loop for reading the gateway response was flawed. There's a wait loop that looks for conditions to wait, but the wait is way too small and there are conditions where the loop is infinite as well, causing a rapid and high-cpu loop:

<img width="821" alt="after" src="https://github.com/user-attachments/assets/724d20d0-e588-4f95-bde1-8dfa167b8a2f" />

This PR addresses it by making the wait between loops longer, unconditional, and handles the potential status codes better.

Here's the change - you'll see no CPU issue.
<img width="858" alt="before" src="https://github.com/user-attachments/assets/74f2cb3d-cfa8-46a9-8cbe-096ae4828c07" />
