### PR TITLE
[Test PR] for upload memory leak

### DIFF
--- a/c/unixFileService.c
+++ b/c/unixFileService.c
@@ -34,6 +34,7 @@
  * inactivity.
  */
 #define TIMEOUT_TIME 600
+#define TRIAL_AVOID_WRITE
 
 /* An enumeration of the possible
  * file transfer types supported
@@ -629,9 +630,14 @@ static void doChunking(UploadSessionTracker *tracker, HttpResponse *response, ch
       status = 0;
       //Only write to file if string isn't empty. If string is empty, case is handled by creation of new file.
       if (response->request->contentLength > 0) {
+#ifdef TRIAL_AVOID_WRITE
+        printf("***GKP:doChunking avoiding write!");
+        status = 0; // avoid write to check memory leak in it
+#else
         status = writeAsciiDataFromBase64(currentSession->file, response->request->contentBody,
                                         response->request->contentLength, currentSession->sourceCCSID,
                                         currentSession->targetCCSID);
+#endif
       }
     }
 


### PR DESCRIPTION


 - SLH allocation and free for the parser. This same SLH is used to create buffer for input content.
https://github.com/zowe/zowe-common-c/blob/c6f577921787ec7489341270dfffd5b0878b7e60/c/httpserver.c#L5829 - makeSLH
https://github.com/zowe/zowe-common-c/blob/c6f577921787ec7489341270dfffd5b0878b7e60/c/httpserver.c#L6215 - SLHFree
https://github.com/zowe/zowe-common-c/blob/c6f577921787ec7489341270dfffd5b0878b7e60/c/alloc.c#L604 -      safeFree64Internal() ; free() not done
 - request and parser share the same SLH. Response has its own slh which is freed in finishResponse().

`************** Code flow for each chunk write **************


1. 	httpHandleTCP() 
		https://github.com/zowe/zowe-common-c/blob/c6f577921787ec7489341270dfffd5b0878b7e60/c/httpserver.c#L5829
		- ShortLivedHeap *slh = makeShortLivedHeap(READ_BUFFER_SIZE=65536, maxBlocks=1024); 
		- peerExtension = makeSocketExtension(.., slh,..)
		- *httpConversation = makeHttpConversation(peerExtension,(HttpServer*)(module->data));
								-> conversation->parser = makeHttpRequestParser(socketExtension->slh); /* allocates the parser on the SLH */
2. httpWorkElementHandler 
		case START_RESP
		
3. 	handlePeerSocketRead() -> 
		- SocketExtension *peerExtension = extension;
		- HttpConversation *conversation = (HttpConversation*)extension->protocolHandler;
		
	4.	doHttpReadWork() ->
			- socketRead()
			- processHttpFragment(parser,readBuffer,bytesRead);
			
		5.	processHttpFragment(parser,readBuffer,bytesRead)); ->
				- After processing headers
				https://github.com/zowe/zowe-common-c/blob/8104c38753286bb15579cbb810adb78be51ea8c0/c/httpserver.c#L2330
				- parser->content = SLHAlloc(parser->slh,parser->specifiedContentLength);
		
				### Loop -> httpHandleTCP  till all the content is read from the chunk and copied into parser->content, then create the create request below.
				
		6.	resetParserAndEnqueue(parser) -> 
				https://github.com/zowe/zowe-common-c/blob/8104c38753286bb15579cbb810adb78be51ea8c0/c/httpserver.c#L2343
								
		7.	enqueueLastRequest(parser) ->
				- HttpRequest *newRequest = (HttpRequest*)SLHAlloc(parser->slh,sizeof(HttpRequest));
				- newRequest->contentBody = copyString(parser->slh, parser->content, parser->specifiedContentLength);
	
		8.	httpWorkElementHandler() ->
									
			9.	doHttpResponseWork() ->
					HttpRequest *firstRequest = dequeueHttpRequest(parser);
					response = makeHttpResponse(firstRequest,parser->slh,conversation->socketExtension->socket);
									- ShortLivedHeap *responseSLH = makeShortLivedHeap(65536,100);
					handleHttpService()
											
			10. serveRequest() ->
													
			11. serveUnixFileContents(HttpService *service, HttpResponse *response) ->
						response->request->contentBody
											
			12. doChunking() -> (if 1st chunk assignSessionID->respondWithSessionID->handlePeerSocketRead)
										
			13. writeAsciiDataFromBase64() -> 
															
			14. finishResponse() ->	
				- SLHFree(response->slh);

	15.	doHttpReadWork	(BACK HERE)


16.	handlePeerSocketRead() (BACK HERE)
		https://github.com/zowe/zowe-common-c/blob/8104c38753286bb15579cbb810adb78be51ea8c0/c/httpserver.c#L5723
		
17. httpWorkElementHandler()
	HTTP_CLOSE_CONVERSATION - SLHFree(sext->slh) This is the SLH allocated in '1'
	https://github.com/zowe/zowe-common-c/blob/c6f577921787ec7489341270dfffd5b0878b7e60/c/httpserver.c#L6215
		
18. httpHandleTCP() (BACK HERE)

************** END OF PROCESSING CHUNK **************`

zowe-common-c: https://github.com/zowe/zowe-common-c/pull/540