### PR TITLE
Accomodate components.apiml.enabled=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `3.3.0`
 - Enhancement: Utility "zis-test" is now used to ensure that ZIS is running and accessible by Zowe before starting ZSS. (zowe/zss#764)
 - Enhancement: Utility "bind-test" is now available in Zowe and used to validate if each Zowe server can succeed in binding to the user requested TCPIP port at each Zowe startup. (zowe/zss#764)
+- Enhancement: zss handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components.
 - Bugfix: JWK logic for single-sign-on to the APIML Gateway had the potential for a high-cpu loop when AT-TLS was enabled and the destination had read errors ([#772](https://github.com/zowe/zss/pull/772))
 - Bugfix: Stop aborting when Zowe starts on new zOS version([#781](https://github.com/zowe/zss/pull/781))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the ZSS package will be documented in this file.
 ## `3.3.0`
 - Enhancement: Utility "zis-test" is now used to ensure that ZIS is running and accessible by Zowe before starting ZSS. (zowe/zss#764)
 - Enhancement: Utility "bind-test" is now available in Zowe and used to validate if each Zowe server can succeed in binding to the user requested TCPIP port at each Zowe startup. (zowe/zss#764)
-- Enhancement: zss handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components.
+- Enhancement: zss handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components. [(#787)](https://github.com/zowe/zss/pull/787)
 - Bugfix: JWK logic for single-sign-on to the APIML Gateway had the potential for a high-cpu loop when AT-TLS was enabled and the destination had read errors ([#772](https://github.com/zowe/zss/pull/772))
 - Bugfix: Stop aborting when Zowe starts on new zOS version([#781](https://github.com/zowe/zss/pull/781))
 

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -28,13 +28,13 @@ components:
       mediationLayer:
         server:
           isHttps: true
-          enabled: ${{ components.gateway.enabled }}
+          enabled: ${{ components.gateway?.enabled || components.apiml?.enabled }}
           gatewayHostname: ${{ std.getenv('ZWE_haInstance_hostname') }}
           hostname: ${{ std.getenv('ZWE_haInstance_hostname') }}
           gatewayPort: ${{ components.gateway.port }}
           port: ${{ components.discovery.port }}
         cachingService:
-          enabled: ${{ components['caching-service'].enabled }}
-        enabled: ${{ components.discovery.enabled }}
+          enabled: ${{ components['caching-service']?.enabled || components.apiml?.enabled }}
+        enabled: ${{ components.discovery?.enabled || components.apiml?.enabled }}
         serviceName: "zss"
       handshakeTimeout: 30000


### PR DESCRIPTION
This PR checks all variables that used to check for discovery/gateway/caching-service and allows components.apiml.enabled to be a substitute for them.

Similar to https://github.com/zowe/zlux-app-server/pull/345