### PR TITLE
Checks for zis stc if provided

### DIFF
--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -12,7 +12,18 @@ if [ ! "${RUN_ON_ZOS}" = "true" ]; then
   echo "Error: ZSS can only be run on z/OS, but validation detected a different OS from uname."
   exit 1
 else
-  "${ZWE_zowe_runtimeDirectory}/bin/utils/zis-test" --zis "${ZWE_components_zss_crossMemoryServerName}"
+  check_proclib=false
+  if [ -n "${ZWE_zowe_setup_dataset_proclib}" ]; then
+    if [ -n "${ZWE_zowe_setup_security_stcs_zis}" ]; then
+      check_proclib=true
+    fi
+  fi
+
+  if [ "${check_proclib}" = "true" ]; then
+    "${ZWE_zowe_runtimeDirectory}/bin/utils/zis-test" --zis "${ZWE_components_zss_crossMemoryServerName}" --proclib "${ZWE_zowe_setup_dataset_proclib}" --stc "${ZWE_zowe_setup_security_stcs_zis}"
+  else            
+    "${ZWE_zowe_runtimeDirectory}/bin/utils/zis-test" --zis "${ZWE_components_zss_crossMemoryServerName}"
+  fi
   rc=$?
   exit $rc
 fi

--- a/build/build_zis_test.sh
+++ b/build/build_zis_test.sh
@@ -32,6 +32,7 @@ c89 \
   -o ${ZSS}/bin/zis-test \
   ${COMMON}/c/alloc.c \
   ${COMMON}/c/crossmemory.c \
+  ${COMMON}/c/pdsutils.c \
   ${COMMON}/c/zos.c \
   ${COMMON}/c/timeutls.c \
   ${COMMON}/c/utils.c \

--- a/c/zisTest.c
+++ b/c/zisTest.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 
 #include "zis/client.h"
+#include "pdsutil.h"
 
 static int printZISStatus(char *zisName) {
   CrossMemoryServerName privilegedServerName = cmsMakeServerName(zisName);
@@ -58,6 +59,10 @@ int main(int argc, char **argv) {
   }
 
   char *zisName = getKeywordArg("--zis",argc,argv);
+  char *stcName = getKeywordArg("--stc",argc,argv);
+  char *proclibName = getKeywordArg("--proclib",argc,argv);
+  bool stcFound = false;
+
 
   if (!zisName) {
     printf("Error: --zis specifying ZIS server name to check is required\n");
@@ -78,7 +83,28 @@ int main(int argc, char **argv) {
           printf("Ensure the Zowe STC id has READ access to ZWES.IS in the FACILITY class\n");
         } 
       } else if (rc == RC_CMS_ZVT_NULL || rc == RC_CMS_ZERO_PC_NUMBER || rc == RC_CMS_GLOBAL_AREA_NULL || rc == RC_CMS_SERVER_NOT_READY) {
-        printf("The ZIS STC does not appear to be running. Start the job (Default: ZWESISTC) before starting the rest of Zowe\n");
+        if (!stcName) {
+          stcName = "ZWESISTC";
+        }
+        if (problibName) {
+          StringList *memberList = getPDSMembers(proclibName);
+          int memberCount = stringListLength(memberList);
+
+          for (int i = 0; i < memberCount; i++) {
+            char *memberName = stringElement->string;
+            if (!strcmp(memberName, stcName)) {
+              stcFound = true;
+              break;
+            }
+          }
+        }
+
+        if (stcFound) {
+          printf("The ZIS STC does not appear to be running. Start the job %s to run ZIS\n", stcName);
+        } else {
+          printf("The ZIS STC does not appear to be running. Locate the ZIS job (default: ZWESISTC) and run ZIS\n");
+        }
+        
       }
     }
   }


### PR DESCRIPTION
This PR expands the zis-test binary to take --proclib and --stc arguments.
When present, zis-test will modify its recommendations on which job name to start if ZIS is down and the stc & proclib arguments provided are valid.