### PR TITLE
Fix 0c4 on failed socket open when socket close attempted

### DIFF
--- a/c/bindTest.c
+++ b/c/bindTest.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
    
   if (serverSocket) {
     printf("Bind succeeded (pointer=0x%p, rc=0x%x, rsn=0x%x)\n", serverSocket, returnCode, reasonCode);
-    socketClose(serverSocket, returnCode, reasonCode);
+    socketClose(serverSocket, &returnCode, &reasonCode);
   } else{
     status = BIND_STATUS_ERROR;
     char *jobname = getenv("_BPX_JOBNAME");

--- a/c/bindTest.c
+++ b/c/bindTest.c
@@ -82,6 +82,7 @@ int main(int argc, char **argv) {
    
   if (serverSocket) {
     printf("Bind succeeded (pointer=0x%p, rc=0x%x, rsn=0x%x)\n", serverSocket, returnCode, reasonCode);
+    socketClose(serverSocket, returnCode, reasonCode);
   } else{
     status = BIND_STATUS_ERROR;
     char *jobname = getenv("_BPX_JOBNAME");
@@ -98,7 +99,6 @@ int main(int argc, char **argv) {
     } else {
       printf("Ensure the Zowe STC job and STC id has permission to make TCPIP binds to %s:%d\n", address, port);
     }
-    socketClose(serverSocket, returnCode, reasonCode);
   }
   return status;
 }


### PR DESCRIPTION
Testing within https://github.com/zowe/zowe-install-packaging/pull/4447 revealed some limitations. This PR fixes a bug in which socketClose was attempted when there was no socket to close - the call has now been moved to the other side of the conditional in which the server socket exists.