### PR TITLE
Revert zwesastc to single-line dd statements at request of extender

### DIFF
--- a/samplib/zis/ZWESASTC
+++ b/samplib/zis/ZWESASTC
@@ -34,8 +34,6 @@
 //*                                                                  */
 //********************************************************************/
 //ZWESAUX  EXEC PGM=ZWESAUX,REGION=&RGN
-//STEPLIB  DD  DSNAME={zowe.setup.dataset.authLoadlib},
-//             DISP=SHR
-//         DD  DSNAME={zowe.setup.dataset.authPluginLib},
-//             DISP=SHR
+//STEPLIB  DD  DSNAME={zowe.setup.dataset.authLoadlib},DISP=SHR
+//         DD  DSNAME={zowe.setup.dataset.authPluginLib},DISP=SHR
 //SYSPRINT DD  SYSOUT=*

--- a/samplib/zis/ZWESASTC
+++ b/samplib/zis/ZWESASTC
@@ -34,6 +34,6 @@
 //*                                                                  */
 //********************************************************************/
 //ZWESAUX  EXEC PGM=ZWESAUX,REGION=&RGN
-//STEPLIB  DD  DSNAME={zowe.setup.dataset.authLoadlib},DISP=SHR
-//         DD  DSNAME={zowe.setup.dataset.authPluginLib},DISP=SHR
+//STEPLIB  DD DSN={zowe.setup.dataset.authLoadlib},DISP=SHR
+//         DD DSN={zowe.setup.dataset.authPluginLib},DISP=SHR
 //SYSPRINT DD  SYSOUT=*


### PR DESCRIPTION
This PR reverts zwesastc contents to what it was in 3.2 and below.
In those versions, the authloadlib and authpluginlib lines were set by shell script text replacement https://github.com/zowe/zowe-install-packaging/blob/v3.1.0/bin/commands/init/stc/index.sh#L202 but were single-line per dd statement.
we attempted to shift to putting ",DISP=SHR" on a second line to allow for longer DSN, but it caused conflict for an extender.
In the future, I hope to re-introduce multi-line when the extender can handle it.

I don't expect this to cause issue in that we're just returning to previous limitations.