### PR TITLE
update default http ip address to 0.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.4.0`
+- Bugfix: Update the default IP address for ZSS in http mode to `0.0.0.0`, fixing errors on some systems where `127.0.0.1` caused connectivity issues. [[#797](https://github.com/zowe/zss/pull/797)]
+
 ## `3.3.0`
 - Enhancement: Utility "zis-test" is now used to ensure that ZIS is running and accessible by Zowe before starting ZSS. (zowe/zss#764)
 - Enhancement: Utility "bind-test" is now available in Zowe and used to validate if each Zowe server can succeed in binding to the user requested TCPIP port at each Zowe startup. (zowe/zss#764)

--- a/c/zss.c
+++ b/c/zss.c
@@ -472,7 +472,7 @@ ZSS_LOGGING_COMPONENTS_MAP(zssLogComponents)
                          \"pluginsDir\": \"../defaults/plugins\",      \
                          \"agent\": {                                  \
                            \"http\": {                                 \
-                             \"ipAddresses\": [\"127.0.0.1\"],         \
+                             \"ipAddresses\": [\"0.0.0.0\"],           \
                              \"port\": 7557                            \
                             }                                          \
                          },                                            \


### PR DESCRIPTION
When testing AT-TLS on the marist systems, the default IP of `127.0.0.1` for zss running in `http` mode caused problems accessing the service. This might not happen on other systems; but `0.0.0.0` should work for everyone. Is there any downside to using `0.0.0.0`?

## Proposed changes
This PR addresses Issue: https://github.com/zowe/zowe-install-packaging/issues/432

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Manually tested by overriding the values through `zowe.yaml`. A build is required to test with automation

## Further comments
Manually tested on the Marist systems. Will be included in automated system tests [with this PR](https://github.com/zowe/zowe-install-packaging/pull/4248).
