### PR TITLE
V2: Typo in logger `_zss.serialization`

### DIFF
--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -329,7 +329,7 @@
           "$ref": "#/$defs/logLevel"
         },
         "_zss.serialization": {
-          "description": "Controls logging of serialiation library functions.",
+          "description": "Controls logging of serialization library functions.",
           "$ref": "#/$defs/logLevel"
         },
         "_zss.zlparser": {


### PR DESCRIPTION
Same as #799, but for V2.