### PR TITLE
Fix wrong compile option for using dns lookup in bind test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.4.0`
+- Bugfix: Fixed hostname to IP address lookup for "bind-test" program. [(#801)](https://github.com/zowe/zss/pull/801)
+
 ## `3.3.0`
 - Enhancement: Utility "zis-test" is now used to ensure that ZIS is running and accessible by Zowe before starting ZSS. (zowe/zss#764)
 - Enhancement: Utility "bind-test" is now available in Zowe and used to validate if each Zowe server can succeed in binding to the user requested TCPIP port at each Zowe startup. (zowe/zss#764)

--- a/build/build_bind_test.sh
+++ b/build/build_bind_test.sh
@@ -23,7 +23,6 @@ mkdir -p "${WORKING_DIR}/tmp-bind-test" && cd "$_"
 xlclang \
   -q64 \
   -v \
-  -qascii \
   -D_XOPEN_SOURCE=600 \
   -DNEW_CAA_LOCATIONS=1 \
   "-Wc,langlvl(extc11),gonum,goff,hgpr,roconst,ASM,asmlib('SYS1.MACLIB')" \


### PR DESCRIPTION
This PR fixes a bug detected in https://github.com/zowe/zowe-install-packaging/pull/4447 where bind-test --host option was failing when giving a hostname instead of IP.
@JoeNemo found that I had been using the -qascii flag inappropriately, leading to wrong string handling when calling bpx functions.

resolves https://github.com/zowe/zss/issues/794