### PR TITLE
Optional flags for xlclang

### DIFF
--- a/build/build_bind_test.sh
+++ b/build/build_bind_test.sh
@@ -21,6 +21,7 @@ echo "Building bind test ..."
 mkdir -p "${WORKING_DIR}/tmp-bind-test" && cd "$_"
 
 xlclang \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   -v \
   -D_XOPEN_SOURCE=600 \

--- a/build/build_zss.sh
+++ b/build/build_zss.sh
@@ -65,6 +65,7 @@ echo "Date stamp: $date_stamp"
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -qascii \
   "-Wc,ILP32,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
   -DYAML_VERSION_MAJOR=${YAML_MAJOR} \

--- a/build/build_zss64.sh
+++ b/build/build_zss64.sh
@@ -61,6 +61,7 @@ echo "Date stamp: $date_stamp"
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   -qascii \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
@@ -108,6 +109,7 @@ echo "Done with ASCII mode 3rd party Objects"
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
   -DYAML_VERSION_MAJOR=${YAML_MAJOR} \


### PR DESCRIPTION
This PR adds env var ZWE_XLCLANG_FLAGS in the compile for xlclang, so that if you have environmental needs different from others, you can just set that during your compiles.

In particular, I was using this to add the -F flag.