### PR TITLE
Stop reading dataset records when JSON printer is in error state

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -293,7 +293,7 @@ int streamDataset(char *filename, int recordLength, jsonPrinter *jPrinter){
     if (rcEtag) { //if etag generation has an error, just don't send it.
       zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_WARNING,  "ICSF error for SHA etag init, %d\n",rcEtag);
     }
-    while (!feof(in)){
+    while (!feof(in) && !jsonCheckIOErrorFlag(jPrinter)){
       bytesRead = fread(buffer,1,recordLength,in);
       if (bytesRead > 0 && !ferror(in)) {
         if (!rcEtag) { rcEtag = icsfDigestUpdate(&digest, buffer, bytesRead); }


### PR DESCRIPTION
Proposed changes:

When ZSS streams dataset contents via streamDataset(), the while (!feof(in)) loop continues reading every record of the dataset even if the JSON printer has already entered an error state (e.g., due to an EBCDIC conversion failure). For large datasets with unmappable characters, this causes ZSS to burn CPU reading and attempting to convert thousands of records that will all fail, producing repeated JSON: conversion error, rc 16, reason 4 messages and high CPU utilization.

This PR adds a check for jsonCheckIOErrorFlag(jPrinter) to the loop condition, so that streamDataset() stops reading records as soon as the JSON printer reports an IO error. This works in conjunction with [zowe-common-c #590](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which ensures the error flag is properly set when conversion fails.

Depends on: zowe/zowe-common-c#590

Type of change: Bug fix