### PR TITLE
Disable logging if logger is launching

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -51,13 +51,17 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
   
   # this is to resolve ZSS bin path in LIBPATH variable.
   LIBPATH="${LIBPATH}:${ZSS_SCRIPT_DIR}"
+
+  ZWES_LOG_FILE=/dev/null
   
   #### Log file initialization ####
   if [ -n "$ZWES_LOG_FILE" ]
   then
     if [[ $ZWES_LOG_FILE == /* ]]
     then
-      echo "Absolute log location given."
+      if [ "$ZWES_LOG_FILE" != "/dev/null" ]; then
+        echo "Absolute log location given."
+      fi
     else
       ZWES_LOG_FILE="${ZSS_SCRIPT_DIR}/${ZWES_LOG_FILE}"
       echo "Relative log location given, set to absolute path=$ZWES_LOG_FILE"
@@ -68,21 +72,6 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
     fi
   else
   # _FILE was not specified; default filename, and check and maybe default _DIR
-    if [ -z "$ZWES_LOG_DIR" ]
-    then
-      if [ -n "$ZWE_zowe_logDirectory" -a -d "$ZWE_zowe_logDirectory" ]
-      then
-        ZWES_LOG_DIR=${ZWE_zowe_logDirectory}
-      else
-        if [ -z "${ZWE_zowe_runtimeDirectory}" ]; then
-          ZWES_LOG_DIR="../log"
-        else
-          echo "No log directory. Logging disabled."
-          ZWES_LOG_DIR=
-          ZWES_LOG_FILE=/dev/null
-        fi
-      fi
-    fi
     if [ -f "$ZWES_LOG_DIR" ]
     then
       ZWES_LOG_FILE=$ZWES_LOG_DIR
@@ -143,7 +132,11 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
     ZSS_CHECK_DIR=$(cd "$(dirname "$ZWES_LOG_FILE")"; pwd)
     ZWES_LOG_FILE=$ZSS_CHECK_DIR/$(basename "$ZWES_LOG_FILE")
   fi
-  echo ZWES_LOG_FILE=${ZWES_LOG_FILE}
+
+  if [ "$ZWES_LOG_FILE" != "/dev/null" ]; then
+    echo ZWES_LOG_FILE=${ZWES_LOG_FILE}
+  fi
+
   export ZWES_LOG_FILE=$ZWES_LOG_FILE
   if [ ! -e $ZWES_LOG_FILE ]
   then

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -51,8 +51,6 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
   
   # this is to resolve ZSS bin path in LIBPATH variable.
   LIBPATH="${LIBPATH}:${ZSS_SCRIPT_DIR}"
-
-  ZWES_LOG_FILE=/dev/null
   
   #### Log file initialization ####
   if [ -n "$ZWES_LOG_FILE" ]
@@ -71,6 +69,7 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
       echo "ZWES_LOG_FILE set (value $ZWES_LOG_FILE).  Ignoring ZWES_LOG_DIR."
     fi
   else
+    ZWES_LOG_FILE=/dev/null
   # _FILE was not specified; default filename, and check and maybe default _DIR
     if [ -f "$ZWES_LOG_DIR" ]
     then


### PR DESCRIPTION
This PR coordinates with https://github.com/zowe/launcher/pull/173 in that it assumes the launcher exists and defaults to logging to /dev/null to only do console output logging.

If you really want to log, for example in development, it should still be possible by setting env var ZWES_LOG_FILE or ZWES_LOG_DIR