### PR TITLE
Add dual cert support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.5.0`
+- Enhancement: ZSS now supports a dedicated client certificate for outbound TLS connections. When `zowe.certificate.keystore.clientCertificateAlias` is set, that certificate is used for client-side connections (e.g. to the APIML Caching Service and JWK endpoint) while the existing `zowe.certificate.keystore.alias` continues to be used as the server certificate. When `clientCertificateAlias` is absent, the existing single-certificate behaviour is preserved for backward compatibility. [(#820)](https://github.com/zowe/zss/pull/820)
+
 ## `3.4.0`
 - Bugfix: Fixed hostname to IP address lookup for "bind-test" program. [(#801)](https://github.com/zowe/zss/pull/801)
 

--- a/c/zss.c
+++ b/c/zss.c
@@ -1241,6 +1241,7 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
   settings->keyshares = keyshares ? keyshares : DEFAULT_TLS_KEY_SHARES;
   settings->keyring = jsonObjectGetString(httpsConfigObject, "keyring");
   settings->label = jsonObjectGetString(httpsConfigObject, "label");
+  settings->clientLabel = jsonObjectGetString(httpsConfigObject, "clientLabel");
   /*  settings->stash = jsonObjectGetString(httpsConfigObject, "stash"); - this is obsolete */
   settings->password = jsonObjectGetString(httpsConfigObject, "password");
   JsonArray *addressArray = jsonObjectGetArray(httpsConfigObject,"ipAddresses");
@@ -1256,6 +1257,7 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
     zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, ZSS_LOG_TLS_SETTINGS_MSG,
             settings->keyring,
             settings->label ? settings->label : "(no label)",
+            settings->clientLabel ? settings->clientLabel : "(no clientLabel)",
             settings->password ? "****" : "(no password)",
             settings->stash ? settings->stash : "(no stash)");
     TlsEnvironment *tlsEnv = NULL;

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -17,6 +17,7 @@ components:
         keyring: ${{ ()=> { if (components.zss.tls) { if (zowe.certificate.keystore.type.match(/JCE.*KS/)) { return zowe.certificate.keystore.file.replace(/safkeyring.*:\/+/,"") } else { return zowe.certificate.keystore.file } } else { return null } }() }}
         password: ${{ ()=> { if (components.zss.tls) { if (zowe.certificate.keystore.type.match(/JCE.*KS/)) { return null } else { return zowe.certificate.keystore.password } } else { return null } }() }}
         label: ${{ ()=> { if (components.zss.tls) { return zowe.certificate.keystore.alias } else { return null } }() }}
+        clientLabel: ${{ ()=> { if (components.zss.tls) { return zowe.certificate.keystore.clientCertificateAlias || null } else { return null } }() }}
         port: ${{ ()=> { if (components.zss.tls) { return  components.zss.port } else { return null } }() }}
         ipAddresses: "${{ ()=> { if (components.zss.tls){ if (zowe.environments?.ZWED_agent_https_ipAddresses){ return zowe.environments.ZWED_agent_https_ipAddresses.split(',') } else if (components.zss.zowe?.network?.server?.listenAddresses) { return components.zss.zowe.network.server.listenAddresses } else if (zowe.network?.server?.listenAddresses) { return zowe.network.server.listenAddresses } else { return [ '0.0.0.0' ] } } else { return null } }() }}"
         maxTls: "${{ ()=> { let maxTls = components.zss.zowe?.network?.server?.tls?.maxTls || zowe.network?.server?.tls?.maxTls; return maxTls ? maxTls : 'TLSv1.3'; }() }}"

--- a/h/zssLogging.h
+++ b/h/zssLogging.h
@@ -270,7 +270,7 @@ bool isLogLevelValid(int level);
 #ifndef ZSS_LOG_TLS_SETTINGS_MSG_ID
 #define ZSS_LOG_TLS_SETTINGS_MSG_ID          ZSS_LOG_MSG_PRFX"1061I"
 #endif
-#define ZSS_LOG_TLS_SETTINGS_MSG_TEXT        "TLS settings: keyring '%s', label '%s', password '%s', stash '%s'\n"
+#define ZSS_LOG_TLS_SETTINGS_MSG_TEXT        "TLS settings: keyring '%s', label '%s', clientLabel '%s', password '%s', stash '%s'\n"
 #define ZSS_LOG_TLS_SETTINGS_MSG             ZSS_LOG_TLS_SETTINGS_MSG_ID" "ZSS_LOG_TLS_SETTINGS_MSG_TEXT
 
 #ifndef ZSS_LOG_ENV_SETTINGS_MSG_ID

--- a/schemas/zss-config.json
+++ b/schemas/zss-config.json
@@ -115,6 +115,10 @@
               "type": [ "string", "null" ],
               "description": "The label (aka alias), identifying the server's certificate in the key store"
             },
+            "clientLabel": {
+              "type": [ "string", "null" ],
+              "description": "The label (aka alias) identifying the client certificate in the key store. When set, this certificate is used for outbound connections instead of the server certificate identified by 'label'. When omitted, 'label' is used for both server and client purposes."
+            },
             "keyring": {
               "type": [ "string", "null" ],
               "description": "This misnamed property is ICSF key ring identifier as '<user>/<ringName>' or USS file path to a .p12 format cert file"


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

Add support for a dedicated client certificate in ZSS, allowing the server certificate and the outbound client certificate to be different. This enables users to assign certificates with narrow EKU values — a server-only cert for the ZSS HTTPS listener and a client-only cert for outbound connections to the APIML Caching Service and JWK endpoint — rather than requiring a single dual-purpose certificate.

When `zowe.certificate.keystore.clientCertificateAlias` is defined in the Zowe YAML, that label is used for all outbound (client) TLS connections. When it is absent, `zowe.certificate.keystore.alias` continues to be used for both purposes, preserving full backward compatibility.

This PR depends upon the following PRs: zowe/zowe-common-c#590

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

**Manual verification steps:**

1. Configure a Zowe instance with two separate certificates in the keyring: one with server-only EKU (`zowe.certificate.keystore.alias`) and one with client-only EKU (`zowe.certificate.keystore.clientCertificateAlias`).
2. Start ZSS and confirm the startup log (message ZWES1061I) shows both the `label` and `clientLabel` values.
3. Verify ZSS accepts inbound HTTPS connections using the server certificate.
4. Enable the APIML Caching Service and confirm ZSS successfully authenticates to it using the client certificate.
5. Enable the JWK endpoint and confirm ZSS successfully fetches the JWK using the client certificate.
6. Repeat steps 3–5 with `clientCertificateAlias` absent to confirm the legacy single-certificate path still works.

## Further comments

The enforcement of the split is done in a single place: `tlsSocketInit()` in `zowe-common-c/c/tls.c`. When `isServer` is `false` and `clientLabel` is non-NULL on the `TlsSettings`, the client label is passed to `GSK_KEYRING_LABEL` instead of `label`. Because all HTTP client connections (Caching Service via `storageApiml.c`, JWK via `jwk.c`) go through `httpClientContextInitSecure()` → `tlsSocketInit(..., false)`, they automatically pick up the correct certificate without any changes to the client-side call sites.

**Files changed:**
- `c/zss.c` — reads `clientLabel` from `components.zss.agent.https.clientLabel` and populates `TlsSettings.clientLabel`
- `h/zssLogging.h` — updated `ZSS_LOG_TLS_SETTINGS_MSG_TEXT` to include `clientLabel` in the ZWES1061I startup log line
- `defaults.yaml` — maps `clientLabel` from `zowe.certificate.keystore.clientCertificateAlias` (null when absent)
- `schemas/zss-config.json` — adds `clientLabel` to the `https` properties object
