### PR TITLE
tlstrace regardless of logging

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -173,7 +173,7 @@ if [[ "${OSNAME}" == "OS/390" ]]; then
     ZSS_SERVER="${ZSS_SERVER_31}"
   fi
 
-  if [ "$ZWE_components_zss_agent_https_trace" = "true" ] && [ "$ZWES_LOG_FILE" != "/dev/null" ]; then
+  if [ "$ZWE_components_zss_agent_https_trace" = "true" ]; then
     export GSK_TRACE_FILE="${ZWES_LOG_FILE}.tlstrace"
     export GSK_TRACE=0xFF
   fi


### PR DESCRIPTION
https://github.com/zowe/zss/pull/820 changed to use /dev/null logging by default, but that disabled tlstrace ability.

it doesnt make sense to gate tlstrace in this way since its only needed for troubleshooting, so i am just removing the condition to allow tlstrace to continue to work.