### PR TITLE
Add a checksum service for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.6.0`
+- Enhancement: New checksum REST API for computing cryptographic hashes of z/OS UNIX files via ICSF. `GET /checksum/info` lists available algorithms; `GET /checksum/file/{algorithm}/{path}` returns a hex-encoded checksum. Supports MD5, SHA-1, SHA-224/256/384/512, and SHA3-224/256/384/512. Both endpoints run under the caller's identity (impersonation) so file access and ICSF algorithm availability are governed by the caller's permissions.
+
 ## `3.5.0`
 - Enhancement: Utility "detect-attls-port" can be used to check if an ATTLS policy exists at a specific connection. (https://github.com/zowe/zss/pull/813)  
 - Enhancement: ZSS now supports a dedicated client certificate for outbound TLS connections. When `zowe.certificate.keystore.clientCertificateAlias` is set, that certificate is used for client-side connections (e.g. to the APIML Caching Service and JWK endpoint) while the existing `zowe.certificate.keystore.alias` continues to be used as the server certificate. When `clientCertificateAlias` is absent, the existing single-certificate behaviour is preserved for backward compatibility. [(#820)](https://github.com/zowe/zss/pull/820)

--- a/build/build_zss.sh
+++ b/build/build_zss.sh
@@ -249,6 +249,7 @@ xlc \
   ${ZSS}/c/registerProduct.c \
   ${ZSS}/c/zis/client.c \
   ${ZSS}/c/serverStatusService.c \
+  ${ZSS}/c/checksumService.c \
   ${ZSS}/c/rasService.c \
   ${ZSS}/c/userInfoService.c \
   ${ZSS}/c/passTicketService.c \

--- a/build/build_zss64.sh
+++ b/build/build_zss64.sh
@@ -249,6 +249,7 @@ if ! c89 \
   ${ZSS}/c/registerProduct.c \
   ${ZSS}/c/zis/client.c \
   ${ZSS}/c/serverStatusService.c \
+  ${ZSS}/c/checksumService.c \
   ${ZSS}/c/rasService.c \
   ${ZSS}/c/userInfoService.c \
   ${ZSS}/c/passTicketService.c \

--- a/c/checksumService.c
+++ b/c/checksumService.c
@@ -1,0 +1,300 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "utils.h"
+#include "json.h"
+#include "bpxnet.h"
+#include "socketmgmt.h"
+#include "unixfile.h"
+#include "httpserver.h"
+#include "logging.h"
+#include "zssLogging.h"
+#include "icsf.h"
+#include "checksumService.h"
+
+#ifdef __ZOWE_OS_ZOS
+
+#define CHECKSUM_READ_BUFFER_SIZE 65536
+
+typedef struct AlgorithmEntry_tag {
+  char *name;
+  int icsfType;
+  int hashLength;
+} AlgorithmEntry;
+
+static AlgorithmEntry algorithmTable[] = {
+  {"md5",      ICSF_DIGEST_MD5,      16},
+  {"sha1",     ICSF_DIGEST_SHA1,     20},
+  {"sha224",   ICSF_DIGEST_SHA224,   28},
+  {"sha256",   ICSF_DIGEST_SHA256,   32},
+  {"sha384",   ICSF_DIGEST_SHA384,   48},
+  {"sha512",   ICSF_DIGEST_SHA512,   64},
+  {"sha3-224", ICSF_DIGEST_SHA3_224, 28},
+  {"sha3-256", ICSF_DIGEST_SHA3_256, 32},
+  {"sha3-384", ICSF_DIGEST_SHA3_384, 48},
+  {"sha3-512", ICSF_DIGEST_SHA3_512, 64}
+};
+
+#define ALGORITHM_COUNT (sizeof(algorithmTable) / sizeof(algorithmTable[0]))
+
+static AlgorithmEntry *findAlgorithm(const char *name) {
+  for (int i = 0; i < ALGORITHM_COUNT; i++) {
+    if (!strcasecmp(name, algorithmTable[i].name)) {
+      return &algorithmTable[i];
+    }
+  }
+  return NULL;
+}
+
+static int probeAlgorithm(int icsfType) {
+  ICSFDigest digest;
+  char hash[64];
+  char *probeString = "ZOWE ALGORITHM CHECK";
+  int probeLen = strlen(probeString);
+  int rc;
+
+  rc = icsfDigestInit(&digest, icsfType);
+  if (rc != 0) {
+    return rc;
+  }
+  rc = icsfDigestUpdate(&digest, probeString, probeLen);
+  if (rc != 0) {
+    return rc;
+  }
+  rc = icsfDigestFinish(&digest, hash);
+  return rc;
+}
+
+static void bytesToHex(const char *bytes, int len, char *hexOut) {
+  static const char hexChars[] = "0123456789abcdef";
+  for (int i = 0; i < len; i++) {
+    unsigned char b = (unsigned char)bytes[i];
+    hexOut[i * 2]     = hexChars[(b >> 4) & 0x0F];
+    hexOut[i * 2 + 1] = hexChars[b & 0x0F];
+  }
+  hexOut[len * 2] = '\0';
+}
+
+static void respondWithError(HttpResponse *response, int statusCode,
+                             const char *statusMessage, const char *errorMsg) {
+  jsonPrinter *out = respondWithJsonPrinter(response);
+  setResponseStatus(response, statusCode, (char *)statusMessage);
+  setDefaultJSONRESTHeaders(response);
+  writeHeader(response);
+  jsonStart(out);
+  jsonAddString(out, "error", (char *)errorMsg);
+  jsonEnd(out);
+  finishResponse(response);
+}
+
+static int serveChecksumInfo(HttpService *service, HttpResponse *response) {
+  HttpRequest *request = response->request;
+
+  if (strcmp(request->method, methodGET)) {
+    respondWithError(response, 405, "Method Not Allowed", "Only GET is supported");
+    return 0;
+  }
+
+  jsonPrinter *out = respondWithJsonPrinter(response);
+  setResponseStatus(response, 200, "OK");
+  setDefaultJSONRESTHeaders(response);
+  writeHeader(response);
+  jsonStart(out);
+  jsonStartArray(out, "algorithms");
+
+  for (int i = 0; i < ALGORITHM_COUNT; i++) {
+    int rc = probeAlgorithm(algorithmTable[i].icsfType);
+    jsonStartObject(out, NULL);
+    jsonAddString(out, "name", algorithmTable[i].name);
+    jsonAddInt(out, "hashBytes", algorithmTable[i].hashLength);
+    if (rc == 0) {
+      jsonAddString(out, "status", "available");
+    } else {
+      jsonAddString(out, "status", "unavailable");
+      jsonAddInt(out, "icsfReturnCode", rc);
+    }
+    jsonEndObject(out);
+  }
+
+  jsonEndArray(out);
+  jsonEnd(out);
+  finishResponse(response);
+  return 0;
+}
+
+static int serveChecksumFile(HttpService *service, HttpResponse *response) {
+  HttpRequest *request = response->request;
+
+  if (strcmp(request->method, methodGET)) {
+    respondWithError(response, 405, "Method Not Allowed", "Only GET is supported");
+    return 0;
+  }
+
+  /* URL: /checksum/file/<algorithm>/<path...>
+   * parsedFile segments: 0=checksum 1=file 2=algorithm 3+=path
+   */
+  StringList *parsedFile = request->parsedFile;
+
+  /* Extract algorithm name from segment 2 */
+  char *algorithmFrag = stringListPrint(parsedFile, 2, 3, "/", 0);
+  if (algorithmFrag == NULL || strlen(algorithmFrag) == 0) {
+    respondWithError(response, 400, "Bad Request", "Missing algorithm in URL path");
+    return 0;
+  }
+
+  AlgorithmEntry *alg = findAlgorithm(algorithmFrag);
+  if (alg == NULL) {
+    respondWithError(response, 400, "Bad Request", "Unsupported algorithm");
+    return 0;
+  }
+
+  /* Extract file path from segments 3+ */
+  char *routeFileFrag = stringListPrint(parsedFile, 3, 1000, "/", 0);
+  if (routeFileFrag == NULL || strlen(routeFileFrag) == 0) {
+    respondWithError(response, 400, "Bad Request", "Missing file path in URL");
+    return 0;
+  }
+
+  char *encodedPath = stringConcatenate(response->slh, "/", routeFileFrag);
+  char *filePath = cleanURLParamValue(response->slh, encodedPath);
+
+  zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_DEBUG,
+          "checksum request: algorithm=%s path=%s\n", alg->name, filePath);
+
+  /* Stat the file to verify it exists and is a regular file */
+  FileInfo info;
+  int returnCode = 0;
+  int reasonCode = 0;
+  int status = fileInfo(filePath, &info, &returnCode, &reasonCode);
+  if (status != 0) {
+    respondWithError(response, 404, "Not Found", "File not found or not accessible");
+    return 0;
+  }
+
+  if (info.fileType != BPXSTA_FILETYPE_REGULAR) {
+    respondWithError(response, 400, "Bad Request", "Path is not a regular file");
+    return 0;
+  }
+
+  /* Open the file for reading */
+  UnixFile *file = fileOpen(filePath, FILE_OPTION_READ_ONLY, 0, 0,
+                            &returnCode, &reasonCode);
+  if (file == NULL) {
+    zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_WARNING,
+            "checksum: failed to open %s, rc=%d rsn=0x%08x\n",
+            filePath, returnCode, reasonCode);
+    respondWithError(response, 500, "Internal Server Error", "Failed to open file");
+    return 0;
+  }
+
+  /* Initialize the digest */
+  ICSFDigest digest;
+  int rc = icsfDigestInit(&digest, alg->icsfType);
+  if (rc != 0) {
+    fileClose(file, &returnCode, &reasonCode);
+    zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_WARNING,
+            "checksum: icsfDigestInit failed, rc=%d\n", rc);
+    respondWithError(response, 500, "Internal Server Error",
+                     "Hash algorithm initialization failed");
+    return 0;
+  }
+
+  /* Stream the file through the digest */
+  char *readBuffer = safeMalloc(CHECKSUM_READ_BUFFER_SIZE, "checksumReadBuf");
+  int hashFailed = 0;
+
+  while (1) {
+    int bytesRead = fileRead(file, readBuffer, CHECKSUM_READ_BUFFER_SIZE,
+                             &returnCode, &reasonCode);
+    if (bytesRead <= 0) {
+      break;
+    }
+    rc = icsfDigestUpdate(&digest, readBuffer, bytesRead);
+    if (rc != 0) {
+      zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_WARNING,
+              "checksum: icsfDigestUpdate failed, rc=%d\n", rc);
+      hashFailed = 1;
+      break;
+    }
+  }
+
+  fileClose(file, &returnCode, &reasonCode);
+
+  if (!hashFailed) {
+    char hashResult[64];
+    rc = icsfDigestFinish(&digest, hashResult);
+    if (rc != 0) {
+      zowelog(NULL, LOG_COMP_ID_UNIXFILE, ZOWE_LOG_WARNING,
+              "checksum: icsfDigestFinish failed, rc=%d\n", rc);
+      hashFailed = 1;
+    }
+
+    if (!hashFailed) {
+      /* Convert hash to hex string */
+      char hexString[129];
+      bytesToHex(hashResult, alg->hashLength, hexString);
+
+      jsonPrinter *out = respondWithJsonPrinter(response);
+      setResponseStatus(response, 200, "OK");
+      setDefaultJSONRESTHeaders(response);
+      writeHeader(response);
+      jsonStart(out);
+      jsonAddString(out, "algorithm", alg->name);
+      jsonAddString(out, "checksum", hexString);
+      jsonAddString(out, "path", filePath);
+      jsonEnd(out);
+      finishResponse(response);
+
+      safeFree(readBuffer, CHECKSUM_READ_BUFFER_SIZE);
+      return 0;
+    }
+  }
+
+  safeFree(readBuffer, CHECKSUM_READ_BUFFER_SIZE);
+  respondWithError(response, 500, "Internal Server Error", "Hash computation failed");
+  return 0;
+}
+
+void installChecksumService(HttpServer *server) {
+  HttpService *httpService;
+
+  httpService = makeGeneratedService("ChecksumInfo", "/checksum/info");
+  httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  httpService->serviceFunction = serveChecksumInfo;
+  httpService->runInSubtask = TRUE;
+  httpService->doImpersonation = TRUE;
+  registerHttpService(server, httpService);
+
+  httpService = makeGeneratedService("ChecksumFile", "/checksum/file/**");
+  httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  httpService->serviceFunction = serveChecksumFile;
+  httpService->runInSubtask = TRUE;
+  httpService->doImpersonation = TRUE;
+  registerHttpService(server, httpService);
+}
+
+#endif /* __ZOWE_OS_ZOS */
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/

--- a/c/zss.c
+++ b/c/zss.c
@@ -74,6 +74,7 @@
 #include "omvsService.h"
 #include "datasetService.h"
 #include "serverStatusService.h"
+#include "checksumService.h"
 #include "rasService.h"
 #include "certificateService.h"
 #include "registerProduct.h"
@@ -1897,6 +1898,7 @@ int main(int argc, char **argv){
       installSecurityManagementServices(server);
       installOMVSService(server);
       installServerStatusService(server, productVersion);
+      installChecksumService(server);
       installZosPasswordService(server);
       installRASService(server);
       installUserInfoService(server);

--- a/h/checksumService.h
+++ b/h/checksumService.h
@@ -1,0 +1,29 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifndef __CHECKSUM_SERVICE_H__
+#define __CHECKSUM_SERVICE_H__
+
+#ifdef __ZOWE_OS_ZOS
+void installChecksumService(HttpServer *server);
+#endif
+
+#endif /* __CHECKSUM_SERVICE_H__ */
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/


### PR DESCRIPTION
## Proposed changes

Add a new ZSS checksum REST API that computes cryptographic hashes of z/OS UNIX files using ICSF (Integrated Cryptographic Service Facility).

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/594

### New endpoints

**GET `/checksum/info`** — Lists all 10 supported hash algorithms and probes each one under the caller's identity via ICSF. Returns `"available"` or `"unavailable"` status for each algorithm. This accounts for per-user SAF authority (READ access to `CSNBOWH`/`CSNEOWH` in `CSFSERV` class) and system-wide algorithm availability in the ICSF options data set.

**GET `/checksum/file/{algorithm}/{path}`** — Streams the file at `{path}` through the specified ICSF hash algorithm and returns the checksum as a lowercase hex string. The file is read as raw bytes (no encoding conversion). Runs under the caller's identity (impersonation), so normal z/OS UNIX file permissions apply.

Supported algorithms: `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`, `sha3-224`, `sha3-256`, `sha3-384`, `sha3-512`.

### Files changed

| File | Change |
|------|--------|
| `h/checksumService.h` | New header — `installChecksumService()` declaration |
| `c/checksumService.c` | New service — algorithm table, probing, file streaming, hex encoding, JSON responses |
| `c/zss.c` | Wire-in — added `#include` and `installChecksumService(server)` call |
| `build/build_zss.sh` | Added `checksumService.c` to 31-bit link list |
| `build/build_zss64.sh` | Added `checksumService.c` to 64-bit link list |

### Example responses

`GET /checksum/info`:
```json
{
  "algorithms": [
    {"name": "sha256", "hashBytes": 32, "status": "available"},
    {"name": "sha3-256", "hashBytes": 32, "status": "unavailable", "icsfReturnCode": 8}
  ]
}
```

`GET /checksum/file/sha256/u/user1/data.txt`:
```json
{
  "algorithm": "sha256",
  "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
  "path": "/u/user1/data.txt"
}
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

### Prerequisites
- A z/OS system with ICSF active
- The test user must have READ access to `CSNBOWH` (31-bit) or `CSNEOWH` (64-bit) in the `CSFSERV` SAF class

### Test 1: Algorithm availability
```
GET /checksum/info
```
- Verify 200 response with a JSON `algorithms` array containing 10 entries
- Each entry has `name`, `hashBytes`, and `status` fields
- Algorithms the user has access to show `"available"`; others show `"unavailable"` with `icsfReturnCode`

### Test 2: SHA-256 checksum of a known file
```bash
# Create a test file
echo -n "hello" > /tmp/checksum_test.txt
# Expected SHA-256: 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
```
```
GET /checksum/file/sha256/tmp/checksum_test.txt
```
- Verify the returned `checksum` matches the expected value
- Verify `algorithm` is `"sha256"` and `path` is `"/tmp/checksum_test.txt"`

### Test 3: Error cases
- `GET /checksum/file/sha256/nonexistent/file` — expect 404
- `GET /checksum/file/bogus/tmp/test.txt` — expect 400 "Unsupported algorithm"
- `GET /checksum/file/sha256/tmp/` (directory) — expect 400 "Path is not a regular file"
- `POST /checksum/info` — expect 405 "Only GET is supported"

### Test 4: Large file
- Create a file larger than 64 KB (the internal read buffer size) to verify streaming works correctly
- Compare the result against `sha256sum` or equivalent on the same file

## Further comments

Both endpoints use `runInSubtask=TRUE` and `doImpersonation=TRUE`, so checksums are computed under the caller's z/OS identity. This means:
- File access is governed by the caller's UNIX permissions, not the ZSS server's
- ICSF algorithm availability is checked against the caller's SAF profile, not the server's

The `/checksum/dataset/**` URL namespace is reserved for future dataset checksum support but is not registered in this PR.

**Swagger documentation for this API is needed in an accompanying zlux-server-framework PR**
