### PR TITLE
Make alloc test binary

### DIFF
--- a/.github/workflows/build_alloc_test.yml
+++ b/.github/workflows/build_alloc_test.yml
@@ -1,0 +1,75 @@
+name: Build alloc-test
+on:
+  push:
+    branches:
+      - v3.x/staging 
+      - v3.x/master
+      - v3.x/rc 
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      PERFORM_RELEASE:
+        description: '[Release] perform release'
+        required: false
+        default: 'false'  
+
+jobs:
+  check-permission:
+    runs-on: ubuntu-latest
+    steps:
+      # this action will fail the whole workflow if permission check fails
+      - name: check permission
+        uses: zowe-actions/shared-actions/permission-check@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-test:
+    runs-on: ubuntu-latest
+    needs: check-permission
+    steps: 
+      - name: '[Prep 1] Checkout'
+        uses: actions/checkout@v2
+        with: 
+            submodules: true
+
+      - name: '[Prep 2] Setup jFrog CLI'
+        uses: jfrog/setup-jfrog-cli@v2
+        env:
+          JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
+
+      - name: '[Prep 3] Set date'
+        id: date
+        run: echo "date=$(date +'%Y%m%d%S')" >> $GITHUB_OUTPUT
+
+      - name: '[Prep 4] Set version'
+        id: version
+        run: echo "version=$(cat build/alloc-test.proj.env | grep VERSION | cut -f 2 -d=)" >> $GITHUB_OUTPUT
+
+      - name: '[Prep 5] Set branchname'
+        id: branch
+        run: echo "branch=$(if [ -n '${{ github.head_ref }}' ]; then echo '${{ github.head_ref }}' | tr '[:lower:]' '[:upper:]'; else echo '${{ github.ref_name }}' | tr '[:lower:]' '[:upper:]'; fi | sed 's@/@-@g')" >> $GITHUB_OUTPUT
+
+
+      - name: '[Prep 6] Prepare workflow'
+        uses: zowe-actions/shared-actions/prepare-workflow@main
+      
+
+      - name: '[Packaging] Make pax'
+        uses: zowe-actions/shared-actions/make-pax@main
+        with:
+          pax-name: 'alloc-test'
+          pax-options: '-x os390 -pp'
+          pax-local-workspace: './.pax/alloc-test'
+          pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
+          pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
+
+      - name: '[Publish] Publish'
+        uses: zowe-actions/shared-actions/publish@main
+        if: success()
+        with:
+          artifacts: |
+            .pax/alloc-test/alloc-test.pax
+          publish-target-path-pattern: libs-snapshot-local/org/zowe/alloc-test/${{ steps.version.outputs.version }}-${{ steps.branch.outputs.branch }}
+          publish-target-file-pattern: alloc-test-${{ steps.version.outputs.version }}-${{ steps.date.outputs.date }}.pax
+          perform-release: ${{ github.event.inputs.PERFORM_RELEASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/tmp*/
 build/build.log
 bin/zssServer
 bin/zssServer64
+bin/alloc-test
 bin/bind-test
 bin/zis-test
 build/*.u
@@ -25,6 +26,7 @@ build/*.s
 !.pax/pre-packaging.sh
 !.pax/post-packaging.sh
 !.pax/prepare-workspace.sh
+!.pax/alloc-test
 !.pax/bind-test
 !.pax/zis-test
 

--- a/.pax/alloc-test/pre-packaging.sh
+++ b/.pax/alloc-test/pre-packaging.sh
@@ -1,0 +1,34 @@
+#!/bin/sh -e
+set -xe
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+################################################################################
+
+
+# contants
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR=$(pwd)
+
+# build
+echo "$SCRIPT_NAME build alloc-test ..."
+STEPLIB=CBC.SCCNCMP "$SCRIPT_DIR/content/build/build_alloc_test.sh"
+if [ $? != 0 ]; then
+  exit $?
+fi
+
+# clean up content folder
+echo "$SCRIPT_NAME cleaning up pax folder ..."
+cd "$SCRIPT_DIR"
+mv content bak && mkdir -p content
+
+# move real files to the content folder
+echo "$SCRIPT_NAME coping files should be in pax ..."
+cd "$SCRIPT_DIR/content"
+cp ../bak/bin/alloc-test .

--- a/.pax/alloc-test/prepare-workspace.sh
+++ b/.pax/alloc-test/prepare-workspace.sh
@@ -15,7 +15,7 @@ set -xe
 # Prepare folders/files will be uploaded to Build/PAX server
 ################################################################################
 
-# contants
+# constants
 SCRIPT_NAME=$(basename "$0")
 SCRIPT_DIR=$(dirname "$0")
 PAX_WORKSPACE_DIR=.pax/alloc-test

--- a/.pax/alloc-test/prepare-workspace.sh
+++ b/.pax/alloc-test/prepare-workspace.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+set -xe
+
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+################################################################################
+
+################################################################################
+# Prepare folders/files will be uploaded to Build/PAX server
+################################################################################
+
+# contants
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR=$(dirname "$0")
+PAX_WORKSPACE_DIR=.pax/alloc-test
+
+# make sure in project root folder
+cd $SCRIPT_DIR/../..
+
+# prepare pax workspace
+echo "[${SCRIPT_NAME}] preparing folders ..."
+rm -fr "${PAX_WORKSPACE_DIR}/ascii" && mkdir -p "${PAX_WORKSPACE_DIR}/ascii"
+rm -fr "${PAX_WORKSPACE_DIR}/content" && mkdir -p "${PAX_WORKSPACE_DIR}/content"
+
+echo "[${SCRIPT_NAME}] copying files ..."
+cp -R * "${PAX_WORKSPACE_DIR}/ascii"
+# move files shouldn't change encoding to IBM-1047 to content folder
+rsync -rv \
+  --include '*/' \
+  --include '*.png' \
+  --exclude '*' \
+  --prune-empty-dirs --remove-source-files \
+  "${PAX_WORKSPACE_DIR}/ascii/" \
+  "${PAX_WORKSPACE_DIR}/content/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ZSS package will be documented in this file.
 
+## `3.6.0`
+- Enhancement: Utility "alloc-test" is now available for checking if an amount of memory can be allocated. [(#831)](https://github.com/zowe/zss/pull/831)
+
 ## `3.4.0`
 - Bugfix: Fixed hostname to IP address lookup for "bind-test" program. [(#801)](https://github.com/zowe/zss/pull/801)
 

--- a/build/alloc-test.proj.env
+++ b/build/alloc-test.proj.env
@@ -1,0 +1,3 @@
+PROJECT="allocTest"
+VERSION=3.0.0
+DEPS=""

--- a/build/build_alloc_test.sh
+++ b/build/build_alloc_test.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+################################################################################
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0 which accompanies
+#  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+################################################################################
+
+WORKING_DIR=$(cd $(dirname "$0") && pwd)
+ZSS="../.."
+COMMON="../../deps/zowe-common-c"
+
+echo "********************************************************************************"
+echo "Building alloc test ..."
+
+mkdir -p "${WORKING_DIR}/tmp-alloc-test" && cd "$_"
+
+xlclang \
+  -q64 \
+  -v \
+  -D_XOPEN_SOURCE=600 \
+  -DNEW_CAA_LOCATIONS=1 \
+  "-Wc,langlvl(extc11),gonum,goff,hgpr,roconst,ASM,asmlib('SYS1.MACLIB')" \
+  -I ${COMMON}/h \
+  -o ${ZSS}/bin/alloc-test \
+  ${COMMON}/c/alloc.c \
+  ${ZSS}/c/allocTest.c ;
+
+rc=$?
+if [ $rc -eq 0 ]; then
+  echo "Build alloc-test successfully"
+  exit 0
+else
+  # remove alloc-test in case the linker had RC=4 and produced the binary
+  rm -f ${ZSS}/bin/alloc-test
+  echo "Build alloc-test failed"
+  exit 8
+fi

--- a/c/allocTest.c
+++ b/c/allocTest.c
@@ -1,0 +1,327 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+/*
+ * allocTest - probes available memory in two z/OS address-space regions:
+ *
+ *   Above the 2 GB bar  (64-bit virtual, gated by MEMLIMIT)     via malloc()
+ *   Below the 2 GB bar  (31-bit virtual, gated by ASSIZEMAX/ulimit -A)  via malloc31()
+ *
+ * Each region is probed with a decreasing power-of-2 loop from --max64 / --max31
+ * down to --min.  The loop stops on the first successful allocation and reports
+ * that size.  No pages are touched (no memset), so the probes complete in
+ * microseconds even for multi-gigabyte sizes.
+ *
+ * Usage:
+ *   alloc-test [--max64 <size>] [--max31 <size>] [--min <size>]
+ *
+ * Size format: plain bytes, or a suffix of K / M / G  (case-insensitive).
+ *
+ * Defaults:
+ *   --max64  4G
+ *   --max31  512M
+ *   --min    32M
+ *
+ * Constraints enforced at startup:
+ *   --min must be >= 1 and <= INT_MAX
+ *   --min must be < --max64
+ *   --min must be < --max31
+ *
+ * Exit codes:
+ *   0  both regions found at least one successful size >= --min
+ *   8  one or both regions could not allocate even --min bytes
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <stdint.h>
+
+#include "copyright.h"
+#include "zowetypes.h"
+#include "alloc.h"
+
+#define ALLOC_STATUS_OK    0
+#define ALLOC_STATUS_ERROR 8
+
+#define MAX_PROBE_BYTES (16ULL * 1024 * 1024 * 1024)  /* 16G absolute ceiling */
+
+/* ------------------------------------------------------------------ */
+/* Size parsing                                                         */
+/* ------------------------------------------------------------------ */
+
+/*
+ * parseSize - convert a human-readable size string to uint64_t bytes.
+ * Accepts: plain decimal integer, or decimal + K / M / G suffix.
+ * Returns 0 and sets *ok = FALSE on any parse error or overflow.
+ */
+static uint64_t parseSize(const char *str, int *ok) {
+  if (!str || *str == '\0') {
+    *ok = FALSE;
+    return 0;
+  }
+
+  char *end;
+  uint64_t value = (uint64_t)strtoull(str, &end, 10);
+
+  if (end == str) {
+    /* no digits consumed */
+    *ok = FALSE;
+    return 0;
+  }
+
+  /* optional suffix */
+  if (*end == 'k' || *end == 'K') {
+    if (value > (uint64_t)UINT64_MAX / 1024) {
+      *ok = FALSE;
+      return 0;
+    }
+    value *= 1024;
+    end++;
+  } else if (*end == 'm' || *end == 'M') {
+    if (value > (uint64_t)UINT64_MAX / (1024 * 1024)) {
+      *ok = FALSE;
+      return 0;
+    }
+    value *= 1024 * 1024;
+    end++;
+  } else if (*end == 'g' || *end == 'G') {
+    if (value > (uint64_t)UINT64_MAX / (1024 * 1024 * 1024)) {
+      *ok = FALSE;
+      return 0;
+    }
+    value *= 1024 * 1024 * 1024;
+    end++;
+  }
+
+  if (*end != '\0') {
+    /* trailing garbage */
+    *ok = FALSE;
+    return 0;
+  }
+
+  *ok = TRUE;
+  return value;
+}
+
+/* Format a uint64_t byte count as a human-readable string (e.g. "4G", "512M"). */
+static void formatSize(uint64_t bytes, char *buf, size_t bufLen) {
+  if (bytes >= 1024 * 1024 * 1024 && bytes % (1024 * 1024 * 1024) == 0) {
+    snprintf(buf, bufLen, "%lluG", (unsigned long long)(bytes / (1024 * 1024 * 1024)));
+  } else if (bytes >= 1024 * 1024 && bytes % (1024 * 1024) == 0) {
+    snprintf(buf, bufLen, "%lluM", (unsigned long long)(bytes / (1024 * 1024)));
+  } else if (bytes >= 1024 && bytes % 1024 == 0) {
+    snprintf(buf, bufLen, "%lluK", (unsigned long long)(bytes / 1024));
+  } else {
+    snprintf(buf, bufLen, "%llu", (unsigned long long)bytes);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Argument helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+static const char *getKeywordArg(const char *key, int argc, char **argv) {
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], key) == 0 && (i + 1) < argc) {
+      return argv[i + 1];
+    }
+  }
+  return NULL;
+}
+
+static int hasFlag(const char *flag, int argc, char **argv) {
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], flag) == 0) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/* ------------------------------------------------------------------ */
+/* Probe loops                                                          */
+/* ------------------------------------------------------------------ */
+
+/*
+ * probe64 - probe above-bar (64-bit) memory using stdlib malloc().
+ * On z/OS LE compiled -q64, malloc() allocates above the 2 GB bar and is
+ * gated by MEMLIMIT.  Returns the largest successful allocation in bytes,
+ * or 0 if even minBytes could not be allocated.
+ */
+static uint64_t probe64(uint64_t maxBytes, uint64_t minBytes) {
+  for (uint64_t size = maxBytes; size >= minBytes; size >>= 1) {
+    void *p = malloc((size_t)size);
+    if (p != NULL) {
+      free(p);
+      return size;
+    }
+  }
+  return 0;
+}
+
+/*
+ * probe31 - probe below-bar (31-bit) memory using malloc31() from alloc.c.
+ * malloc31() calls __malloc31() on z/OS LE, which allocates below the 2 GB
+ * bar and is gated by ASSIZEMAX / ulimit -A.
+ *
+ * malloc31() takes an int, so maxBytes is clamped to INT_MAX.
+ * No memset is performed; pages are not touched.
+ */
+static uint64_t probe31(uint64_t maxBytes, uint64_t minBytes) {
+  /* malloc31 signature is: char *malloc31(int size) */
+  uint64_t startBytes = maxBytes;
+  if (startBytes > (uint64_t)INT_MAX) {
+    startBytes = (uint64_t)INT_MAX;
+  }
+
+  for (uint64_t size = startBytes; size >= minBytes; size >>= 1) {
+    char *p = malloc31((int)size);
+    if (p != NULL) {
+      free31(p, (int)size);
+      return size;
+    }
+  }
+  return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                 */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv) {
+
+  if (argc == 1 || hasFlag("-h", argc, argv) || hasFlag("--help", argc, argv)) {
+    printf("alloc-test - Probes available memory in two z/OS address-space regions.\n");
+    printf("  Regions probed:\n");
+    printf("    64-bit (above 2GB bar) via malloc()    -- gated by MEMLIMIT\n");
+    printf("    31-bit (below 2GB bar) via malloc31()  -- gated by ASSIZEMAX / ulimit -A\n");
+    printf("  Format: alloc-test [--max64 <size>] [--max31 <size>] [--min <size>]\n");
+    printf("  Size format: plain bytes, or suffix K/M/G (e.g. 4G, 512M, 65536K)\n");
+    printf("  Defaults: --max64 4G  --max31 512M  --min 32M\n");
+    printf("  Exit values: 0 if both regions allocated at least --min bytes, 8 otherwise\n");
+    return ALLOC_STATUS_OK;
+  }
+
+  /* ---- parse arguments ---- */
+  int ok;
+  const char *max64Str = getKeywordArg("--max64", argc, argv);
+  const char *max31Str = getKeywordArg("--max31", argc, argv);
+  const char *minStr   = getKeywordArg("--min",   argc, argv);
+
+  uint64_t max64    = 4ULL * 1024 * 1024 * 1024;  /* 4G  — ULL required: 4G overflows int32 */
+  uint64_t max31    = 512 * 1024 * 1024;           /* 512M */
+  uint64_t minBytes = 32 * 1024 * 1024;            /* 32M  */
+
+  if (max64Str != NULL) {
+    ok = FALSE;
+    max64 = parseSize(max64Str, &ok);
+    if (!ok || max64 == 0) {
+      fprintf(stderr, "Error: invalid --max64 value '%s'\n", max64Str);
+      return ALLOC_STATUS_ERROR;
+    }
+    if (max64 > MAX_PROBE_BYTES) {
+      fprintf(stderr, "Error: --max64 value '%s' exceeds the 16G absolute maximum\n", max64Str);
+      return ALLOC_STATUS_ERROR;
+    }
+  }
+
+  if (max31Str != NULL) {
+    ok = FALSE;
+    max31 = parseSize(max31Str, &ok);
+    if (!ok || max31 == 0) {
+      fprintf(stderr, "Error: invalid --max31 value '%s'\n", max31Str);
+      return ALLOC_STATUS_ERROR;
+    }
+    if (max31 > MAX_PROBE_BYTES) {
+      fprintf(stderr, "Error: --max31 value '%s' exceeds the 16G absolute maximum\n", max31Str);
+      return ALLOC_STATUS_ERROR;
+    }
+    /* malloc31() takes int; cap at INT_MAX */
+    if (max31 > (uint64_t)INT_MAX) {
+      fprintf(stderr, "Error: --max31 value '%s' exceeds INT_MAX (%d); "
+              "31-bit allocations are limited to 2GB\n", max31Str, INT_MAX);
+      return ALLOC_STATUS_ERROR;
+    }
+  }
+
+  if (minStr != NULL) {
+    ok = FALSE;
+    minBytes = parseSize(minStr, &ok);
+    if (!ok || minBytes == 0) {
+      fprintf(stderr, "Error: invalid --min value '%s'\n", minStr);
+      return ALLOC_STATUS_ERROR;
+    }
+  }
+
+  /* ---- validate --min constraints ---- */
+  if (minBytes > (uint64_t)INT_MAX) {
+    fprintf(stderr, "Error: --min value exceeds INT_MAX (%d); "
+            "must be a valid 31-bit allocation size\n", INT_MAX);
+    return ALLOC_STATUS_ERROR;
+  }
+  if (minBytes >= max64) {
+    char minBuf[32], maxBuf[32];
+    formatSize(minBytes, minBuf, sizeof(minBuf));
+    formatSize(max64, maxBuf, sizeof(maxBuf));
+    fprintf(stderr, "Error: --min (%s) must be less than --max64 (%s)\n",
+            minBuf, maxBuf);
+    return ALLOC_STATUS_ERROR;
+  }
+  if (minBytes >= max31) {
+    char minBuf[32], maxBuf[32];
+    formatSize(minBytes, minBuf, sizeof(minBuf));
+    formatSize(max31, maxBuf, sizeof(maxBuf));
+    fprintf(stderr, "Error: --min (%s) must be less than --max31 (%s)\n",
+            minBuf, maxBuf);
+    return ALLOC_STATUS_ERROR;
+  }
+
+  /* ---- run probes ---- */
+  char sizeBuf[32];
+  int status = ALLOC_STATUS_OK;
+
+  /* 64-bit probe */
+  uint64_t result64 = probe64(max64, minBytes);
+  if (result64 > 0) {
+    formatSize(result64, sizeBuf, sizeof(sizeBuf));
+    printf("64-bit allocation succeeded at %s\n", sizeBuf);
+  } else {
+    formatSize(minBytes, sizeBuf, sizeof(sizeBuf));
+    printf("64-bit allocation failed: could not allocate %s above the 2GB bar "
+           "(check MEMLIMIT in RACF/TSS/ACF2 OMVS segment)\n", sizeBuf);
+    status = ALLOC_STATUS_ERROR;
+  }
+
+  /* 31-bit probe */
+  uint64_t result31 = probe31(max31, minBytes);
+  if (result31 > 0) {
+    formatSize(result31, sizeBuf, sizeof(sizeBuf));
+    printf("31-bit allocation succeeded at %s\n", sizeBuf);
+  } else {
+    formatSize(minBytes, sizeBuf, sizeof(sizeBuf));
+    printf("31-bit allocation failed: could not allocate %s below the 2GB bar "
+           "(check ASSIZEMAX in RACF/TSS/ACF2 OMVS segment or ulimit -A)\n", sizeBuf);
+    status = ALLOC_STATUS_ERROR;
+  }
+
+  return status;
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/


### PR DESCRIPTION
## Proposed changes

Add the `alloc-test` binary: an empirical memory probe for z/OS that tests both the 64-bit (above-the-bar) and 31-bit (below-the-bar) address-space regions. This binary is used by the new `zwe validate memory` command (in `zowe-install-packaging`) to confirm that allocations of the expected sizes actually succeed at runtime, independent of ESM configuration values.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes

### New files

**`c/allocTest.c`**
- Probes available memory in two z/OS address-space regions:
  - 64-bit (above 2 GB bar) via `malloc()` — gated by `MEMLIMIT`
  - 31-bit (below 2 GB bar) via `malloc31()` from `zowe-common-c/c/alloc.c` — gated by `ASSIZEMAX` / `ulimit -A`
- Accepts `--max64`, `--max31`, and `--min` size arguments (e.g. `2G`, `256M`, `32M`)
- Enforces a 16 G absolute ceiling (`MAX_PROBE_BYTES`) on both max arguments
- Uses a decreasing power-of-2 loop; no `memset` is performed, so probes are near-instant even for multi-gigabyte sizes
- Outputs one line per region: `64-bit allocation succeeded at 2G` / `31-bit allocation succeeded at 256M` (or a failure message with a diagnostic hint)
- Exit code 0 if both regions succeed; 8 if either fails
- Links `zowe-common-c/c/alloc.c` and `zowe-common-c/h/alloc.h`

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

```sh
# Both regions should succeed and print sizes
bin/alloc-test --max64 2G --max31 256M --min 32M

# Expected output (sizes may vary by MEMLIMIT / ASSIZEMAX configuration):
# 64-bit allocation succeeded at 2G
# 31-bit allocation succeeded at 256M

# Test argument validation
bin/alloc-test --max64 32G   # should fail: exceeds 16G ceiling
bin/alloc-test --max64 1G --min 2G  # should fail: --min >= --max64
```


## Further comments

- `malloc31()` (from `zowe-common-c/c/alloc.c`) calls `__malloc31()` directly without `memset`, making it safe for probing large sizes without touching pages. `safeMalloc31()` was deliberately avoided because it calls `memset(res, 0, size)` after allocation, which would cause a 256 M probe to take more time.
- Similarly, `malloc()` (not `safeMalloc64()`) is used for the 64-bit probe for the same reason.
- The 16 G absolute ceiling (`MAX_PROBE_BYTES`) prevents runaway probes regardless of what arguments are passed.
