### PR TITLE
Fix base64 padding length calculation

### DIFF
--- a/c/safIdtService.c
+++ b/c/safIdtService.c
@@ -155,11 +155,11 @@ void extractUsernameFromJwt(HttpResponse *response, char *jwt, char *username) {
 
   // count on '=' padding characters that are omitted in JWT
   if (payLoadLength % 4 == 3) {
-    allocateLength = payLoadLength + 1;
+    allocateLength = payLoadLength + 2;  // count on '=' and '\0'
     base64Padding[0] = '=';
   }
   else if (payLoadLength % 4 == 2) {
-    allocateLength = payLoadLength + 2;
+    allocateLength = payLoadLength + 3;    // count on '==' and '\0'
     base64Padding[0] = '=';
     base64Padding[1] = '=';
   }

--- a/c/safIdtService.c
+++ b/c/safIdtService.c
@@ -155,11 +155,11 @@ void extractUsernameFromJwt(HttpResponse *response, char *jwt, char *username) {
 
   // count on '=' padding characters that are omitted in JWT
   if (payLoadLength % 4 == 3) {
-    allocateLength = payLoadLength + 2;  // count on '=' and '\0'
+    allocateLength += 1;  // count on '='
     base64Padding[0] = '=';
   }
   else if (payLoadLength % 4 == 2) {
-    allocateLength = payLoadLength + 3;    // count on '==' and '\0'
+    allocateLength += 2;    // count on '=='
     base64Padding[0] = '=';
     base64Padding[1] = '=';
   }


### PR DESCRIPTION
Initially there is a room for null terminator:
`allocateLength = payLoadLength + 1; // count on '\0' terminating character`

Later (for specific modulo 4 length) we are adding only space for extra equal sign(s), but not for null terminator.

```c
  allocateLength = payLoadLength + 1; // count on '\0' terminating character
  if (payLoadLength % 4 == 3) {
    allocateLength += 1;
    // space for '=' (null terminator already added)
  }
  else if (payLoadLength % 4 == 2) {
    allocateLength += 2;
    // space for '==' (null terminator already added)
  }
```