### PR TITLE
zss: check the path length

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -862,8 +862,8 @@ static WebPluginListElt* readWebPluginDefinitions(HttpServer *server, ShortLived
           zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "found JSON file %s\n", name);
           memset(path, 0, sizeof(path));
           Json *json = NULL;
-          int characterWritten = snprintf(path, sizeof(path), "%s%s%s", dirname, needsSlash ? "/" : "", name);
-          if (characterWritten > 0 && characterWritten < sizeof(path)) {
+          int charactersWritten = snprintf(path, sizeof(path), "%s%s%s", dirname, needsSlash ? "/" : "", name);
+          if (charactersWritten > 0 && charactersWritten < sizeof(path)) {
             json = jsonParseFile(slh, path, errorBuffer, sizeof (errorBuffer));
           }
           if (json) {

--- a/c/zss.c
+++ b/c/zss.c
@@ -666,8 +666,11 @@ static JsonObject *readPluginDefinition(ShortLivedHeap *slh,
   char errorBuffer[512];
   
   zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG2, "%s begin identifier %s location %s\n", __FUNCTION__, pluginIdentifier, resolvedPluginLocation);
-  sprintf(path, "%s/%s", resolvedPluginLocation, "pluginDefinition.json");
-  Json *pluginDefinitionJson = jsonParseFile(slh, path, errorBuffer, sizeof (errorBuffer));
+  Json *pluginDefinitionJson = NULL;
+  int charactersWritten = snprintf(path, sizeof(path), "%s/%s", resolvedPluginLocation, "pluginDefinition.json");
+  if (charactersWritten > 0 && charactersWritten < sizeof(path)) {
+    pluginDefinitionJson = jsonParseFile(slh, path, errorBuffer, sizeof (errorBuffer));
+  }
   if (pluginDefinitionJson) {
     dumpJson(pluginDefinitionJson);
     JsonObject *pluginDefinitionJsonObject = jsonAsObject(pluginDefinitionJson);
@@ -858,8 +861,11 @@ static WebPluginListElt* readWebPluginDefinitions(HttpServer *server, ShortLived
         if (isJsonFile) {
           zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_DEBUG, "found JSON file %s\n", name);
           memset(path, 0, sizeof(path));
-          sprintf(path, "%s%s%s", dirname, needsSlash ? "/" : "", name);
-          Json *json = jsonParseFile(slh, path, errorBuffer, sizeof (errorBuffer));
+          Json *json = NULL;
+          int characterWritten = snprintf(path, sizeof(path), "%s%s%s", dirname, needsSlash ? "/" : "", name);
+          if (characterWritten > 0 && characterWritten < sizeof(path)) {
+            json = jsonParseFile(slh, path, errorBuffer, sizeof (errorBuffer));
+          }
           if (json) {
             dumpJson(json);
             JsonObject *jsonObject = jsonAsObject(json);


### PR DESCRIPTION
2 issues
1. `sprintf` can silently overwrite the buffer
2. `snprintf` is buffer-overflow safe, but we have to check, if the path was not trimmed:

If `/very/...long/path/pluginDefinition.json` would be printed as `/very/...long/path/pluginDefinition.jso` (missing `n` at the end), we will not read such file.