### PR TITLE
Enforce SAF authorization check for /server/agent sensitive endpoints

### DIFF
--- a/c/serverStatusService.c
+++ b/c/serverStatusService.c
@@ -42,6 +42,11 @@
 #include "configmgr.h"
 #include "serverStatusService.h"
 #include "zss.h"
+#include "zis/client.h"
+#include "zos.h"
+
+#define SAF_CLASS "ZOWE"
+#define SERVER_AGENT_PROFILE "ZLUX.0.COR.GET.SERVER.AGENT"
 
 #ifdef __ZOWE_OS_ZOS
 
@@ -240,7 +245,8 @@ static int respondWithServices(HttpResponse *response, HttpServer *server) {
 static bool statusEndPointRequireAuthAndRBAC(const char *endpoint) {
   return !strcmp(endpoint, "config") ||
          !strcmp(endpoint, "log") ||
-         !strcmp(endpoint, "logLevels");
+         !strcmp(endpoint, "logLevels") ||
+         !strcmp(endpoint, "environment");
 }
 
 static int serveStatus(HttpService *service, HttpResponse *response) {
@@ -256,7 +262,15 @@ static int serveStatus(HttpService *service, HttpResponse *response) {
   JsonObject *dataserviceAuth = (cfgGetStatus == ZCFG_SUCCESS ? jsonAsObject(dataserviceAuthJson) : NULL);
   int rbacParm = dataserviceAuth ? jsonObjectGetBoolean(dataserviceAuth, "rbac") : 0;
   int isAuthenticated = response->request->authenticated;
-  bool allowFullAccess = isAuthenticated && rbacParm;
+  bool allowFullAccess = false;
+  if (isAuthenticated && rbacParm) {
+    CrossMemoryServerName *privilegedServerName = getConfiguredProperty(server,
+        HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY);
+    ZISAuthServiceStatus reqStatus = {0};
+    int rc = zisCheckEntity(privilegedServerName, request->username, SAF_CLASS,
+        SERVER_AGENT_PROFILE, SAF_AUTH_ATTR_READ, &reqStatus);
+    allowFullAccess = (rc == RC_ZIS_SRVC_OK);
+  }
   if (!strcmp(request->method, methodGET)) {
     char *l1 = stringListPrint(request->parsedFile, 2, 1, "/", 0);
     if (!allowFullAccess && statusEndPointRequireAuthAndRBAC(l1)) {


### PR DESCRIPTION
When RBAC is enabled, /server/agent/environment exposes all environment variables to any authenticated user without an actual SAF check. The code only verified that RBAC was turned on, not that the user was authorized.

Now zisCheckEntity() performs a real RACF check against ZLUX.0.COR.GET.SERVER.AGENT before granting access to sensitive data. Also added "environment" to the endpoint gate alongside config, log, and logLevels.