### PR TITLE
More granular security checks for built-in ZIS services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the ZSS package will be documented in this file.
 
 ## `3.6.0`
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
+- Enhancement: add more granular SAF checks for the built-in ZIS services [(#852)](https://github.com/zowe/zss/pull/852)
 
 ## `3.5.0`
 - Enhancement: Utility "detect-attls-port" can be used to check if an ATTLS policy exists at a specific connection. (https://github.com/zowe/zss/pull/813)  

--- a/c/zis/server.c
+++ b/c/zis/server.c
@@ -172,72 +172,81 @@ static int registerCoreServices(ZISContext *context) {
   int regRC = RC_CMS_OK;
 
   regRC = cmsRegisterService(server, ZIS_SERVICE_ID_AUTH_SRV,
-                             zisAuthServiceFunction, NULL,
+                             zisAuthServiceFunction,
+                             zisAuthServiceGetServiceData(context->parms),
                              CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_SNARFER_SRV,
-                             zisSnarferServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_SPACE_SWITCH |
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_SNARFER_SRV, zisSnarferServiceFunction,
+      zisSnarferServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_SPACE_SWITCH | CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_NWM_SRV,
-                             zisNWMServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC =
+      cmsRegisterService(server, ZIS_SERVICE_ID_NWM_SRV, zisNWMServiceFunction,
+                         zisNWMServiceGetServiceData(context->parms),
+                         CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_USERPROF_SRV,
-                             zisUserProfilesServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_USERPROF_SRV, zisUserProfilesServiceFunction,
+      zisUserProfilesServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GRESPROF_SRV,
-                             zisGenresProfilesServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_GRESPROF_SRV, zisGenresProfilesServiceFunction,
+      zisGenresProfilesServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_ACSLIST_SRV,
-                             zisGenresAccessListServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_ACSLIST_SRV, zisGenresAccessListServiceFunction,
+      zisGenresAccessListServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GENRES_ADMIN_SRV,
-                             zisGenresProfileAdminServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_GENRES_ADMIN_SRV,
+      zisGenresProfileAdminServiceFunction,
+      zisGenresProfileAdminServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GRPPROF_SRV,
-                             zisGroupProfilesServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_GRPPROF_SRV, zisGroupProfilesServiceFunction,
+      zisGroupProfilesServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
-  regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GRPALIST_SRV,
-                             zisGroupAccessListServiceFunction, NULL,
-                             CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
+  regRC = cmsRegisterService(
+      server, ZIS_SERVICE_ID_GRPALIST_SRV, zisGroupAccessListServiceFunction,
+      zisGroupAccessListServiceGetServiceData(context->parms),
+      CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;
   }
 
   regRC = cmsRegisterService(server, ZIS_SERVICE_ID_GROUP_ADMIN_SRV,
-                             zisGroupAdminServiceFunction, NULL,
+                             zisGroupAdminServiceFunction,
+                             zisGroupAdminServiceGetServiceData(context->parms),
                              CMS_SERVICE_FLAG_RELOCATE_TO_COMMON);
   if (regRC != RC_CMS_OK) {
     return RC_ZIS_ERROR;

--- a/c/zis/services/auth.c
+++ b/c/zis/services/auth.c
@@ -24,7 +24,9 @@
 #include "recovery.h"
 #include "zos.h"
 
+#include "zis/parm.h"
 #include "zis/utils.h"
+#include "zis/services/common.h"
 #include "zis/services/auth.h"
 
 #define ZIS_PARMLIB_PARM_AUTH_USER_CLASS    CMS_PROD_ID".AUTH.CLASS"
@@ -408,6 +410,12 @@ int zisAuthServiceFunction(CrossMemoryServerGlobalArea *globalArea,
 
   int logLevel = globalArea->pcLogLevel;
 
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_AUTH_SRV, ZIS_SERVICE_SAF_AL_AUTH_SRV)) {
+    return RC_ZIS_AUTHSRV_NO_ACCESS;
+  }
+
   if (logLevel >= ZOWE_LOG_DEBUG) {
     cmsPrintf(&globalArea->serverName, CMS_LOG_DEBUG_MSG_ID
               " in authServiceFunction, parm = 0x%p\n", parm);
@@ -449,6 +457,21 @@ int zisAuthServiceFunction(CrossMemoryServerGlobalArea *globalArea,
   cmCopyToPrimaryWithCallerKey(clientParmAddr, &localParmList,
                                sizeof(AuthServiceParmList));
   return handlerRC;
+}
+
+void *zisAuthServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  // as opposed to the rest of the built-in services, the SAF check is off by
+  // default in the auth service
+  parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_AUTH_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_AUTH_PARM_VALUE_SAF_ON)) {
+    parm.aStr.flags &= ~ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
 }
 
 

--- a/c/zis/services/nwm.c
+++ b/c/zis/services/nwm.c
@@ -23,7 +23,9 @@
 #include "crossmemory.h"
 #include "zos.h"
 
+#include "zis/parm.h"
 #include "zis/utils.h"
+#include "zis/services/common.h"
 #include "zis/services/nwm.h"
 
 static int callNWMService(char jobName[],
@@ -67,6 +69,12 @@ int zisNWMServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                           void *parm) {
 
   int traceLevel = globalArea->pcLogLevel;
+
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_NWM_SRV, ZIS_SERVICE_SAF_AL_NWM_SRV)) {
+    return RC_ZIS_NWMSRV_NO_ACCESS;
+  }
 
   void *clientParmAddr = parm;
   if (clientParmAddr == NULL) {
@@ -158,6 +166,18 @@ int zisNWMServiceFunction(CrossMemoryServerGlobalArea *globalArea,
              localParmList.nmiReasonCode);
 
   return status;
+}
+
+void *zisNWMServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_NWM_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_NWM_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
 }
 
 

--- a/c/zis/services/secmgmt.c
+++ b/c/zis/services/secmgmt.c
@@ -26,7 +26,9 @@
 #include "recovery.h"
 #include "zos.h"
 
+#include "zis/parm.h"
 #include "zis/utils.h"
+#include "zis/services/common.h"
 #include "zis/services/secmgmt.h"
 #include "zis/services/secmgmtUtils.h"
 
@@ -201,6 +203,12 @@ static int zisUserProfilesServiceFunctionRACF(CrossMemoryServerGlobalArea *globa
 
 int zisUserProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                    CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_USERPROF_SRV,
+                    ZIS_SERVICE_SAF_AL_USERPROF_SRV)) {
+    return RC_ZIS_UPRFSRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisUserProfilesServiceFunctionRACF(globalArea, service, parm);
@@ -403,6 +411,12 @@ int zisGenresProfilesServiceFunctionRACF(CrossMemoryServerGlobalArea *globalArea
 
 int zisGenresProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                    CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_GRESPROF_SRV,
+                    ZIS_SERVICE_SAF_AL_GRESPROF_SRV)) {
+    return RC_ZIS_GRPRFSRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisGenresProfilesServiceFunctionRACF(globalArea, service, parm);
@@ -599,6 +613,12 @@ int zisGenresAccessListServiceFunctionRACF(CrossMemoryServerGlobalArea *globalAr
 
 int zisGenresAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                        CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_ACSLIST_SRV,
+                    ZIS_SERVICE_SAF_AL_ACSLIST_SRV)) {
+    return RC_ZIS_ACSLSRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisGenresAccessListServiceFunctionRACF(globalArea, service, parm);
@@ -1098,6 +1118,12 @@ int zisGenresProfileAdminServiceFunctionRACF(CrossMemoryServerGlobalArea *global
 
 int zisGenresProfileAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                    CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_GENRES_ADMIN_SRV,
+                    ZIS_SERVICE_SAF_AL_GENRES_ADMIN_SRV)) {
+    return RC_ZIS_GSADMNSRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisGenresProfileAdminServiceFunctionRACF(globalArea, service, parm);
@@ -1278,6 +1304,12 @@ int zisGroupProfilesServiceFunctionRACF(CrossMemoryServerGlobalArea *globalArea,
 
 int zisGroupProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                    CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_GRPPROF_SRV,
+                    ZIS_SERVICE_SAF_AL_GRPPROF_SRV)) {
+    return RC_ZIS_GPPRFSRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisGroupProfilesServiceFunctionRACF(globalArea, service, parm);
@@ -1453,6 +1485,12 @@ int zisGroupAccessListServiceFunctionRACF(CrossMemoryServerGlobalArea *globalAre
 
 int zisGroupAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                       CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_GRPALIST_SRV,
+                    ZIS_SERVICE_SAF_AL_GRPALIST_SRV)) {
+    return RC_ZIS_GRPALSRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisGroupAccessListServiceFunctionRACF(globalArea, service, parm);
@@ -1902,12 +1940,102 @@ int zisGroupAdminServiceFunctionRACF(CrossMemoryServerGlobalArea *globalArea,
 
 int zisGroupAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                  CrossMemoryService *service, void *parm) {
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_GROUP_ADMIN_SRV,
+                    ZIS_SERVICE_SAF_AL_GROUP_ADMIN_SRV)) {
+    return RC_ZIS_GRPASRV_NO_ACCESS;
+  }
   ExternalSecurityManager esm = getExternalSecurityManager();
   switch (esm) {
     case ZOS_ESM_RACF: return zisGroupAdminServiceFunctionRACF(globalArea, service, parm);
     case ZOS_ESM_RTSS: return zisGroupAdminServiceFunctionTSS(globalArea, service, parm);
     default: return RC_ZIS_GRPASRV_UNSUPPORTED_ESM;
   }
+}
+
+void *zisUserProfilesServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_USERPROF_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_USERPROF_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
+
+void *zisGenresProfilesServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_GRESPROF_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_GRESPROF_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
+
+void *zisGenresAccessListServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_ACSLIST_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_ACSLIST_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
+
+void *zisGenresProfileAdminServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_GENRES_ADMIN_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_GENRES_ADMIN_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
+
+void *zisGroupProfilesServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_GRPPROF_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_GRPPROF_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
+
+void *zisGroupAccessListServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_GRPALIST_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_GRPALIST_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
+
+void *zisGroupAdminServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_GROUP_ADMIN_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_GROUP_ADMIN_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
 }
 
 /*

--- a/c/zis/services/snarfer.c
+++ b/c/zis/services/snarfer.c
@@ -24,7 +24,9 @@
 #include "recovery.h"
 #include "zos.h"
 
+#include "zis/parm.h"
 #include "zis/utils.h"
+#include "zis/services/common.h"
 #include "zis/services/snarfer.h"
 
 typedef struct SToken_tag {
@@ -261,6 +263,13 @@ int zisSnarferServiceFunction(CrossMemoryServerGlobalArea *globalArea,
 
   int logLevel = globalArea->pcLogLevel;
 
+  if (IS_ZIS_CORE_SERVICE_SAF_ON(service->serviceData) &&
+      !cmsTestAuth2(globalArea, ZIS_SERVICES_DEFAULT_SAF_CLASS,
+                    ZIS_SERVICE_SAF_PN_SNARFER_SRV,
+                    ZIS_SERVICE_SAF_AL_SNARFER_SRV)) {
+    return RC_ZIS_SNRFSRV_NO_ACCESS;
+  }
+
   void *clientParmAddr = parm;
   if (clientParmAddr == NULL) {
     return RC_ZIS_SNRFSRV_PARMLIST_NULL;
@@ -429,6 +438,17 @@ void snarferDSECTs() {
 
 }
 
+void *zisSnarferServiceGetServiceData(const struct ZISParmSet_tag *parms) {
+  union {
+    ZISCoreServiceParm aStr;
+    void *asPtr;
+  } parm = {0};
+  const char *value = zisGetParmValue(parms, ZIS_SERVICE_SNARFER_PARM_SAF);
+  if (value && !strcmp(value, ZIS_SERVICE_SNARFER_PARM_VALUE_SAF_OFF)) {
+    parm.aStr.flags |= ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK;
+  }
+  return parm.asPtr;
+}
 
 /*
   This program and the accompanying materials are

--- a/c/zis/stubinit.c
+++ b/c/zis/stubinit.c
@@ -236,6 +236,7 @@
     stubVector[ZIS_STUB_CMMKSNAM] = (void*)cmsMakeServerName;
     stubVector[ZIS_STUB_CMGETPRX] = (void*)cmsGetConfigParmExt;
     stubVector[ZIS_STUB_CMGETPUX] = (void*)cmsGetConfigParmExtUnchecked;
+    stubVector[ZIS_STUB_CMTSAUT2] = (void*)cmsTestAuth2;
     stubVector[ZIS_STUB_DYNASTXU] = (void*)createSimpleTextUnit;
     stubVector[ZIS_STUB_DYNASTX2] = (void*)createSimpleTextUnit2;
     stubVector[ZIS_STUB_DYNACTXU] = (void*)createCharTextUnit;

--- a/h/zis/services/auth.h
+++ b/h/zis/services/auth.h
@@ -15,6 +15,13 @@
 
 #define ZIS_SERVICE_ID_AUTH_SRV                   11
 
+#define ZIS_SERVICE_SAF_PN_AUTH_SRV CMS_PROD_ID".IS.SRV.AUTH"
+#define ZIS_SERVICE_SAF_AL_AUTH_SRV CMS_SAF_ACCESS_LEVEL_UPDATE
+
+#define ZIS_SERVICE_AUTH_PARM_SAF CMS_PROD_ID".SRV.AUTH.SAF"
+  #define ZIS_SERVICE_AUTH_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_AUTH_PARM_VALUE_SAF_OFF "OFF"
+
 ZOWE_PRAGMA_PACK
 typedef struct SAFAuthStatus_tag {
   int safRC;
@@ -92,7 +99,11 @@ ZOWE_PRAGMA_PACK_RESET
 int zisAuthServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                            CrossMemoryService *service, void *parm);
 
+#pragma map(zisAuthServiceGetServiceData, "ZISDAUTH")
+void *zisAuthServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_AUTHSRV_OK                         0
+#define RC_ZIS_AUTHSRV_NO_ACCESS                  4
 #define RC_ZIS_AUTHSRV_PARMLIST_NULL              8
 #define RC_ZIS_AUTHSRV_BAD_EYECATCHER             9
 #define RC_ZIS_AUTHSRV_DELETE_FAILED              10

--- a/h/zis/services/auth.h
+++ b/h/zis/services/auth.h
@@ -99,6 +99,8 @@ ZOWE_PRAGMA_PACK_RESET
 int zisAuthServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                            CrossMemoryService *service, void *parm);
 
+struct ZISParmSet_tag;
+
 #pragma map(zisAuthServiceGetServiceData, "ZISDAUTH")
 void *zisAuthServiceGetServiceData(const struct ZISParmSet_tag *parms);
 

--- a/h/zis/services/common.h
+++ b/h/zis/services/common.h
@@ -15,9 +15,17 @@
 
 #define ZIS_SERVICES_DEFAULT_SAF_CLASS "FACILITY"
 
+/**
+ * The purpose of this structure is to communicate additional flags to the core
+ * services.
+ *
+ * The struct is passed to the core services within the storage of the "parm"
+ * 8-byte pointer passed to service functions; this is why it must always fit in
+ * 8-bytes. The reason for this hack is to avoid allocating additional common storage.
+ */
 typedef struct ZISCoreServiceParm_tag {
-#define ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK 0x00000001
-  unsigned flags : 8;
+#define ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK 0x01
+  unsigned char flags;
   char reserved[7];
 } ZISCoreServiceParm;
 

--- a/h/zis/services/common.h
+++ b/h/zis/services/common.h
@@ -19,9 +19,10 @@
  * The purpose of this structure is to communicate additional flags to the core
  * services.
  *
- * The struct is passed to the core services within the storage of the "parm"
- * 8-byte pointer passed to service functions; this is why it must always fit in
- * 8-bytes. The reason for this hack is to avoid allocating additional common storage.
+ * The struct is passed to the core services within the storage of the
+ * "CrossMemoryService->serviceData" 8-byte pointer passed to service
+ * functions; this is why it must always fit in 8-bytes. The reason for this
+ * hack is to avoid allocating additional common storage.
  */
 typedef struct ZISCoreServiceParm_tag {
 #define ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK 0x01

--- a/h/zis/services/common.h
+++ b/h/zis/services/common.h
@@ -1,0 +1,39 @@
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifndef ZIS_SERVICES_COMMON_H_
+#define ZIS_SERVICES_COMMON_H_
+
+#define ZIS_SERVICES_DEFAULT_SAF_CLASS "FACILITY"
+
+typedef struct ZISCoreServiceParm_tag {
+#define ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK 0x00000001
+  unsigned flags : 8;
+  char reserved[7];
+} ZISCoreServiceParm;
+
+#define IS_ZIS_CORE_SERVICE_SAF_ON(data) ({ \
+     !(((ZISCoreServiceParm *)&data)->flags & ZIS_CORE_SERVICE_FLAG_NO_SAF_CHECK); \
+   })
+
+#endif /* ZIS_SERVICES_COMMON_H_ */
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/

--- a/h/zis/services/nwm.h
+++ b/h/zis/services/nwm.h
@@ -52,6 +52,8 @@ int zisNWMServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                           CrossMemoryService *service,
                           void *parm);
 
+struct ZISParmSet_tag;
+
 #pragma map(zisNWMServiceGetServiceData, "ZISDNWMS")
 void *zisNWMServiceGetServiceData(const struct ZISParmSet_tag *parms);
 

--- a/h/zis/services/nwm.h
+++ b/h/zis/services/nwm.h
@@ -17,6 +17,13 @@
 
 #define ZIS_SERVICE_ID_NWM_SRV                    13
 
+#define ZIS_SERVICE_SAF_PN_NWM_SRV CMS_PROD_ID".IS.SRV.NWM"
+#define ZIS_SERVICE_SAF_AL_NWM_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_NWM_PARM_SAF CMS_PROD_ID".SRV.NWM.SAF"
+  #define ZIS_SERVICE_NWM_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_NWM_PARM_VALUE_SAF_OFF "OFF"
+
 ZOWE_PRAGMA_PACK
 typedef struct ZISNWMServiceParmList_tag {
 
@@ -45,7 +52,11 @@ int zisNWMServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                           CrossMemoryService *service,
                           void *parm);
 
+#pragma map(zisNWMServiceGetServiceData, "ZISDNWMS")
+void *zisNWMServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_NWMSRV_OK                         0
+#define RC_ZIS_NWMSRV_NO_ACCESS                  4
 #define RC_ZIS_NWMSRV_PARMLIST_NULL              8
 #define RC_ZIS_NWMSRV_BAD_EYECATCHER             9
 #define RC_ZIS_NWMSRV_BUFFER_NULL                10

--- a/h/zis/services/secmgmt.h
+++ b/h/zis/services/secmgmt.h
@@ -98,6 +98,8 @@ typedef struct ZISUserProfileServiceParmList_tag {
 
 ZOWE_PRAGMA_PACK_RESET
 
+struct ZISParmSet_tag;
+
 #pragma map(zisUserProfilesServiceFunction, "ZISSXUPR")
 int zisUserProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                    CrossMemoryService *service, void *parm);

--- a/h/zis/services/secmgmt.h
+++ b/h/zis/services/secmgmt.h
@@ -60,6 +60,13 @@ typedef struct ZISUserID_tag {
 
 #define ZIS_SERVICE_ID_USERPROF_SRV               14
 
+#define ZIS_SERVICE_SAF_PN_USERPROF_SRV CMS_PROD_ID".IS.SRV.SM.USRPROF"
+#define ZIS_SERVICE_SAF_AL_USERPROF_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_USERPROF_PARM_SAF CMS_PROD_ID".SRV.SM.USRPROF.SAF"
+  #define ZIS_SERVICE_USERPROF_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_USERPROF_PARM_VALUE_SAF_OFF "OFF"
+
 ZOWE_PRAGMA_PACK
 
 typedef struct ZISUserProfileEntry_tag {
@@ -96,7 +103,11 @@ int zisUserProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                    CrossMemoryService *service, void *parm);
 int validateUserProfileParmList(ZISUserProfileServiceParmList *parm);
 
+#pragma map(zisUserProfilesServiceGetServiceData, "ZISDXUPR")
+void *zisUserProfilesServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_UPRFSRV_OK                         0
+#define RC_ZIS_UPRFSRV_NO_ACCESS                  4
 #define RC_ZIS_UPRFSRV_PARMLIST_NULL              8
 #define RC_ZIS_UPRFSRV_BAD_EYECATCHER             9
 #define RC_ZIS_UPRFSRV_USER_ID_TOO_LONG           10
@@ -111,6 +122,13 @@ int validateUserProfileParmList(ZISUserProfileServiceParmList *parm);
 /*** Genres profile service ***/
 
 #define ZIS_SERVICE_ID_GRESPROF_SRV               15
+
+#define ZIS_SERVICE_SAF_PN_GRESPROF_SRV CMS_PROD_ID".IS.SRV.SM.GENPROF"
+#define ZIS_SERVICE_SAF_AL_GRESPROF_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_GRESPROF_PARM_SAF CMS_PROD_ID".SRV.SM.GENPROF.SAF"
+  #define ZIS_SERVICE_GRESPROF_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_GRESPROF_PARM_VALUE_SAF_OFF "OFF"
 
 ZOWE_PRAGMA_PACK
 
@@ -148,7 +166,11 @@ int zisGenresProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                      CrossMemoryService *service, void *parm);
 int validateGenresProfileParmList(ZISGenresProfileServiceParmList *parm);
 
+#pragma map(zisGenresProfilesServiceGetServiceData, "ZISDXGRP")
+void *zisGenresProfilesServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_GRPRFSRV_OK                        0
+#define RC_ZIS_GRPRFSRV_NO_ACCESS                 4
 #define RC_ZIS_GRPRFSRV_PARMLIST_NULL             8
 #define RC_ZIS_GRPRFSRV_BAD_EYECATCHER            9
 #define RC_ZIS_GRPRFSRV_CLASS_TOO_LONG            10
@@ -165,6 +187,13 @@ int validateGenresProfileParmList(ZISGenresProfileServiceParmList *parm);
 /*** General resource access list service ***/
 
 #define ZIS_SERVICE_ID_ACSLIST_SRV                16
+
+#define ZIS_SERVICE_SAF_PN_ACSLIST_SRV CMS_PROD_ID".IS.SRV.SM.GENACL"
+#define ZIS_SERVICE_SAF_AL_ACSLIST_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_ACSLIST_PARM_SAF CMS_PROD_ID".SRV.SM.GENACL.SAF"
+  #define ZIS_SERVICE_ACSLIST_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_ACSLIST_PARM_VALUE_SAF_OFF "OFF"
 
 ZOWE_PRAGMA_PACK
 
@@ -203,7 +232,11 @@ int zisGenresAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                        CrossMemoryService *service, void *parm);
 int validateGenresAccessListParmList(ZISGenresAccessListServiceParmList *parm);
 
+#pragma map(zisGenresAccessListServiceGetServiceData, "ZISDXGAL")
+void *zisGenresAccessListServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_ACSLSRV_OK                         0
+#define RC_ZIS_ACSLSRV_NO_ACCESS                  4
 #define RC_ZIS_ACSLSRV_PARMLIST_NULL              8
 #define RC_ZIS_ACSLSRV_BAD_EYECATCHER             9
 #define RC_ZIS_ACSLSRV_CLASS_TOO_LONG             10
@@ -220,6 +253,13 @@ int validateGenresAccessListParmList(ZISGenresAccessListServiceParmList *parm);
 /*** General resource profile administration service ***/
 
 #define ZIS_SERVICE_ID_GENRES_ADMIN_SRV           17
+
+#define ZIS_SERVICE_SAF_PN_GENRES_ADMIN_SRV CMS_PROD_ID".IS.SRV.SM.GENADM"
+#define ZIS_SERVICE_SAF_AL_GENRES_ADMIN_SRV CMS_SAF_ACCESS_LEVEL_UPDATE
+
+#define ZIS_SERVICE_GENRES_ADMIN_PARM_SAF CMS_PROD_ID".SRV.SM.GENADM.SAF"
+  #define ZIS_SERVICE_GENRES_ADMIN_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_GENRES_ADMIN_PARM_VALUE_SAF_OFF "OFF"
 
 #pragma enum(2)
 
@@ -288,7 +328,11 @@ int zisGenresProfileAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea
                                          CrossMemoryService *service, void *parm);
 int validateGenresParmList(ZISGenresAdminServiceParmList *parmList);
 
+#pragma map(zisGenresProfileAdminServiceGetServiceData, "ZISDXPAA")
+void *zisGenresProfileAdminServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_GSADMNSRV_OK                       0
+#define RC_ZIS_GSADMNSRV_NO_ACCESS                4
 #define RC_ZIS_GSADMNSRV_PARMLIST_NULL            8
 #define RC_ZIS_GSADMNSRV_BAD_EYECATCHER           9
 #define RC_ZIS_GSADMNSRV_PROF_TOO_LONG            10
@@ -310,6 +354,13 @@ int validateGenresParmList(ZISGenresAdminServiceParmList *parmList);
 /*** Group profile service ***/
 
 #define ZIS_SERVICE_ID_GRPPROF_SRV                18
+
+#define ZIS_SERVICE_SAF_PN_GRPPROF_SRV CMS_PROD_ID".IS.SRV.SM.GRPPROF"
+#define ZIS_SERVICE_SAF_AL_GRPPROF_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_GRPPROF_PARM_SAF CMS_PROD_ID".SRV.SM.GRPPROF.SAF"
+  #define ZIS_SERVICE_GRPPROF_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_GRPPROF_PARM_VALUE_SAF_OFF "OFF"
 
 ZOWE_PRAGMA_PACK
 
@@ -347,7 +398,11 @@ int zisGroupProfilesServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                     CrossMemoryService *service, void *parm);
 int validateGroupProfileParmList(ZISGroupProfileServiceParmList *parm);
 
+#pragma map(zisGroupProfilesServiceGetServiceData, "ZISDXGPP")
+void *zisGroupProfilesServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_GPPRFSRV_OK                        0
+#define RC_ZIS_GPPRFSRV_NO_ACCESS                 4
 #define RC_ZIS_GPPRFSRV_PARMLIST_NULL             8
 #define RC_ZIS_GPPRFSRV_BAD_EYECATCHER            9
 #define RC_ZIS_GPPRFSRV_GROUP_TOO_LONG            10
@@ -362,6 +417,13 @@ int validateGroupProfileParmList(ZISGroupProfileServiceParmList *parm);
 /*** Group access list service ***/
 
 #define ZIS_SERVICE_ID_GRPALIST_SRV               19
+
+#define ZIS_SERVICE_SAF_PN_GRPALIST_SRV CMS_PROD_ID".IS.SRV.SM.GRPACL"
+#define ZIS_SERVICE_SAF_AL_GRPALIST_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_GRPALIST_PARM_SAF CMS_PROD_ID".SRV.SM.GRPACL.SAF"
+  #define ZIS_SERVICE_GRPALIST_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_GRPALIST_PARM_VALUE_SAF_OFF "OFF"
 
 ZOWE_PRAGMA_PACK
 
@@ -400,7 +462,11 @@ int zisGroupAccessListServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                       CrossMemoryService *service, void *parm);
 int validateGroupAccessListParmList(ZISGroupAccessListServiceParmList *parm);
 
+#pragma map(zisGroupAccessListServiceGetServiceData, "ZISDXGPA")
+void *zisGroupAccessListServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_GRPALSRV_OK                        0
+#define RC_ZIS_GRPALSRV_NO_ACCESS                 4
 #define RC_ZIS_GRPALSRV_PARMLIST_NULL             8
 #define RC_ZIS_GRPALSRV_BAD_EYECATCHER            9
 #define RC_ZIS_GRPALSRV_GROUP_TOO_LONG            10
@@ -415,6 +481,13 @@ int validateGroupAccessListParmList(ZISGroupAccessListServiceParmList *parm);
 /*** Group administration service ***/
 
 #define ZIS_SERVICE_ID_GROUP_ADMIN_SRV            20
+
+#define ZIS_SERVICE_SAF_PN_GROUP_ADMIN_SRV CMS_PROD_ID".IS.SRV.SM.GRPADM"
+#define ZIS_SERVICE_SAF_AL_GROUP_ADMIN_SRV CMS_SAF_ACCESS_LEVEL_UPDATE
+
+#define ZIS_SERVICE_GROUP_ADMIN_PARM_SAF CMS_PROD_ID".SRV.SM.GRPADM.SAF"
+  #define ZIS_SERVICE_GROUP_ADMIN_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_GROUP_ADMIN_PARM_VALUE_SAF_OFF "OFF"
 
 #pragma enum(2)
 
@@ -485,7 +558,11 @@ int zisGroupAdminServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                                  CrossMemoryService *service, void *parm);
 int validateGroupParmList(ZISGroupAdminServiceParmList *parmList);
 
+#pragma map(zisGroupAdminServiceGetServiceData, "ZISDXPGA")
+void *zisGroupAdminServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_GRPASRV_OK                         0
+#define RC_ZIS_GRPASRV_NO_ACCESS                  4
 #define RC_ZIS_GRPASRV_PARMLIST_NULL              8
 #define RC_ZIS_GRPASRV_BAD_EYECATCHER             9
 #define RC_ZIS_GRPASRV_GROUP_TOO_LONG             10

--- a/h/zis/services/snarfer.h
+++ b/h/zis/services/snarfer.h
@@ -15,6 +15,13 @@
 
 #define ZIS_SERVICE_ID_SNARFER_SRV                12
 
+#define ZIS_SERVICE_SAF_PN_SNARFER_SRV CMS_PROD_ID".IS.SRV.SNARFER"
+#define ZIS_SERVICE_SAF_AL_SNARFER_SRV CMS_SAF_ACCESS_LEVEL_READ
+
+#define ZIS_SERVICE_SNARFER_PARM_SAF CMS_PROD_ID".SRV.SNARFER.SAF"
+  #define ZIS_SERVICE_SNARFER_PARM_VALUE_SAF_ON "ON"
+  #define ZIS_SERVICE_SNARFER_PARM_VALUE_SAF_OFF "OFF"
+
 ZOWE_PRAGMA_PACK
 typedef struct SnarferServiceParmList_tag {
   char eyecatcher[8];
@@ -31,7 +38,11 @@ ZOWE_PRAGMA_PACK_RESET
 int zisSnarferServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                               CrossMemoryService *service, void *parm);
 
+#pragma map(zisSnarferServiceGetServiceData, "ZISDSNRF")
+void *zisSnarferServiceGetServiceData(const struct ZISParmSet_tag *parms);
+
 #define RC_ZIS_SNRFSRV_OK                         0
+#define RC_ZIS_SNRFSRV_NO_ACCESS                  4
 #define RC_ZIS_SNRFSRV_PARMLIST_NULL              8
 #define RC_ZIS_SNRFSRV_BAD_EYECATCHER             9
 #define RC_ZIS_SNRFSRV_BAD_DEST                   10

--- a/h/zis/services/snarfer.h
+++ b/h/zis/services/snarfer.h
@@ -38,6 +38,8 @@ ZOWE_PRAGMA_PACK_RESET
 int zisSnarferServiceFunction(CrossMemoryServerGlobalArea *globalArea,
                               CrossMemoryService *service, void *parm);
 
+struct ZISParmSet_tag;
+
 #pragma map(zisSnarferServiceGetServiceData, "ZISDSNRF")
 void *zisSnarferServiceGetServiceData(const struct ZISParmSet_tag *parms);
 

--- a/h/zis/zisstubs.h
+++ b/h/zis/zisstubs.h
@@ -20,7 +20,7 @@
    FULL BACKWARD COMPATIBILITY MUST BE MAINTAINED
    */
 
-#define ZIS_STUBS_VERSION 7
+#define ZIS_STUBS_VERSION 8
 
 /*
   How does a user check for compatibility?
@@ -317,6 +317,7 @@
 /* #define ZIS_STUB_CMECSAF2 384 cmsFreeECSAStorage2 - not in CMS_CLIENT */
 #define ZIS_STUB_CMGETPRX 385 /* cmsGetConfigParmExt */
 #define ZIS_STUB_CMGETPUX 386 /* cmsGetConfigParmExtUnchecked */
+#define ZIS_STUB_CMTSAUT2 387 /* cmsTestAuth2 */
 
 /* dynalloc, 400-429 */
 #define ZIS_STUB_DYNASTXU 400 /* createSimpleTextUnit mapped */

--- a/tests/build_zis_saf_test.sh
+++ b/tests/build_zis_saf_test.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+################################################################################
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0 which accompanies
+#  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+################################################################################
+
+WORKING_DIR=$(dirname "$0")
+ZSS="../.."
+COMMON="../../deps/zowe-common-c"
+
+echo "********************************************************************************"
+echo "Building ZIS core services SAF test..."
+
+mkdir -p "${WORKING_DIR}/tmp-zissaft"
+cd ${WORKING_DIR}/tmp-zissaft
+
+xlc -DCMS_CLIENT -D_OPEN_THREADS=1 \
+  "-Wc,langlvl(extc99),asm,asmlib('SYS1.MACLIB'),asmlib('CEE.SCEEMAC')" \
+  -I ${COMMON}/h -I ${ZSS}/h \
+ ../zis-saf-test.c \
+ ${COMMON}/c/crossmemory.c \
+ ${COMMON}/c/zos.c \
+ ${COMMON}/c/zvt.c \
+ ${COMMON}/c/timeutls.c \
+ ${COMMON}/c/alloc.c \
+ ${COMMON}/c/utils.c \
+ ${COMMON}/c/le.c \
+ ${COMMON}/c/recovery.c \
+ ${COMMON}/c/scheduling.c \
+ ${COMMON}/c/collections.c \
+ ${COMMON}/c/logging.c \
+ -o zis-saf-test
+
+echo "Build successful"

--- a/tests/zis-saf-test.c
+++ b/tests/zis-saf-test.c
@@ -1,0 +1,223 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which
+  accompanies this distribution, and is available at
+  https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+/*
+ * Program to test the ZIS core services' SAF protection.
+ *
+ * Invokes a specified core service with a deliberately bad eyecatcher.
+ * Expected behavior:
+ *   - SAF enabled + caller has access    -> BAD_EYECATCHER
+ *   - SAF enabled + caller has no access -> NO_ACCESS
+ *   - SAF disabled                       -> BAD_EYECATCHER
+ *
+ * PARM format: server_name service saf_on has_access
+ *   server_name : cross-memory server name (e.g. ZWESIS_STD)
+ *   service     : AUTH|SNARFER|NWM|USERPROF|GRESPROF|ACSLIST|
+ *                 GENRES_ADMIN|GRPPROF|GRPALIST|GROUP_ADMIN
+ *   saf_on      : Y or N (is SAF enabled in the PARMLIB?)
+ *   has_access  : Y or N (does the caller have access to the SAF profile?)
+ *
+ * Return codes:
+ *   0  - test passed (actual RC matches expected)
+ *   1  - usage info requested
+ *   4  - test failed (RC mismatch)
+ *   8+ - setup/usage error
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "crossmemory.h"
+#include "zis/services/auth.h"
+#include "zis/services/snarfer.h"
+#include "zis/services/nwm.h"
+#include "zis/services/secmgmt.h"
+
+#define SIZE_OF_FIELD($struct, $field) sizeof((($struct *)0)->$field)
+
+#define RC_TEST_PASS 0
+#define RC_USAGE 1
+#define RC_TEST_FAIL 4
+#define RC_BAD_PARM 8
+#define RC_CALL_FAILED 16
+
+typedef struct ServiceAttrs_tag {
+  int serviceID;
+  int rcNoAccess;
+  int rcBadEyecatcher;
+} ServiceAttrs;
+
+static int getServiceAttrsByName(const char *name, ServiceAttrs *attrs) {
+  if (!strcmp(name, "AUTH")) {
+    attrs->serviceID = ZIS_SERVICE_ID_AUTH_SRV;
+    attrs->rcNoAccess = RC_ZIS_AUTHSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_AUTHSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "SNARFER")) {
+    attrs->serviceID = ZIS_SERVICE_ID_SNARFER_SRV;
+    attrs->rcNoAccess = RC_ZIS_SNRFSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_SNRFSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "NWM")) {
+    attrs->serviceID = ZIS_SERVICE_ID_NWM_SRV;
+    attrs->rcNoAccess = RC_ZIS_NWMSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_NWMSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "USERPROF")) {
+    attrs->serviceID = ZIS_SERVICE_ID_USERPROF_SRV;
+    attrs->rcNoAccess = RC_ZIS_UPRFSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_UPRFSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "GRESPROF")) {
+    attrs->serviceID = ZIS_SERVICE_ID_GRESPROF_SRV;
+    attrs->rcNoAccess = RC_ZIS_GRPRFSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_GRPRFSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "ACSLIST")) {
+    attrs->serviceID = ZIS_SERVICE_ID_ACSLIST_SRV;
+    attrs->rcNoAccess = RC_ZIS_ACSLSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_ACSLSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "GENRES_ADMIN")) {
+    attrs->serviceID = ZIS_SERVICE_ID_GENRES_ADMIN_SRV;
+    attrs->rcNoAccess = RC_ZIS_GSADMNSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_GSADMNSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "GRPPROF")) {
+    attrs->serviceID = ZIS_SERVICE_ID_GRPPROF_SRV;
+    attrs->rcNoAccess = RC_ZIS_GPPRFSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_GPPRFSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "GRPALIST")) {
+    attrs->serviceID = ZIS_SERVICE_ID_GRPALIST_SRV;
+    attrs->rcNoAccess = RC_ZIS_GRPALSRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_GRPALSRV_BAD_EYECATCHER;
+    return 0;
+  }
+  if (!strcmp(name, "GROUP_ADMIN")) {
+    attrs->serviceID = ZIS_SERVICE_ID_GROUP_ADMIN_SRV;
+    attrs->rcNoAccess = RC_ZIS_GRPASRV_NO_ACCESS;
+    attrs->rcBadEyecatcher = RC_ZIS_GRPASRV_BAD_EYECATCHER;
+    return 0;
+  }
+  return -1;
+}
+
+static int parseFlag(const char *str) {
+  if (!strcmp(str, "Y")) {
+    return 1;
+  }
+  if (!strcmp(str, "N")) {
+    return 0;
+  }
+  return -1;
+}
+
+static void printUsage(void) {
+  printf(
+      "usage: zis-saf-test <server_name> <service_name> <saf_on> "
+      "<has_access>\n");
+}
+
+int main(int argc, char *argv[]) {
+
+  if (argc == 2 && !strcmp(argv[1], "-h")) {
+    printUsage();
+    return RC_USAGE;
+  }
+
+  if (argc < 5) {
+    printf("error: not enough arguments\n");
+    printUsage();
+    return RC_BAD_PARM;
+  }
+
+  // server name
+  int nameLen = strlen(argv[1]);
+  if (nameLen > SIZE_OF_FIELD(CrossMemoryServerName, nameSpacePadded)) {
+    printf("error: server name too long\n");
+    return RC_BAD_PARM;
+  }
+  CrossMemoryServerName serverName = cmsMakeServerName(argv[1]);
+
+  // service name
+  ServiceAttrs service;
+  if (getServiceAttrsByName(argv[2], &service) != 0) {
+    printf("error: unknown service '%s'\n", argv[2]);
+    return RC_BAD_PARM;
+  }
+
+  // flags for the SAF check on/off and for whether the caller is supposed to
+  // have access
+  int safOn = parseFlag(argv[3]);
+  if (safOn < 0) {
+    printf("error: saf_on must be Y or N\n");
+    return RC_BAD_PARM;
+  }
+  int hasAccess = parseFlag(argv[4]);
+  if (hasAccess < 0) {
+    printf("error: has_access must be Y or N\n");
+    return RC_BAD_PARM;
+  }
+
+  int expectedRC;
+  if (safOn && !hasAccess) {
+    expectedRC = service.rcNoAccess;
+  } else {
+    expectedRC = service.rcBadEyecatcher;
+  }
+
+  // prepare a fake parmlist (all zeros is a bad eyecatcher for any service)
+  // this size should be enough; in the worst case the call will ABEND leading
+  // to an unexpected RC and a test failure
+  char fakePlist[8192] = {0};
+
+  // call the service
+  int serviceRC = 0;
+  int cmsRC =
+      cmsCallService(&serverName, service.serviceID, fakePlist, &serviceRC);
+  if (cmsRC != RC_CMS_OK) {
+    printf("error: xmem call failed, cmsRC=%d, serviceRC=%d\n", cmsRC,
+           serviceRC);
+    if (cmsRC == RC_CMS_PERMISSION_DENIED) {
+      printf("error: CMS permission denied (no ZWES.IS access)\n");
+    }
+    return RC_CALL_FAILED;
+  }
+
+  // check the result
+  if (serviceRC == expectedRC) {
+    printf("info: PASS - serviceRC=%d (expected %d)\n", serviceRC, expectedRC);
+    return RC_TEST_PASS;
+  } else {
+    printf("warn: FAIL - serviceRC=%d (expected %d)\n", serviceRC, expectedRC);
+    return RC_TEST_FAIL;
+  }
+}
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which
+  accompanies this distribution, and is available at
+  https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The purpose of the new checks is more granular security since some users may not want to give access to all the built-in services by default; this is similar to the mechanism that already exists in ZIS plug-ins.

The implementation is not generic as it just adds explicit checks to each service. This was done on purpose as it is very unlikely we'd be adding more core services to ZIS as the plug-in system is more flexible (similar how you'd choose PCs over SVCs for your application). A generic implementation has been attempted, but it adds unnecessary code to the
common path and has to change the xmem global area which all may affect users who don't care about the built-in services.

All the services except AUTH have the new SAF checks enabled by default. The user can specify a special per-service PARMLIB parameter to disable the corresponding SAF check in case granting additional SAF access is not possible.

Below is the table listing the SAF profiles in the FACILITY class and options for each service:
| Service               | SAF profile                   | Required access | PARMLIB option              | Default value |
|-----------------------|-------------------------------|-----------------|-----------------------------|---------------|
| Auth                  | ZWES.IS.SRV.AUTH              | UPDATE          | ZWES.SRV.AUTH.SAF           | OFF          |
| NWM                   | ZWES.IS.SRV.NWM               | READ            | ZWES.SRV.NWM.SAF            | ON            |
| Snarfer               | ZWES.IS.SRV.SNARFER           | READ            | ZWES.SRV.SNARFER.SAF        | ON            |
| User profiles         | ZWES.IS.SRV.SM.USRPROF        | READ            | ZWES.SRV.SM.USRPROF.SAF     | ON            |
| Genres profiles       | ZWES.IS.SRV.SM.GENPROF        | READ            | ZWES.SRV.SM.GENPROF.SAF     | ON            |
| Genres access list    | ZWES.IS.SRV.SM.GENACL         | READ            | ZWES.SRV.SM.GENACL.SAF      | ON            |
| Genres profile admin  | ZWES.IS.SRV.SM.GENADM         | UPDATE          | ZWES.SRV.SM.GENADM.SAF      | ON            |
| Group profiles        | ZWES.IS.SRV.SM.GRPPROF        | READ            | ZWES.SRV.SM.GRPPROF.SAF     | ON            |
| Group access list     | ZWES.IS.SRV.SM.GRPACL         | READ            | ZWES.SRV.SM.GRPACL.SAF      | ON            |
| Group admin           | ZWES.IS.SRV.SM.GRPADM         | UPDATE          | ZWES.SRV.SM.GRPADM.SAF      | ON            |

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

Use the new test program (`tests/zis-saf-tests.c`) to verify that the additional SAF checks and PARMLIB config parameters work as intended.
