### PR TITLE
Print the `3.x` for specific error

### DIFF
--- a/c/zss.c
+++ b/c/zss.c
@@ -1702,7 +1702,7 @@ int main(int argc, char **argv){
   char *configs = getKeywordArg("--configs",argc,argv);
   char *configmgrTraceLevelString = getKeywordArg("--configTrace",argc,argv);
   if (schemas == NULL || configs == NULL){
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS 2.x requires schemas and config\n");
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS 3.x requires schemas and config\n");
     zssStatus = ZSS_STATUS_ERROR;
     goto out_term_stcbase;
   }


### PR DESCRIPTION
In V3, when `zss` is started without schema or config, it prints the message `ZWES1013I` with the version.
Following message is misleading.

```
ZWES1013I ZSS Server has started. Version '3.5.0+20260501' 64-bit
ZSS 2.x requires schemas and config
```

Alternative (future version independent) solution would be `ZSS 2.x or later requires schemas and config`