### PR TITLE
[DO NOT MERGE] Handle JSON conversion failures IO vs unmappable EBCIDIC bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
 - Enhancement: add more granular SAF checks for the built-in ZIS services [(#852)](https://github.com/zowe/zss/pull/852)
 - Enhancement: The `/unixfile/contents` PUT endpoint now accepts `sourceEncoding` and `targetEncoding` as either charset name strings (e.g. `"IBM-1047"`, `"UTF-8"`) or decimal CCSID integer strings (e.g. `"1047"`, `"819"`). Previously only integer strings were accepted. Resolution is handled by `parseEncodingValue()` in zowe-common-c. [(#593)](https://github.com/zowe/zss/issues/593)
+- Bugfix: A single unmappable character in a dataset record no longer truncates the whole response; bad records are blanked and streaming continues, with a hard cap that stops a dataset failing every record from looping on the CPU. [(#675)](https://github.com/zowe/zowe-common-c/pull/675)
 
 ## `3.5.0`
 - Enhancement: Utility "detect-attls-port" can be used to check if an ATTLS policy exists at a specific connection. (https://github.com/zowe/zss/pull/813)  
@@ -170,4 +171,3 @@ All notable changes to the ZSS package will be documented in this file.
 
 ### New features and enhancements
 - Added scripts to allow ZSS to be its own component in the zowe install packaging
-

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -82,6 +82,12 @@
 #define ERROR_MESSAGE_BUFFER_SIZE 1024
 #define ERROR_MESSAGE_PRINT_SIZE ERROR_MESSAGE_BUFFER_SIZE - 128
 
+/* Upper bound on consecutive per-record charset-conversion failures before we
+   abort streaming a dataset. This is a flag-independent hard cap that guarantees
+   the record loop cannot spin the CPU even if every record fails to convert
+   (e.g. an SVC dump full of unmappable bytes). */
+#define MAX_CONSEC_CONVERSION_FAILURES 100
+
 
 static char defaultDatasetTypesAllowed[3] = {'A','D','X'};
 static char clusterTypesAllowed[3] = {'C','D','I'}; /* TODO: support 'I' type DSNs */
@@ -291,17 +297,31 @@ int streamDataset(char *filename, int recordLength, jsonPrinter *jPrinter){
   jsonStartArray(jPrinter,"records");
   int contentLength = 0;
   int bytesRead = 0;
+  /* Hard safety net: bound the loop independent of any cooperative flag so a
+     dataset/dump that fails conversion on every record cannot spin the CPU. */
+  int consecutiveFailures = 0;
   if (in) {
     rcEtag = icsfDigestInit(&digest, ICSF_DIGEST_SHA1);
     if (rcEtag) { //if etag generation has an error, just don't send it.
       zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_WARNING,  "ICSF error for SHA etag init, %d\n",rcEtag);
     }
-    while (!feof(in) && !jsonCheckIOErrorFlag(jPrinter)){
+    while (!feof(in) && !jsonCheckIOErrorFlag(jPrinter)
+                     && consecutiveFailures < MAX_CONSEC_CONVERSION_FAILURES){
       bytesRead = fread(buffer,1,recordLength,in);
       if (bytesRead > 0 && !ferror(in)) {
         if (!rcEtag) { rcEtag = icsfDigestUpdate(&digest, buffer, bytesRead); }
         jsonAddUnterminatedString(jPrinter, NULL, buffer, bytesRead);
         contentLength = contentLength + bytesRead;
+        /* A bad record writes a blank (see jsonConvertAndWriteBuffer) and we keep
+           going so one unmappable byte doesn't truncate the whole response. Count
+           consecutive conversion failures and clear the latch so the next record
+           is processed; the hard cap below stops a dump that fails every record. */
+        if (jsonCheckDataConversionErrorFlag(jPrinter)) {
+          consecutiveFailures++;
+          jsonClearDataConversionErrorFlag(jPrinter);
+        } else {
+          consecutiveFailures = 0;
+        }
       } else if (bytesRead == 0 && !feof(in) && !ferror(in)) {
         // empty record
         jsonAddString(jPrinter, NULL, "");
@@ -309,6 +329,11 @@ int streamDataset(char *filename, int recordLength, jsonPrinter *jPrinter){
         zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG,  "Error reading DSN=%s, rc=%d\n", filename, bytesRead);
         break;
       }
+    }
+    if (consecutiveFailures >= MAX_CONSEC_CONVERSION_FAILURES) {
+      zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_WARNING,
+              "Aborting record stream for DSN=%s after %d consecutive conversion failures\n",
+              filename, consecutiveFailures);
     }
     fclose(in);
     if (!rcEtag) { rcEtag = icsfDigestFinish(&digest, hash); }


### PR DESCRIPTION

## Proposed changes
Fixes JSON response truncation and a high-CPU loop when streaming dataset records that contain unmappable EBCDIC bytes. A single bad byte in one record previously latched a shared error flag that suppressed **all** further output, truncating the entire response (`EOF found inside string constant`). 

This splits the error handling so data-conversion failures no longer gate output, while real IO errors still hard-stop, and adds a bounded loop so a dataset that fails every record can't spin the CPU.

### Changes

| File | Change |
|------|--------|
| `h/json.h` | Added `dataConversionErrorFlag` to `jsonPrinter_tag`; declared `jsonSetDataConversionErrorFlag`, `jsonCheckDataConversionErrorFlag`, `jsonClearDataConversionErrorFlag` |
| `c/json.c` | Conversion failure in `jsonConvertAndWriteBuffer` now sets `dataConversionErrorFlag` (not `ioErrorFlag`) and writes a blank placeholder instead of suppressing output; write failure still sets `ioErrorFlag`; added the 3 flag accessors; both flags reset in `jsonPrinterReset` |
| `zss/c/datasetjson.c` | Record loop blanks bad records and continues, clears the conversion latch each record, and enforces a hard cap (`MAX_CONSEC_CONVERSION_FAILURES = 100`) with a warning log |

### Resulting Behavior

| Scenario | Before | After |
|----------|--------|-------|
| One / a few bad records (unmappable byte) | Entire response truncated mid-string (`EOF found inside string constant`) | Bad record blanked, streaming continues, full response completes |
| Every record fails (e.g. SVC dump of unmappable bytes) | High-CPU runaway loop to EOF | Loop aborts after 100 consecutive failures and logs a warning |
| Real IO error (broken socket) | Loop stops, all output suppressed | Unchanged — `ioErrorFlag` still hard-stops everything |


This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zss/issues* if any]

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/675/

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
