### PR TITLE
Bugfix: fail startup when the configuration manager cannot be created (#868)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the ZSS package will be documented in this file.
 
 ## `3.6.0`
+- Bugfix: ZSS stops at startup with a SEVERE message when the configuration manager cannot be created, instead of dereferencing NULL. [(#868)](https://github.com/zowe/zss/issues/868)
 - Bugfix: Verify fields in several services for null values. [(#836)](https://github.com/zowe/zss/pull/836)
 - Enhancement: When running in HA mode, ZSS now uses the per-HA-instance merged YAML config file(e.g. `.zowe-lpar1-merged.yaml`) exposed via `ZWE_HA_INSTANCE_CONFIG` (written by `zwe internal start prepare`) instead of the global `ZWE_CLI_PARAMETER_CONFIG`. (https://github.com/zowe/zss/pull/826)
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)

--- a/c/zss.c
+++ b/c/zss.c
@@ -1728,13 +1728,13 @@ int main(int argc, char **argv){
   cfgSetConfigPath(configmgr,ZSS_CFGNAME,configs);
   int schemaLoadStatus = cfgLoadSchemas(configmgr,ZSS_CFGNAME,schemas);
   if (schemaLoadStatus){
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS Could not load schemas, status=%d\n", schemaLoadStatus);
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS could not load schemas, status=%d\n", schemaLoadStatus);
     zssStatus = ZSS_STATUS_ERROR;
     goto out_term_stcbase;
   }
 
   if (cfgLoadConfiguration(configmgr,ZSS_CFGNAME) != 0){
-    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS Could not load configurations\n");
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "ZSS could not load configurations\n");
     zssStatus = ZSS_STATUS_ERROR;
     goto out_term_stcbase;
   }

--- a/c/zss.c
+++ b/c/zss.c
@@ -1716,6 +1716,12 @@ int main(int argc, char **argv){
   ConfigManager *configmgr
     /* HERE set up a directory from things from Sean */
     = makeConfigManager(); /* configs,schemas,1,stderr); */
+  if (configmgr == NULL) {
+    /* Stop here rather than dereference NULL, like the neighbouring checks */
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_SEVERE, "ZSS could not create the configuration manager\n");
+    zssStatus = ZSS_STATUS_ERROR;
+    goto out_term_stcbase;
+  }
   CFGConfig *theConfig = addConfig(configmgr,ZSS_CFGNAME);
   cfgSetTraceStream(configmgr,stderr);
   cfgSetTraceLevel(configmgr, configmgrTraceLevel);


### PR DESCRIPTION
Fixes #868.

## What

`makeConfigManager()` can return NULL: zowe-common-c #674 made it do so when the embedded JavaScript runtime cannot be set up (not key 8, not problem state). `zss.c` passed the result on unchecked. On z/OS the first dereference of NULL reads low storage instead of failing, so the server carried on from garbage rather than stopping.

This adds the missing check next to the other startup checks: log at SEVERE and take the existing termination path.

## Testing

Compiled and linked as part of `build/build_zss.sh` (xlc, 31-bit) and `build/build_zss64.sh` (xlclang, 64-bit) on the Marist system, against `v3.x/staging` of both zss and zowe-common-c: rc 0, no diagnostics on `zss.c`. The failure path itself needs a ZSS started outside key 8 or problem state and was not driven.
