### PR TITLE
Support verifyCertificates modes: STRICT and NONSTRICT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the ZSS package will be documented in this file.
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
 - Enhancement: add more granular SAF checks for the built-in ZIS services [(#852)](https://github.com/zowe/zss/pull/852)
 - Enhancement: The `/unixfile/contents` PUT endpoint now accepts `sourceEncoding` and `targetEncoding` as either charset name strings (e.g. `"IBM-1047"`, `"UTF-8"`) or decimal CCSID integer strings (e.g. `"1047"`, `"819"`). Previously only integer strings were accepted. Resolution is handled by `parseEncodingValue()` in zowe-common-c. [(#593)](https://github.com/zowe/zss/issues/593)
+- Enhancement: Support verifyCertificates modes: RESTRICT and NONSTRICT [(#873)](https://github.com/zowe/zss/pull/873)
 
 ## `3.5.0`
 - Enhancement: Utility "detect-attls-port" can be used to check if an ATTLS policy exists at a specific connection. (https://github.com/zowe/zss/pull/813)  

--- a/c/zss.c
+++ b/c/zss.c
@@ -1259,6 +1259,23 @@ static bool readAgentHttpsSettingsV2(ShortLivedHeap *slh,
   if (getStatus){
     zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_SEVERE, "internal error accessing .components.zss.port, err=%d\n", getStatus);
   }
+  char *verifyCertificates = NULL;
+  if ((getStatus = cfgGetStringC(configmgr, ZSS_CFGNAME, &verifyCertificates, 2, "zowe", "verifyCertificates")) != 0) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, "internal error accessing .zowe.verifyCertificates, err=%d, will default to STRICT\n", getStatus);
+  }
+  if (!verifyCertificates || 0 == strcasecmp(verifyCertificates, "STRICT")) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "verifyCertificates mode: STRICT\n");
+    settings->certVerify = TLS_CERTVERIFY_STRICT;
+  } else if (0 == strcasecmp(verifyCertificates, "NONSTRICT")) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "verifyCertificates mode: NONSTRICT\n");
+    settings->certVerify = TLS_CERTVERIFY_NONSTRICT;
+  } else if (0 == strcasecmp(verifyCertificates, "DISABLED")) {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_INFO, "verifyCertificates mode: DISABLED\n");
+    settings->certVerify = TLS_CERTVERIFY_DISABLED;
+  } else {
+    zowelog(NULL, LOG_COMP_ID_MVD_SERVER, ZOWE_LOG_WARNING, ".zowe.verifyCertificates got an unknown value \"%s\", will default to STRICT\n", verifyCertificates);
+    settings->certVerify = TLS_CERTVERIFY_STRICT;
+  }
   bool useTls = false;
   cfgGetBooleanC(configmgr,ZSS_CFGNAME,&useTls,3,"components","zss","tls");
   bool isHttpsConfigured = useTls && settings->keyring;


### PR DESCRIPTION
Support configuration `zowe.verifyCertificates`.

**Currently, only `STRICT` and `NONSTRICT` are supported.**

ZSS only reads the related configuration and set TLS env. `zowe-common-c` does the real work.

`DISABLED` is not supported for now, but ZSS only propagates the configuration, `zowe-common-c` will force it to `NONSTRICT` and write `LOG_COMP_HTTPCLIENT` log.

See related PR in zowe-common-c: [PR#616 Let GSK validate the CN and SAN domains of server certificates- #616
](https://github.com/zowe/zowe-common-c/pull/616/changes)